### PR TITLE
Validate the obsolete resources with golang tests

### DIFF
--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -186,6 +186,7 @@ func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.M
 		common.NamespacedResource("apps/v1", "Deployment", instance.GetNamespace(), "sources-controller"),
 		// Remove the resources at at 0.14
 		common.NamespacedResource("v1", "ServiceAccount", instance.GetNamespace(), "pingsource-jobrunner"),
+		common.NamespacedResource("batch/v1", "Job", instance.GetNamespace(), "v0.14.0-upgrade"),
 		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "knative-eventing-jobrunner"),
 		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "pingsource-jobrunner"),
 	}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,13 +18,13 @@
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 # The previous operator release.
-readonly PREVIOUS_OPERATOR_RELEASE_VERSION="v0.14.2"
+readonly PREVIOUS_OPERATOR_RELEASE_VERSION="0.14.2"
 # The previous serving release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
 # different from PREVIOUS_OPERATOR_RELEASE_VERSION.
-readonly PREVIOUS_SERVING_RELEASE_VERSION="v0.14.0"
+readonly PREVIOUS_SERVING_RELEASE_VERSION="0.14.0"
 # The previous eventing release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
 # different from PREVIOUS_OPERATOR_RELEASE_VERSION.
-readonly PREVIOUS_EVENTING_RELEASE_VERSION="v0.14.2"
+readonly PREVIOUS_EVENTING_RELEASE_VERSION="0.14.2"
 # This is the branch name of serving repo, where we run the upgrade tests.
 SERVING_REPO_BRANCH=${PULL_BASE_REF}
 # Istio version we test with
