### PR TITLE
Use the combined operator instead of separated operator

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -17,11 +17,14 @@
 # This script provides helper methods to perform cluster actions.
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
-# Latest serving operator release.
-readonly LATEST_SERVING_OPERATOR_RELEASE_VERSION="v0.14.0"
-# Latest serving release, installed by the operator at LATEST_SERVING_OPERATOR_RELEASE_VERSION. This can be
-# different from LATEST_SERVING_OPERATOR_RELEASE_VERSION.
-LATEST_SERVING_RELEASE_VERSION="v0.14.0"
+# The previous operator release.
+readonly PREVIOUS_OPERATOR_RELEASE_VERSION="v0.14.2"
+# The previous serving release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
+# different from PREVIOUS_OPERATOR_RELEASE_VERSION.
+readonly PREVIOUS_SERVING_RELEASE_VERSION="v0.14.0"
+# The previous eventing release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
+# different from PREVIOUS_OPERATOR_RELEASE_VERSION.
+readonly PREVIOUS_EVENTING_RELEASE_VERSION="v0.14.2"
 # This is the branch name of serving repo, where we run the upgrade tests.
 SERVING_REPO_BRANCH=${PULL_BASE_REF}
 # Istio version we test with
@@ -117,10 +120,10 @@ function donwload_knative_serving() {
 
 # Install Istio.
 function install_istio() {
-  local base_url="https://raw.githubusercontent.com/knative/serving/${LATEST_SERVING_RELEASE_VERSION}"
+  local base_url="https://raw.githubusercontent.com/knative/serving/${PREVIOUS_SERVING_RELEASE_VERSION}"
   local istio_version="istio-${ISTIO_VERSION}"
   if [[ ${istio_version} == *-latest ]] ; then
-    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/${LATEST_SERVING_RELEASE_VERSION}/third_party/${istio_version})
+    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/${PREVIOUS_SERVING_RELEASE_VERSION}/third_party/${istio_version})
   fi
   INSTALL_ISTIO_CRD_YAML="${base_url}/$(istio_crds_yaml $istio_version)"
   INSTALL_ISTIO_YAML="${base_url}/$(istio_yaml $istio_version $ISTIO_MESH)"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -31,28 +31,25 @@
 # project $PROJECT_ID, start knative in it, run the tests and delete the
 # cluster.
 
-readonly LATEST_EVENTING_OPERATOR_RELEASE_VERSION="v0.14.2"
-readonly LATEST_EVENTING_RELEASE_VERSION="v0.14.2"
-
 export GO111MODULE=auto
 
 source $(dirname $0)/e2e-common.sh
 
-function install_previous_serving_operator_release() {
-  local full_url="https://github.com/knative/serving-operator/releases/download/${LATEST_SERVING_OPERATOR_RELEASE_VERSION}/serving-operator.yaml"
+function download_install_previous_operator_release() {
+  local full_url="https://github.com/knative/operator/releases/download/${PREVIOUS_OPERATOR_RELEASE_VERSION}/operator.yaml"
 
   wget "${full_url}" -O "${release_yaml}" \
-      || fail_test "Unable to download latest Knative Serving Operator release."
+      || fail_test "Unable to download latest Knative Operator release."
 
   donwload_knative_serving ${SERVING_REPO_BRANCH}
   install_istio || fail_test "Istio installation failed"
-  install_previous_serving_release
+  install_previous_operator_release
 }
 
-function install_previous_serving_release() {
-  header "Installing Knative Serving operator previous public release"
-  kubectl apply -f "${release_yaml}" || fail_test "Knative Serving Operator latest release installation failed"
-  wait_until_pods_running default || fail_test "Serving Operator did not come up"
+function install_previous_operator_release() {
+  header "Installing Knative operator of the previous public release"
+  kubectl apply -f "${release_yaml}" || fail_test "Knative Operator previous release installation failed"
+  wait_until_pods_running default || fail_test "Operator did not come up"
 }
 
 function create_custom_resource() {
@@ -84,25 +81,9 @@ metadata:
 EOF
 }
 
-function install_previous_eventing_operator_release() {
-  local full_url="https://github.com/knative/eventing-operator/releases/download/${LATEST_EVENTING_OPERATOR_RELEASE_VERSION}/eventing-operator.yaml"
-
-  wget "${full_url}" -O "${release_eventing_yaml}" \
-      || fail_test "Unable to download latest Knative Eventing Operator release."
-
-  install_previous_eventing_release
-}
-
-function install_previous_eventing_release() {
-  header "Installing Knative Eventing operator previous public release"
-  kubectl apply -f "${release_eventing_yaml}" || fail_test "Knative Eventing Operator latest release installation failed"
-  wait_until_pods_running default || fail_test "Eventing Operator did not come up"
-}
-
 function knative_setup() {
   create_namespace
-  install_previous_serving_operator_release
-  install_previous_eventing_operator_release
+  download_install_previous_operator_release
   create_custom_resource
   wait_until_pods_running ${TEST_NAMESPACE}
   wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
@@ -193,8 +174,8 @@ echo "Prober PID is ${PROBER_PID}"
 
 install_operator
 
-# If we got this far, the operator installed Knative Serving of the latest source code.
-header "Running tests for Knative Serving Operator"
+# If we got this far, the operator installed Knative of the latest source code.
+header "Running tests for Knative Operator"
 failed=0
 
 # Run the postupgrade tests under operator
@@ -213,7 +194,7 @@ go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade || failed=1
 # Verify with the bash script to make sure there is no resource with the label of the previous release.
 list_resources="deployment,pod,service,apiservice,cm,crd,sa,ClusterRole,ClusterRoleBinding,Image,ValidatingWebhookConfiguration,\
 MutatingWebhookConfiguration,Secret,RoleBinding,APIService,Gateway"
-result="$(kubectl get ${list_resources} -l serving.knative.dev/release=${LATEST_SERVING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
+result="$(kubectl get ${list_resources} -l serving.knative.dev/release=${PREVIOUS_SERVING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
 
 # If the ${result} is not empty, we fail the tests, because the resources from the previous release still exist.
 if [[ ! -z ${result} ]] ; then
@@ -225,7 +206,7 @@ fi
 # Verify with the bash script to make sure there is no resource with the label of the previous release.
 list_resources="deployment,pod,service,cm,crd,sa,ClusterRole,ClusterRoleBinding,ValidatingWebhookConfiguration,\
 MutatingWebhookConfiguration,Secret,RoleBinding"
-result="$(kubectl get ${list_resources} -l eventing.knative.dev/release=${LATEST_EVENTING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
+result="$(kubectl get ${list_resources} -l eventing.knative.dev/release=${PREVIOUS_EVENTING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
 
 # If the ${result} is not empty, we fail the tests, because the resources from the previous release still exist.
 if [[ ! -z ${result} ]] ; then
@@ -234,8 +215,7 @@ if [[ ! -z ${result} ]] ; then
   fail_test "The resources with the label of previous release have not been removed."
 fi
 
-install_previous_serving_release
-install_previous_eventing_release
+install_previous_operator_release
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* This patch added the manifests of knative @ 0.15 into the kodata.
* The net-istio is in a different version from knative serving. For simplicity, this PR removed the version_test.go fo yaml validation.
* This PR installs combined operator for 0.14.x as the previous release for upgrade tests.
* This PR updates the test cases to verify resources in 0.15.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
