### PR TITLE
Make the retry logic work to verify the Knative Serving resources

### DIFF
--- a/test/resources/knativeeventing.go
+++ b/test/resources/knativeeventing.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -75,44 +73,4 @@ func EnsureKnativeEventingExists(clients eventingv1alpha1.KnativeEventingInterfa
 // IsKnativeEventingReady will check the status conditions of the KnativeEventing and return true if the KnativeEventing is ready.
 func IsKnativeEventingReady(s *v1alpha1.KnativeEventing, err error) (bool, error) {
 	return s.Status.IsReady(), err
-}
-
-// WaitForKnativeEventingDeploymentState polls the status of the Knative deployments every `interval`
-// until `inState` returns `true` indicating the deployments match the desired deployments.
-func WaitForKnativeEventingDeploymentState(clients *test.Clients, namespace string, expectedDeployments []string, logf logging.FormatLogger,
-	inState func(deps *v1.DeploymentList, expectedDeployments []string, err error, logf logging.FormatLogger) (bool, error)) error {
-	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForKnativeDeploymentState/%s/%s", expectedDeployments, "KnativeDeploymentIsReady"))
-	defer span.End()
-
-	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
-		dpList, err := clients.KubeClient.Kube.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
-		return inState(dpList, expectedDeployments, err, logf)
-	})
-
-	return waitErr
-}
-
-// IsKnativeEventingDeploymentReady will check the status conditions of the deployments and return true if the deployments meet the desired status.
-func IsKnativeEventingDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []string, err error,
-	logf logging.FormatLogger) (bool, error) {
-	if err != nil {
-		return false, err
-	}
-	if len(dpList.Items) != len(expectedDeployments) {
-		logf("The expected number of deployments is %v, and got %v.", len(expectedDeployments), len(dpList.Items))
-		return false, nil
-	}
-	for _, deployment := range dpList.Items {
-		if !stringInList(deployment.Name, expectedDeployments) {
-			logf("The deployment %v is not found in the expected list of deployment.", deployment.Name)
-			return false, nil
-		}
-		for _, c := range deployment.Status.Conditions {
-			if c.Type == v1.DeploymentAvailable && c.Status != corev1.ConditionTrue {
-				logf("The deployment %v is not ready.", deployment.Name)
-				return false, nil
-			}
-		}
-	}
-	return true, nil
 }

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// knativeserving.go provides methods to perform actions on the KnativeServing resource.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/operator/test"
+	"knative.dev/pkg/test/logging"
+)
+
+const (
+	// Interval specifies the time between two polls.
+	Interval = 10 * time.Second
+	// Timeout specifies the timeout for the function PollImmediate to reach a certain status.
+	Timeout = 5 * time.Minute
+	// LoggingConfigKey specifies specifies the key name of the logging config map.
+	LoggingConfigKey = "logging"
+	// DefaultsConfigKey specifies the key name of the default config map.
+	DefaultsConfigKey = "defaults"
+)
+
+// WaitForKnativeDeploymentState polls the status of the Knative deployments every `interval`
+// until `inState` returns `true` indicating the deployments match the desired deployments.
+func WaitForKnativeDeploymentState(clients *test.Clients, namespace string, expectedDeployments []string, logf logging.FormatLogger,
+	inState func(deps *v1.DeploymentList, expectedDeployments []string, err error, logf logging.FormatLogger) (bool, error)) error {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForKnativeDeploymentState/%s/%s", expectedDeployments, "KnativeDeploymentIsReady"))
+	defer span.End()
+
+	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+		dpList, err := clients.KubeClient.Kube.AppsV1().Deployments(namespace).List(metav1.ListOptions{})
+		return inState(dpList, expectedDeployments, err, logf)
+	})
+
+	return waitErr
+}
+
+// IsKnativeDeploymentReady will check the status conditions of the deployments and return true if the deployments meet the desired status.
+func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []string, err error,
+	logf logging.FormatLogger) (bool, error) {
+	if err != nil {
+		return false, err
+	}
+	if len(dpList.Items) != len(expectedDeployments) {
+		logf("The expected number of deployments is %v, and got %v.", len(expectedDeployments), len(dpList.Items))
+		return false, nil
+	}
+	for _, deployment := range dpList.Items {
+		if !stringInList(deployment.Name, expectedDeployments) {
+			logf("The deployment %v is not found in the expected list of deployment.", deployment.Name)
+			return false, nil
+		}
+		for _, c := range deployment.Status.Conditions {
+			if c.Type == v1.DeploymentAvailable && c.Status != corev1.ConditionTrue {
+				logf("The deployment %v is not ready.", deployment.Name)
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -238,10 +238,10 @@ func verifyNoKSOperatorCR(clients *test.Clients) error {
 	return nil
 }
 
-// AssertKSOperatorDeploymentStatus verifies if the Knative deployments reach the READY status.
-func AssertKSOperatorDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, expectedDeployments []string) {
-	if _, err := WaitForKnativeServingDeploymentState(clients, namespace, expectedDeployments,
-		IsKnativeServingDeploymentReady); err != nil {
+// AssertKnativeDeploymentStatus verifies if the Knative deployments reach the READY status.
+func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, expectedDeployments []string) {
+	if err := WaitForKnativeDeploymentState(clients, namespace, expectedDeployments, t.Logf,
+		IsKnativeDeploymentReady); err != nil {
 		t.Fatalf("Knative Serving deployments failed to meet the expected deployments: %v", err)
 	}
 }
@@ -341,12 +341,4 @@ func verifyNoKnativeEventings(clients *test.Clients) error {
 		return errors.New("Unable to verify cluster-scoped resources are deleted if any KnativeEventing exists")
 	}
 	return nil
-}
-
-// AssertKEOperatorDeploymentStatus verifies if the Knative deployments reach the READY status.
-func AssertKEOperatorDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, expectedDeployments []string) {
-	if err := WaitForKnativeEventingDeploymentState(clients, namespace, expectedDeployments, t.Logf,
-		IsKnativeEventingDeploymentReady); err != nil {
-		t.Fatalf("Knative Eventing deployments failed to meet the expected deployments: %v", err)
-	}
 }

--- a/test/upgrade/knativeeventingpreupgrade_test.go
+++ b/test/upgrade/knativeeventingpreupgrade_test.go
@@ -48,6 +48,6 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 		resources.AssertKEOperatorCRReadyStatus(t, clients, names)
 		expectedDeployments := []string{"eventing-controller", "eventing-webhook", "imc-controller",
 			"imc-dispatcher", "broker-controller", "sources-controller"}
-		resources.AssertKEOperatorDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 	})
 }

--- a/test/upgrade/knativeeventingupgrade_test.go
+++ b/test/upgrade/knativeeventingupgrade_test.go
@@ -49,6 +49,6 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		resources.AssertKEOperatorCRReadyStatus(t, clients, names)
 		expectedDeployments := []string{"eventing-controller", "eventing-webhook", "imc-controller",
 			"imc-dispatcher", "broker-controller", "broker-filter", "broker-ingress", "mt-broker-controller"}
-		resources.AssertKEOperatorDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 	})
 }

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -49,7 +49,7 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		expectedDeployments := []string{"networking-istio", "webhook", "controller", "activator", "autoscaler-hpa",
 			"autoscaler", "istio-webhook"}
-		resources.AssertKSOperatorDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
 	})
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #105 

## Proposed Changes

* This PR fixes the issue with retry logic for Knative Serving to verify its deployment resources.
* It creates functions called `AssertKnativeDeploymentStatus`, `WaitForKnativeDeploymentState` and `IsKnativeDeploymentReady` for both serving and eventing to test the deployment resources.
* It removes the repeated code of deployment verifying and status checking.