@@ -120,10 +120,10 @@ function donwload_knative_serving() {
 
 # Install Istio.
 function install_istio() {
-  local base_url="https://raw.githubusercontent.com/knative/serving/${PREVIOUS_SERVING_RELEASE_VERSION}"
+  local base_url="https://raw.githubusercontent.com/knative/serving/v${PREVIOUS_SERVING_RELEASE_VERSION}"
   local istio_version="istio-${ISTIO_VERSION}"
   if [[ ${istio_version} == *-latest ]] ; then
-    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/${PREVIOUS_SERVING_RELEASE_VERSION}/third_party/${istio_version})
+    istio_version=$(curl https://raw.githubusercontent.com/knative/serving/v${PREVIOUS_SERVING_RELEASE_VERSION}/third_party/${istio_version})
   fi
   INSTALL_ISTIO_CRD_YAML="${base_url}/$(istio_crds_yaml $istio_version)"
   INSTALL_ISTIO_YAML="${base_url}/$(istio_yaml $istio_version $ISTIO_MESH)"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -192,28 +192,28 @@ cd ${KNATIVE_SERVING_DIR}/serving
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade || failed=1
 
 # Verify with the bash script to make sure there is no resource with the label of the previous release.
-list_resources="deployment,pod,service,apiservice,cm,crd,sa,ClusterRole,ClusterRoleBinding,Image,ValidatingWebhookConfiguration,\
-MutatingWebhookConfiguration,Secret,RoleBinding,APIService,Gateway"
-result="$(kubectl get ${list_resources} -l serving.knative.dev/release=${PREVIOUS_SERVING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
+#list_resources="deployment,pod,service,apiservice,cm,crd,sa,ClusterRole,ClusterRoleBinding,Image,ValidatingWebhookConfiguration,\
+#MutatingWebhookConfiguration,Secret,RoleBinding,APIService,Gateway"
+#result="$(kubectl get ${list_resources} -l serving.knative.dev/release=${PREVIOUS_SERVING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
 
 # If the ${result} is not empty, we fail the tests, because the resources from the previous release still exist.
-if [[ ! -z ${result} ]] ; then
-  header "The following obsolete resources still exist for serving operator:"
-  echo "${result}"
-  fail_test "The resources with the label of previous release have not been removed."
-fi
+#if [[ ! -z ${result} ]] ; then
+#  header "The following obsolete resources still exist for serving operator:"
+#  echo "${result}"
+#  fail_test "The resources with the label of previous release have not been removed."
+#fi
 
 # Verify with the bash script to make sure there is no resource with the label of the previous release.
-list_resources="deployment,pod,service,cm,crd,sa,ClusterRole,ClusterRoleBinding,ValidatingWebhookConfiguration,\
-MutatingWebhookConfiguration,Secret,RoleBinding"
-result="$(kubectl get ${list_resources} -l eventing.knative.dev/release=${PREVIOUS_EVENTING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
+#list_resources="deployment,pod,service,cm,crd,sa,ClusterRole,ClusterRoleBinding,ValidatingWebhookConfiguration,\
+#MutatingWebhookConfiguration,Secret,RoleBinding"
+#result="$(kubectl get ${list_resources} -l eventing.knative.dev/release=${PREVIOUS_EVENTING_RELEASE_VERSION} --all-namespaces 2>/dev/null)"
 
 # If the ${result} is not empty, we fail the tests, because the resources from the previous release still exist.
-if [[ ! -z ${result} ]] ; then
-  header "The following obsolete resources still exist for eventing operator:"
-  echo "${result}"
-  fail_test "The resources with the label of previous release have not been removed."
-fi
+#if [[ ! -z ${result} ]] ; then
+#  header "The following obsolete resources still exist for eventing operator:"
+#  echo "${result}"
+#  fail_test "The resources with the label of previous release have not been removed."
+#fi
 
 install_previous_operator_release
 wait_until_pods_running ${TEST_NAMESPACE}

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -19,7 +19,10 @@ limitations under the License.
 
 package test
 
-import "os"
+import (
+	"flag"
+	"os"
+)
 
 var (
 	// ServingOperatorNamespace is the default namespace for serving operator e2e tests
@@ -28,6 +31,8 @@ var (
 	EventingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-eventing")
 	// OperatorName is the default operator name for serving operator e2e tests
 	OperatorName = getenv("TEST_RESOURCE", "knative")
+	// OperatorFlags holds the flags or defaults for knative/operator settings in the user's environment.
+	OperatorFlags = initializeOperatorFlags()
 )
 
 func getenv(name, defaultValue string) string {
@@ -36,4 +41,21 @@ func getenv(name, defaultValue string) string {
 		value = defaultValue
 	}
 	return value
+}
+
+// OperatorEnvironmentFlags holds the e2e flags needed only by the operator repo.
+type OperatorEnvironmentFlags struct {
+	PreviousServingVersion  string // Indicates the previous version of Knative Serving.
+	PreviousEventingVersion string // Indicates the previous version of Knative Eventing.
+}
+
+func initializeOperatorFlags() *OperatorEnvironmentFlags {
+	var f OperatorEnvironmentFlags
+
+	flag.StringVar(&f.PreviousServingVersion, "preservingversion", "",
+		"Set this flag to the previous version of Knative Serving.")
+	flag.StringVar(&f.PreviousEventingVersion, "preeventingversion", "",
+		"Set this flag to the previous version of Knative Eventing.")
+
+	return &f
 }

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -147,6 +147,7 @@ func removeDuplications(slice []string) []string {
 	return list
 }
 
+// WaitForKnativeResourceState returns the status of whether all obsolete resources are removed
 func WaitForKnativeResourceState(clients *test.Clients, namespace string,
 	obsResources []unstructured.Unstructured, logf logging.FormatLogger, inState func(clients *test.Clients,
 		namespace string, obsResources []unstructured.Unstructured, logf logging.FormatLogger) (bool, error)) error {
@@ -160,6 +161,7 @@ func WaitForKnativeResourceState(clients *test.Clients, namespace string,
 	return waitErr
 }
 
+// IsKnativeObsoleteResourceGone check the status conditions of the resources and return true if the obsolete resources are removed.
 func IsKnativeObsoleteResourceGone(clients *test.Clients, namespace string, obsResources []unstructured.Unstructured,
 	logf logging.FormatLogger) (bool, error) {
 	for _, resource := range obsResources {

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -27,12 +27,17 @@ import (
 	"testing"
 	"time"
 
+	"knative.dev/pkg/apis"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+
 	mf "github.com/manifestival/manifestival"
 	"knative.dev/operator/pkg/reconciler/common"
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/operator/test"
 	"knative.dev/pkg/test/logging"
@@ -91,9 +96,9 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 
 // GetExpectedDeployments will return an array of deployment resources based on the version for the knative
 // component.
-func GetExpectedDeployments(t *testing.T, version, kcomponent string) []string {
-	manifestPath := common.RetrieveManifestPath(version, kcomponent)
-	manifest, err := mf.NewManifest(manifestPath)
+
+func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manifest, []string) {
+	manifest, err := GetManifest(version, kcomponent)
 	if err != nil {
 		t.Fatalf("Failed to get the manifest for Knative: %v", err)
 	}
@@ -102,7 +107,13 @@ func GetExpectedDeployments(t *testing.T, version, kcomponent string) []string {
 	for _, resource := range manifest.Filter(mf.ByKind("Deployment")).Resources() {
 		deployments = append(deployments, resource.GetName())
 	}
-	return removeDuplications(deployments)
+	return manifest, removeDuplications(deployments)
+}
+
+// GetManifest will return the manifest based on the version for the knative
+func GetManifest(version, kcomponent string) (mf.Manifest, error) {
+	manifestPath := common.RetrieveManifestPath(version, kcomponent)
+	return mf.NewManifest(manifestPath)
 }
 
 // SetKodataDir will set the env var KO_DATA_PATH into the path of the kodata of this repository.
@@ -134,4 +145,37 @@ func removeDuplications(slice []string) []string {
 		}
 	}
 	return list
+}
+
+func WaitForKnativeResourceState(clients *test.Clients, namespace string,
+	obsResources []unstructured.Unstructured, logf logging.FormatLogger, inState func(clients *test.Clients,
+		namespace string, obsResources []unstructured.Unstructured, logf logging.FormatLogger) (bool, error)) error {
+	span := logging.GetEmitableSpan(context.Background(), fmt.Sprintf("WaitForKnativeResourceState/%s/%s", obsResources, "KnativeObsoleteResourceIsGone"))
+	defer span.End()
+
+	waitErr := wait.PollImmediate(Interval, Timeout, func() (bool, error) {
+		return inState(clients, namespace, obsResources, logf)
+	})
+
+	return waitErr
+}
+
+func IsKnativeObsoleteResourceGone(clients *test.Clients, namespace string, obsResources []unstructured.Unstructured,
+	logf logging.FormatLogger) (bool, error) {
+	for _, resource := range obsResources {
+		gvr := apis.KindToResource(resource.GroupVersionKind())
+		var err error
+		if resource.GetNamespace() != "" {
+			// This is a namespaced resource
+			_, err = clients.Dynamic.Resource(gvr).Namespace(namespace).Get(resource.GetName(), metav1.GetOptions{})
+		} else {
+			// This is a clustered resource
+			_, err = clients.Dynamic.Resource(gvr).Get(resource.GetName(), metav1.GetOptions{})
+		}
+		if !apierrs.IsNotFound(err) {
+			logf("The resource %v still exists.", resource.GetName())
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -27,6 +27,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -236,6 +237,14 @@ func verifyNoKSOperatorCR(clients *test.Clients) error {
 		return errors.New("Unable to verify cluster-scoped resources are deleted if any KnativeServing exists")
 	}
 	return nil
+}
+
+// AssertKnativeObsoleteResource verifies if all obsolete resources disappear in the cluster
+func AssertKnativeObsoleteResource(t *testing.T, clients *test.Clients, namespace string, obsResources []unstructured.Unstructured) {
+	if err := WaitForKnativeResourceState(clients, namespace, obsResources, t.Logf,
+		IsKnativeObsoleteResourceGone); err != nil {
+		t.Fatalf("Knative obsolete resources failed to be removed: %v", err)
+	}
 }
 
 // AssertKnativeDeploymentStatus verifies if the Knative deployments reach the READY status.

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -66,8 +65,6 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		if preEventingVer == "" {
 			preEventingVer = version
 		}
-		fmt.Println("previous eventing version")
-		fmt.Println(preEventingVer)
 		// Compare the previous manifest with the target manifest, we verify that all the obsolete resources
 		// do not exist any more.
 		preManifest, err := resources.GetManifest(preEventingVer, kcomponent)

--- a/test/upgrade/knativeeventing_preupgrade_test.go
+++ b/test/upgrade/knativeeventing_preupgrade_test.go
@@ -58,7 +58,8 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the status.version, get the deployment resources.
-		expectedDeployments := resources.GetExpectedDeployments(t, keventing.Status.Version, "knative-eventing")
+		defer os.Unsetenv(common.KoEnvKey)
+		_, expectedDeployments := resources.GetExpectedDeployments(t, keventing.Status.Version, "knative-eventing")
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 	})

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -66,8 +65,6 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		if preServingVer == "" {
 			preServingVer = version
 		}
-		fmt.Println("previous serving version")
-		fmt.Println(preServingVer)
 		// Compare the previous manifest with the target manifest, we verify that all the obsolete resources
 		// do not exist any more.
 		preManifest, err := resources.GetManifest(preServingVer, kcomponent)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #114

## Proposed Changes

* This PR removed all the test cases in bash and re-implement them in golang, to check the obsolete resources.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
