### PR TITLE
Update go.mod to specify the module is go1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/operator
 
-go 1.13
+go 1.14
 
 require (
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,16 +68,19 @@ github.com/cespare/xxhash/v2
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.11.1+incompatible
+## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.5.0+incompatible
 github.com/evanphx/json-patch
 # github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+## explicit
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.1.0
 github.com/go-logr/logr
 github.com/go-logr/logr/testing
 # github.com/go-logr/zapr v0.1.1
+## explicit
 github.com/go-logr/zapr
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -109,6 +112,7 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.4.0
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
@@ -125,6 +129,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/grpc-ecosystem/grpc-gateway v1.12.2
+## explicit
 github.com/grpc-ecosystem/grpc-gateway/internal
 github.com/grpc-ecosystem/grpc-gateway/runtime
 github.com/grpc-ecosystem/grpc-gateway/utilities
@@ -142,8 +147,10 @@ github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
 # github.com/manifestival/client-go-client v0.2.2
+## explicit
 github.com/manifestival/client-go-client
 # github.com/manifestival/manifestival v0.5.1-0.20200526175228-b0136214e13f
+## explicit
 github.com/manifestival/manifestival
 github.com/manifestival/manifestival/overlay
 github.com/manifestival/manifestival/patch
@@ -157,6 +164,7 @@ github.com/modern-go/reflect2
 # github.com/openzipkin/zipkin-go v0.2.2
 github.com/openzipkin/zipkin-go/model
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.5.0
 github.com/prometheus/client_golang/prometheus
@@ -175,6 +183,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
 # go.opencensus.io v0.22.3
+## explicit
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/internal/tagencoding
@@ -199,6 +208,7 @@ go.uber.org/atomic
 # go.uber.org/multierr v1.5.0
 go.uber.org/multierr
 # go.uber.org/zap v1.14.1
+## explicit
 go.uber.org/zap
 go.uber.org/zap/buffer
 go.uber.org/zap/internal/bufferpool
@@ -208,6 +218,7 @@ go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/mod v0.3.0
+## explicit
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
@@ -253,6 +264,7 @@ golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.1.0
 gomodules.xyz/jsonpatch/v2
 # gonum.org/v1/gonum v0.0.0-20190710053202-4340aa3071a0
+## explicit
 gonum.org/v1/gonum/blas
 gonum.org/v1/gonum/blas/blas64
 gonum.org/v1/gonum/blas/cblas128
@@ -363,14 +375,19 @@ google.golang.org/grpc/tap
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.2.8
+## explicit
 gopkg.in/yaml.v2
 # istio.io/api v0.0.0-20191115173247-e1a1952e5b81
+## explicit
 istio.io/api/networking/v1alpha3
 # istio.io/client-go v0.0.0-20191120150049-26c62a04cdbc
+## explicit
 istio.io/client-go/pkg/apis/networking/v1alpha3
 # istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d
+## explicit
 istio.io/gogo-genproto/googleapis/google/api
 # k8s.io/api v0.17.3 => k8s.io/api v0.16.4
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -414,6 +431,7 @@ k8s.io/api/storage/v1beta1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 # k8s.io/apimachinery v0.17.3 => k8s.io/apimachinery v0.16.4
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -462,6 +480,7 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.16.4
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
@@ -666,6 +685,7 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.18.0 => k8s.io/code-generator v0.16.4
+## explicit
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args
@@ -726,12 +746,15 @@ k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # knative.dev/caching v0.0.0-20200122154023-853d6022845c
+## explicit
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
 # knative.dev/eventing v0.14.1-0.20200428210242-f355830c4d70
+## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/eventing
 # knative.dev/pkg v0.0.0-20200519155757-14eb3ae3a5a7
+## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck
 knative.dev/pkg/apis/duck/v1
@@ -778,8 +801,32 @@ knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
 # knative.dev/test-infra v0.0.0-20200519161858-554a95a37986
+## explicit
 knative.dev/test-infra/scripts
 # sigs.k8s.io/controller-runtime v0.5.0
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
+# github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
+# k8s.io/api => k8s.io/api v0.16.4
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.4
+# k8s.io/apimachinery => k8s.io/apimachinery v0.16.4
+# k8s.io/apiserver => k8s.io/apiserver v0.16.4
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.16.4
+# k8s.io/client-go => k8s.io/client-go v0.16.4
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.16.4
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.4
+# k8s.io/code-generator => k8s.io/code-generator v0.16.4
+# k8s.io/component-base => k8s.io/component-base v0.16.4
+# k8s.io/cri-api => k8s.io/cri-api v0.16.4
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.16.4
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.4
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.16.4
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.16.4
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.16.4
+# k8s.io/kubectl => k8s.io/kubectl v0.16.4
+# k8s.io/kubelet => k8s.io/kubelet v0.16.4
+# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.16.4
+# k8s.io/metrics => k8s.io/metrics v0.16.4
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.16.4


### PR DESCRIPTION
Thus the go commands will default to -mod=vendor

See: https://golang.org/doc/go1.14#go-command