### PR TITLE
Create the func RetrieveManifest to generate the manifest

### DIFF
--- a/pkg/reconciler/common/read_releases_test.go
+++ b/pkg/reconciler/common/read_releases_test.go
@@ -17,14 +17,14 @@ limitations under the License.
 package common
 
 import (
+	"context"
 	"os"
 	"testing"
 
-	mf "github.com/manifestival/manifestival"
 	util "knative.dev/operator/pkg/reconciler/common/testing"
 )
 
-func TestRetrieveManifestPath(t *testing.T) {
+func TestRetrieveManifest(t *testing.T) {
 	koPath := "testdata/kodata"
 
 	tests := []struct {
@@ -48,9 +48,9 @@ func TestRetrieveManifestPath(t *testing.T) {
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			manifestPath := RetrieveManifestPath(test.version, test.component)
+			manifestPath := retrieveManifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
-			manifest, err := mf.NewManifest(manifestPath)
+			manifest, err := RetrieveManifest(context.Background(), test.version, test.component, nil)
 			util.AssertEqual(t, err, nil)
 			util.AssertEqual(t, len(manifest.Resources()) > 0, true)
 		})
@@ -75,9 +75,9 @@ func TestRetrieveManifestPath(t *testing.T) {
 
 	for _, test := range invalidPathTests {
 		t.Run(test.component, func(t *testing.T) {
-			manifestPath := RetrieveManifestPath(test.version, test.component)
+			manifestPath := retrieveManifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
-			manifest, err := mf.NewManifest(manifestPath)
+			manifest, err := RetrieveManifest(context.Background(), test.version, test.component, nil)
 			util.AssertEqual(t, err != nil, true)
 			util.AssertEqual(t, len(manifest.Resources()) == 0, true)
 		})

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -17,9 +17,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/zapr"
 	mfc "github.com/manifestival/client-go-client"
-	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	"k8s.io/client-go/tools/cache"
 
@@ -62,11 +60,13 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		logger.Fatal(err)
 	}
 
+	mfClient, err := mfc.NewClient(injection.GetConfig(ctx))
+	if err != nil {
+		logger.Fatal(err)
+	}
+
 	version := common.GetLatestRelease(kcomponent)
-	manifestPath := common.RetrieveManifestPath(version, kcomponent)
-	manifest, err := mfc.NewManifest(manifestPath,
-		injection.GetConfig(ctx),
-		mf.UseLogger(zapr.NewLogger(logger.Desugar()).WithName("manifestival")))
+	manifest, err := common.RetrieveManifest(ctx, version, kcomponent, mfClient)
 
 	if err != nil {
 		logger.Fatalw("Error creating the Manifest for knative-serving", zap.Error(err))

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -98,7 +98,7 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 // component.
 
 func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manifest, []string) {
-	manifest, err := GetManifest(version, kcomponent)
+	manifest, err := common.RetrieveManifest(context.Background(), version, kcomponent, nil)
 	if err != nil {
 		t.Fatalf("Failed to get the manifest for Knative: %v", err)
 	}
@@ -108,12 +108,6 @@ func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manife
 		deployments = append(deployments, resource.GetName())
 	}
 	return manifest, removeDuplications(deployments)
-}
-
-// GetManifest will return the manifest based on the version for the knative
-func GetManifest(version, kcomponent string) (mf.Manifest, error) {
-	manifestPath := common.RetrieveManifestPath(version, kcomponent)
-	return mf.NewManifest(manifestPath)
 }
 
 // SetKodataDir will set the env var KO_DATA_PATH into the path of the kodata of this repository.

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -67,7 +68,7 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		}
 		// Compare the previous manifest with the target manifest, we verify that all the obsolete resources
 		// do not exist any more.
-		preManifest, err := resources.GetManifest(preEventingVer, kcomponent)
+		preManifest, err := common.RetrieveManifest(context.Background(), preEventingVer, kcomponent, nil)
 		if err != nil {
 			t.Fatalf("Failed to get KnativeEventing manifest: %v", err)
 		}

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -67,7 +68,7 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		}
 		// Compare the previous manifest with the target manifest, we verify that all the obsolete resources
 		// do not exist any more.
-		preManifest, err := resources.GetManifest(preServingVer, kcomponent)
+		preManifest, err := common.RetrieveManifest(context.Background(), preServingVer, kcomponent, nil)
 		if err != nil {
 			t.Fatalf("Failed to get KnativeServing manifest: %v", err)
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* This PR creates a common function RetrieveManifest to generate the manifest, based on version, component and the mf.Client.

CC @jcrossley3 @markusthoemmes @evankanderson @Cynocracy 
This is fundamental.
Next, I plan to dynamically delete the obsolete resources, by comparing the target and current manifests.