### PR TITLE
With 0.15 the MTChannelBasedBroker is the new default broker

### DIFF
--- a/pkg/reconciler/knativeeventing/common/defaultbroker.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker.go
@@ -51,7 +51,7 @@ func DefaultBrokerConfigMapTransform(instance *eventingv1alpha1.KnativeEventing,
 
 			defaultBrokerClass := instance.Spec.DefaultBrokerClass
 			if defaultBrokerClass == "" {
-				defaultBrokerClass = eventing.ChannelBrokerClassValue
+				defaultBrokerClass = eventing.MTChannelBrokerClassValue
 			}
 			defaults.ClusterDefault.BrokerClass = defaultBrokerClass
 

--- a/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
@@ -52,7 +52,7 @@ func TestDefaultBrokerTransform(t *testing.T) {
 		defaultBrokerClass: "",
 		expected: makeConfigMap(t, "config-br-defaults", v1alpha1.ConfigMapData{
 			"clusterDefault": {
-				"brokerClass": "ChannelBasedBroker",
+				"brokerClass": "MTChannelBasedBroker",
 				"apiVersion":  "v1",
 				"kind":        "ConfigMap",
 				"name":        "config-br-default-channel",


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

* related to https://github.com/knative/eventing/issues/3139 - updates the actual default broker

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
With 0.15 the MTChannelBasedBroker is the new default
```
