### PR TITLE
[WIP] First pass at spec.version

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -57,6 +57,9 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeEventing
           properties:
+            version:
+              description: The version of Knative Eventing to be installed
+              type: string
             config:
               additionalProperties:
                 additionalProperties:

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -57,6 +57,9 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeServing
           properties:
+            version:
+              description: The version of Knative Serving to be installed
+              type: string
             config:
               additionalProperties:
                 additionalProperties:

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -54,6 +54,8 @@ type KComponentSpec interface {
 	GetRegistry() *Registry
 	// GetResources returns a list of container resource overrides.
 	GetResources() []ResourceRequirementsOverride
+	// GetVersion gets the version to be installed
+	GetVersion() string
 }
 
 // KComponentStatus is a common interface for status mutations of all known types.
@@ -83,6 +85,9 @@ type KComponentStatus interface {
 	GetVersion() string
 	// SetVersion sets the currently installed version of the component.
 	SetVersion(version string)
+
+	// IsReady return true if all conditions are satisfied
+	IsReady() bool
 }
 
 // CommonSpec unifies common fields and functions on the Spec.
@@ -99,6 +104,10 @@ type CommonSpec struct {
 	// Override containers' resource requirements
 	// +optional
 	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
+
+	// Override containers' resource requirements
+	// +optional
+	Version string `json:"version,omitempty"`
 }
 
 // GetConfig implements KComponentSpec.
@@ -114,6 +123,11 @@ func (c *CommonSpec) GetRegistry() *Registry {
 // GetResources implements KComponentSpec.
 func (c *CommonSpec) GetResources() []ResourceRequirementsOverride {
 	return c.Resources
+}
+
+// GetVersion implements KComponentSpec.
+func (c *CommonSpec) GetVersion() string {
+	return c.Version
 }
 
 // ConfigMapData is a nested map of maps representing all upstream ConfigMaps. The first

--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -30,7 +30,7 @@ var (
 
 // Install applies the manifest resources for the given version and updates the given
 // status accordingly.
-func Install(manifest *mf.Manifest, version string, status v1alpha1.KComponentStatus) error {
+func Install(manifest *mf.Manifest, status v1alpha1.KComponentStatus) error {
 	// The Operator needs a higher level of permissions if it 'bind's non-existent roles.
 	// To avoid this, we strictly order the manifest application as (Cluster)Roles, then
 	// (Cluster)RoleBindings, then the rest of the manifest.
@@ -47,7 +47,6 @@ func Install(manifest *mf.Manifest, version string, status v1alpha1.KComponentSt
 		return fmt.Errorf("failed to apply non rbac manifest: %w", err)
 	}
 	status.MarkInstallSucceeded()
-	status.SetVersion(version)
 	return nil
 }
 

--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestInstall(t *testing.T) {
 	// Resources in the manifest
-	version := "v0.14-test"
 	deployment := *NamespacedResource("apps/v1", "Deployment", "test", "test-deployment")
 	role := *NamespacedResource("rbac.authorization.k8s.io/v1", "Role", "test", "test-role")
 	roleBinding := *NamespacedResource("rbac.authorization.k8s.io/v1", "RoleBinding", "test", "test-role-binding")
@@ -50,7 +49,7 @@ func TestInstall(t *testing.T) {
 	status := &v1alpha1.KnativeServingStatus{
 		Version: "0.13-test",
 	}
-	if err := Install(&manifest, version, status); err != nil {
+	if err := Install(&manifest, status); err != nil {
 		t.Fatalf("Install() = %v, want no error", err)
 	}
 
@@ -62,15 +61,10 @@ func TestInstall(t *testing.T) {
 	if condition == nil || condition.Status != corev1.ConditionTrue {
 		t.Fatalf("InstallSucceeded = %v, want %v", condition, corev1.ConditionTrue)
 	}
-
-	if got, want := status.GetVersion(), version; got != want {
-		t.Fatalf("GetVersion() = %s, want %s", got, want)
-	}
 }
 
 func TestInstallError(t *testing.T) {
 	oldVersion := "v0.13-test"
-	version := "v0.14-test"
 
 	client := &fakeClient{err: errors.New("test")}
 	manifest, err := mf.ManifestFrom(mf.Slice([]unstructured.Unstructured{
@@ -83,7 +77,7 @@ func TestInstallError(t *testing.T) {
 	status := &v1alpha1.KnativeServingStatus{
 		Version: oldVersion,
 	}
-	if err := Install(&manifest, version, status); err == nil {
+	if err := Install(&manifest, status); err == nil {
 		t.Fatalf("Install() = nil, wanted an error")
 	}
 

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	util "knative.dev/operator/pkg/reconciler/common/testing"
 )
 
@@ -28,18 +29,18 @@ func TestRetrieveManifestPath(t *testing.T) {
 	koPath := "testdata/kodata"
 
 	tests := []struct {
-		component string
+		component v1alpha1.KComponent
 		version   string
 		name      string
 		expected  string
 	}{{
 		name:      "Valid Knative Serving Version",
-		component: "knative-serving",
+		component: &v1alpha1.KnativeServing{},
 		version:   "0.14.0",
 		expected:  koPath + "/knative-serving/0.14.0",
 	}, {
 		name:      "Valid Knative Eventing Version",
-		component: "knative-eventing",
+		component: &v1alpha1.KnativeEventing{},
 		version:   "0.14.2",
 		expected:  koPath + "/knative-eventing/0.14.2",
 	}}
@@ -48,7 +49,7 @@ func TestRetrieveManifestPath(t *testing.T) {
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			manifestPath := ManifestPath(test.version, test.component)
+			manifestPath := manifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
 			manifest, err := mf.NewManifest(manifestPath)
 			util.AssertEqual(t, err, nil)
@@ -57,25 +58,25 @@ func TestRetrieveManifestPath(t *testing.T) {
 	}
 
 	invalidPathTests := []struct {
-		component string
+		component v1alpha1.KComponent
 		version   string
 		name      string
 		expected  string
 	}{{
 		name:      "Invalid Knative Serving Version",
-		component: "knative-serving",
+		component: &v1alpha1.KnativeServing{},
 		version:   "invalid-version",
 		expected:  koPath + "/knative-serving/invalid-version",
 	}, {
 		name:      "Invalid Knative component name",
-		component: "invalid-component",
+		component: nil,
 		version:   "0.14.2",
-		expected:  koPath + "/invalid-component/0.14.2",
+		expected:  "0.14.2",
 	}}
 
 	for _, test := range invalidPathTests {
-		t.Run(test.component, func(t *testing.T) {
-			manifestPath := ManifestPath(test.version, test.component)
+		t.Run(test.name, func(t *testing.T) {
+			manifestPath := manifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
 			manifest, err := mf.NewManifest(manifestPath)
 			util.AssertEqual(t, err != nil, true)
@@ -88,21 +89,24 @@ func TestGetLatestRelease(t *testing.T) {
 	koPath := "testdata/kodata"
 
 	tests := []struct {
-		component string
+		name      string
+		component v1alpha1.KComponent
 		expected  string
 	}{{
-		component: "knative-serving",
+		name:      "serving",
+		component: &v1alpha1.KnativeServing{},
 		expected:  "0.15.0",
 	}, {
-		component: "knative-eventing",
+		name:      "eventing",
+		component: &v1alpha1.KnativeEventing{},
 		expected:  "0.15.0",
 	}}
 
 	os.Setenv(KoEnvKey, koPath)
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
-		t.Run(test.component, func(t *testing.T) {
-			version := LatestRelease(test.component)
+		t.Run(test.name, func(t *testing.T) {
+			version := latestRelease(test.component)
 			util.AssertEqual(t, version, test.expected)
 		})
 	}
@@ -112,20 +116,23 @@ func TestListReleases(t *testing.T) {
 	koPath := "testdata/kodata"
 
 	tests := []struct {
-		component string
+		name      string
+		component v1alpha1.KComponent
 		expected  []string
 	}{{
-		component: "knative-serving",
+		name:      "knative-serving",
+		component: &v1alpha1.KnativeServing{},
 		expected:  []string{"0.15.0", "0.14.0"},
 	}, {
-		component: "knative-eventing",
+		name:      "knative-eventing",
+		component: &v1alpha1.KnativeEventing{},
 		expected:  []string{"0.15.0", "0.14.2"},
 	}}
 
 	os.Setenv(KoEnvKey, koPath)
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
-		t.Run(test.component, func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			version, err := allReleases(test.component)
 			util.AssertEqual(t, err, nil)
 			util.AssertDeepEqual(t, version, test.expected)

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -48,7 +48,7 @@ func TestRetrieveManifestPath(t *testing.T) {
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			manifestPath := RetrieveManifestPath(test.version, test.component)
+			manifestPath := ManifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
 			manifest, err := mf.NewManifest(manifestPath)
 			util.AssertEqual(t, err, nil)
@@ -75,7 +75,7 @@ func TestRetrieveManifestPath(t *testing.T) {
 
 	for _, test := range invalidPathTests {
 		t.Run(test.component, func(t *testing.T) {
-			manifestPath := RetrieveManifestPath(test.version, test.component)
+			manifestPath := ManifestPath(test.version, test.component)
 			util.AssertEqual(t, manifestPath, test.expected)
 			manifest, err := mf.NewManifest(manifestPath)
 			util.AssertEqual(t, err != nil, true)
@@ -102,7 +102,7 @@ func TestGetLatestRelease(t *testing.T) {
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
 		t.Run(test.component, func(t *testing.T) {
-			version := GetLatestRelease(test.component)
+			version := LatestRelease(test.component)
 			util.AssertEqual(t, version, test.expected)
 		})
 	}
@@ -126,7 +126,7 @@ func TestListReleases(t *testing.T) {
 	defer os.Unsetenv(KoEnvKey)
 	for _, test := range tests {
 		t.Run(test.component, func(t *testing.T) {
-			version, err := ListReleases(test.component)
+			version, err := allReleases(test.component)
 			util.AssertEqual(t, err, nil)
 			util.AssertDeepEqual(t, version, test.expected)
 		})

--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -36,10 +36,6 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-const (
-	kcomponent = "knative-eventing"
-)
-
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -53,22 +49,18 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		logger.Fatalw("Failed to remove old resources", zap.Error(err))
 	}
 
-	version := common.GetLatestRelease(kcomponent)
-	manifestPath := common.RetrieveManifestPath(version, kcomponent)
-	manifest, err := mfc.NewManifest(manifestPath,
-		injection.GetConfig(ctx),
-		mf.UseLogger(zapr.NewLogger(logger.Desugar()).WithName("manifestival")))
-
+	mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
 	if err != nil {
-		logger.Fatalw("Error creating the Manifest for knative-eventing", zap.Error(err))
+		logger.Fatalw("Error creating client from injected config", zap.Error(err))
 	}
+	mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
+	manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
 
 	c := &Reconciler{
 		kubeClientSet:     kubeClient,
 		operatorClientSet: operatorclient.Get(ctx),
 		platform:          common.GetPlatform(ctx),
-		config:            manifest,
-		targetVersion:     version,
+		manifest:          manifest,
 	}
 	impl := knereconciler.NewImpl(ctx, c)
 

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -22,12 +22,11 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	clientset "knative.dev/operator/pkg/client/clientset/versioned"
 
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	knereconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing"
 	"knative.dev/operator/pkg/reconciler/common"
 	kec "knative.dev/operator/pkg/reconciler/knativeeventing/common"
@@ -45,10 +44,8 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// kubeClientSet allows us to talk to the k8s for operator APIs
 	operatorClientSet clientset.Interface
-	// config is the manifest of KnativeEventing
-	config mf.Manifest
-	// targetVersion is the version of the KnativeEventing manifest to install
-	targetVersion string
+	// manifest is empty but with a valid client and logger
+	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform
 	platform common.Extension
 }
@@ -58,7 +55,7 @@ var _ knereconciler.Interface = (*Reconciler)(nil)
 var _ knereconciler.Finalizer = (*Reconciler)(nil)
 
 // FinalizeKind removes all resources after deletion of a KnativeEventing.
-func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
 	// List all KnativeEventings to determine if cluster-scoped resources should be deleted.
@@ -74,34 +71,46 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha
 		}
 	}
 
-	// Appending nothing effectively results in a deep-copy clone
-	manifest := r.config.Append()
-	if err := r.transform(ctx, &manifest, original); err != nil {
-		return fmt.Errorf("failed to transform manifest: %w", err)
+	// TODO: which manifest should we delete? both?
+	version := ""
+	if original.GetStatus().IsReady() {
+		version = original.Status.Version
+	} else {
+		version = common.TargetRelease(original)
 	}
 
+	manifest, err := common.FetchManifest(common.ManifestPath(version, common.PathElement(original)))
+	if err != nil {
+		return err
+	}
+	manifest = r.manifest.Append(manifest)
+	if err := r.transform(ctx, &manifest, original); err != nil {
+		return err
+	}
 	logger.Info("Deleting cluster-scoped resources")
 	return common.Uninstall(&manifest)
 }
 
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
-func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	ke.Status.InitializeConditions()
 	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
-	stages := []func(context.Context, *mf.Manifest, *eventingv1alpha1.KnativeEventing) error{
+	stages := []func(context.Context, *mf.Manifest, v1alpha1.KComponent) error{
+		r.create,
 		r.transform,
 		r.ensureFinalizerRemoval,
 		r.install,
 		r.checkDeployments,
 		r.deleteObsoleteResources,
+		r.updateVersion,
 	}
 
 	// Appending nothing effectively results in a deep-copy clone
-	manifest := r.config.Append()
+	manifest := r.manifest.Append()
 	for _, stage := range stages {
 		if err := stage(ctx, &manifest, ke); err != nil {
 			return err
@@ -111,16 +120,29 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.Kna
 	return nil
 }
 
+// create mutates the passed manifest, appending to it one appropriate
+// for the specified version in the instance
+func (r *Reconciler) create(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	path := common.ManifestPath(common.TargetRelease(instance), common.PathElement(instance))
+	m, err := common.FetchManifest(path)
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}
+
 // transform mutates the passed manifest to one with common and
 // platform transforms, plus any extras passed in
-func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, component v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
+	instance := component.(*v1alpha1.KnativeEventing)
 	return common.Transform(ctx, manifest, instance, r.platform,
 		kec.DefaultBrokerConfigMapTransform(instance, logger))
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-eventing-manifest" is removed from the resource.
-func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance v1alpha1.KComponent) error {
 	patch, err := common.FinalizerRemovalPatch(instance, oldFinalizerName)
 	if err != nil {
 		return fmt.Errorf("failed to construct the patch: %w", err)
@@ -130,61 +152,50 @@ func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, i
 		return nil
 	}
 
-	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeEventings(instance.Namespace)
-	if _, err := patcher.Patch(instance.Name, types.MergePatchType, patch); err != nil {
+	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeEventings(instance.GetNamespace())
+	if _, err := patcher.Patch(instance.GetName(), types.MergePatchType, patch); err != nil {
 		return fmt.Errorf("failed to patch finalizer away: %w", err)
 	}
 	return nil
 }
 
-func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, ke v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Installing manifest")
-	return common.Install(manifest, r.targetVersion, &ke.Status)
+	return common.Install(manifest, ke.GetStatus())
 }
 
-func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, ke v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Checking deployments")
-	return common.CheckDeployments(r.kubeClientSet, manifest, &ke.Status)
+	return common.CheckDeployments(r.kubeClientSet, manifest, ke.GetStatus())
 }
 
 // Delete obsolete resources from previous versions
-func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
-	resources := []*unstructured.Unstructured{
-		// Remove old resources from 0.12
-		// https://github.com/knative/eventing-operator/issues/90
-		// sources and controller are merged.
-		// delete removed or renamed resources.
-		common.NamespacedResource("v1", "ServiceAccount", instance.GetNamespace(), "eventing-source-controller"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "knative-eventing-source-controller"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "knative-eventing-source-controller"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "eventing-source-controller"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "eventing-source-controller-resolver"),
-		// Remove the legacysinkbindings webhook at 0.13
-		common.ClusterScopedResource("admissionregistration.k8s.io/v1beta1", "MutatingWebhookConfiguration", "legacysinkbindings.webhook.sources.knative.dev"),
-		// Remove the knative-eventing-sources-namespaced-admin ClusterRole at 0.13
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "knative-eventing-sources-namespaced-admin"),
-		// Remove the apiserversources.sources.eventing.knative.dev CRD at 0.13
-		common.ClusterScopedResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "apiserversources.sources.eventing.knative.dev"),
-		// Remove the containersources.sources.eventing.knative.dev CRD at 0.13
-		common.ClusterScopedResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "containersources.sources.eventing.knative.dev"),
-		// Remove the cronjobsources.sources.eventing.knative.dev CRD at 0.13
-		common.ClusterScopedResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "cronjobsources.sources.eventing.knative.dev"),
-		// Remove the sinkbindings.sources.eventing.knative.dev CRD at 0.13
-		common.ClusterScopedResource("apiextensions.k8s.io/v1beta1", "CustomResourceDefinition", "sinkbindings.sources.eventing.knative.dev"),
-		// Remove the deployment sources-controller at 0.13
-		common.NamespacedResource("apps/v1", "Deployment", instance.GetNamespace(), "sources-controller"),
-		// Remove the resources at at 0.14
-		common.NamespacedResource("v1", "ServiceAccount", instance.GetNamespace(), "pingsource-jobrunner"),
-		common.NamespacedResource("batch/v1", "Job", instance.GetNamespace(), "v0.14.0-upgrade"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "knative-eventing-jobrunner"),
-		common.ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "pingsource-jobrunner"),
+func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	if instance.GetStatus().GetVersion() == "" {
+		return nil
 	}
-	for _, r := range resources {
-		if err := manifest.Client.Delete(r); err != nil {
-			return err
-		}
+	if common.TargetRelease(instance) == instance.GetStatus().GetVersion() {
+		return nil
+	}
+	logger := logging.FromContext(ctx)
+	m, err := common.FetchManifest(common.ManifestPath(instance.GetStatus().GetVersion(), common.PathElement(instance)))
+	if err != nil {
+		logger.Error(err, "Unable to fetch previous manifest; some obsolete resources may remain")
+		return nil
+	}
+	m = r.manifest.Append(m)
+	if err := r.transform(ctx, &m, instance); err != nil {
+		return err
+	}
+	return m.Filter(mf.None(mf.In(*manifest))).Delete()
+}
+
+// updateVersion sets the status version if all conditions are satisfied
+func (r *Reconciler) updateVersion(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	if instance.GetStatus().IsReady() {
+		instance.GetStatus().SetVersion(common.TargetRelease(instance))
 	}
 	return nil
 }

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -71,15 +71,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 		}
 	}
 
-	// TODO: which manifest should we delete? both?
-	version := ""
-	if original.GetStatus().IsReady() {
-		version = original.Status.Version
-	} else {
-		version = common.TargetRelease(original)
-	}
-
-	manifest, err := common.FetchManifest(common.ManifestPath(version, common.PathElement(original)))
+	manifest, err := common.InstalledManifest(original)
 	if err != nil {
 		return err
 	}
@@ -123,8 +115,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 // create mutates the passed manifest, appending to it one appropriate
 // for the specified version in the instance
 func (r *Reconciler) create(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
-	path := common.ManifestPath(common.TargetRelease(instance), common.PathElement(instance))
-	m, err := common.FetchManifest(path)
+	m, err := common.TargetManifest(instance)
 	if err != nil {
 		return err
 	}
@@ -176,11 +167,8 @@ func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.M
 	if instance.GetStatus().GetVersion() == "" {
 		return nil
 	}
-	if common.TargetRelease(instance) == instance.GetStatus().GetVersion() {
-		return nil
-	}
 	logger := logging.FromContext(ctx)
-	m, err := common.FetchManifest(common.ManifestPath(instance.GetStatus().GetVersion(), common.PathElement(instance)))
+	m, err := common.InstalledManifest(instance)
 	if err != nil {
 		logger.Error(err, "Unable to fetch previous manifest; some obsolete resources may remain")
 		return nil
@@ -195,7 +183,7 @@ func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.M
 // updateVersion sets the status version if all conditions are satisfied
 func (r *Reconciler) updateVersion(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	if instance.GetStatus().IsReady() {
-		instance.GetStatus().SetVersion(common.TargetRelease(instance))
+		instance.GetStatus().SetVersion(common.TargetVersion(instance))
 	}
 	return nil
 }

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -22,11 +22,10 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	clientset "knative.dev/operator/pkg/client/clientset/versioned"
 	knsreconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeserving"
 	"knative.dev/operator/pkg/reconciler/common"
@@ -45,10 +44,8 @@ type Reconciler struct {
 	kubeClientSet kubernetes.Interface
 	// operatorClientSet allows us to configure operator objects
 	operatorClientSet clientset.Interface
-	// config is the manifest of KnativeServing
-	config mf.Manifest
-	// targetVersion is the version of the KnativeServing manifest to install
-	targetVersion string
+	// manifest is empty but with a valid client and logger
+	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform
 	platform common.Extension
 }
@@ -58,7 +55,7 @@ var _ knsreconciler.Interface = (*Reconciler)(nil)
 var _ knsreconciler.Finalizer = (*Reconciler)(nil)
 
 // FinalizeKind removes all resources after deletion of a KnativeServing.
-func (r *Reconciler) FinalizeKind(ctx context.Context, original *servingv1alpha1.KnativeServing) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.KnativeServing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
 	// List all KnativeServings to determine if cluster-scoped resources should be deleted.
@@ -74,34 +71,47 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *servingv1alpha1
 		}
 	}
 
-	// Appending nothing effectively results in a deep-copy clone
-	manifest := r.config.Append()
-	if err := r.transform(ctx, &manifest, original); err != nil {
-		return fmt.Errorf("failed to transform manifest: %w", err)
+	// TODO: which manifest should we delete? both?
+	version := ""
+	if original.GetStatus().IsReady() {
+		version = original.Status.Version
+	} else {
+		version = common.TargetRelease(original)
 	}
 
+	manifest, err := common.FetchManifest(common.ManifestPath(version, common.PathElement(original)))
+	if err != nil {
+		return err
+	}
+	manifest = r.manifest.Append(manifest)
+	if err := r.transform(ctx, &manifest, original); err != nil {
+		return err
+	}
 	logger.Info("Deleting cluster-scoped resources")
 	return common.Uninstall(&manifest)
 }
 
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
-func (r *Reconciler) ReconcileKind(ctx context.Context, ks *servingv1alpha1.KnativeServing) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	ks.Status.InitializeConditions()
 	ks.Status.ObservedGeneration = ks.Generation
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
-	stages := []func(context.Context, *mf.Manifest, *servingv1alpha1.KnativeServing) error{
+	stages := []func(context.Context, *mf.Manifest, v1alpha1.KComponent) error{
+		r.create,
+		// r.ingress -- should append to the one passed to it
 		r.transform,
 		r.ensureFinalizerRemoval,
 		r.install,
 		r.checkDeployments,
 		r.deleteObsoleteResources,
+		r.updateVersion,
 	}
 
 	// Appending nothing effectively results in a deep-copy clone
-	manifest := r.config.Append()
+	manifest := r.manifest.Append()
 	for _, stage := range stages {
 		if err := stage(ctx, &manifest, ks); err != nil {
 			return err
@@ -111,10 +121,23 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *servingv1alpha1.Knat
 	return nil
 }
 
+// create mutates the passed manifest, appending to it one appropriate
+// for the specified version in the instance
+func (r *Reconciler) create(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	path := common.ManifestPath(common.TargetRelease(instance), common.PathElement(instance))
+	m, err := common.FetchManifest(path)
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}
+
 // transform mutates the passed manifest to one with common and
 // platform transforms, plus any extras passed in
-func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
+func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, component v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
+	instance := component.(*v1alpha1.KnativeServing)
 	return common.Transform(ctx, manifest, instance, r.platform,
 		ksc.GatewayTransform(instance, logger),
 		ksc.CustomCertsTransform(instance, logger),
@@ -123,21 +146,21 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, insta
 }
 
 // Apply the manifest resources
-func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
+func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Installing manifest")
-	return common.Install(manifest, r.targetVersion, &instance.Status)
+	return common.Install(manifest, instance.GetStatus())
 }
 
 // Check for all deployments available
-func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
+func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Checking deployments")
-	return common.CheckDeployments(r.kubeClientSet, manifest, &instance.Status)
+	return common.CheckDeployments(r.kubeClientSet, manifest, instance.GetStatus())
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-serving-manifest" is removed from the resource.
-func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
+func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance v1alpha1.KComponent) error {
 	patch, err := common.FinalizerRemovalPatch(instance, oldFinalizerName)
 	if err != nil {
 		return fmt.Errorf("failed to construct the patch: %w", err)
@@ -147,27 +170,39 @@ func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, i
 		return nil
 	}
 
-	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeServings(instance.Namespace)
-	if _, err := patcher.Patch(instance.Name, types.MergePatchType, patch); err != nil {
+	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeServings(instance.GetNamespace())
+	if _, err := patcher.Patch(instance.GetName(), types.MergePatchType, patch); err != nil {
 		return fmt.Errorf("failed to patch finalizer away: %w", err)
 	}
 	return nil
 }
 
-// Delete obsolete resources from previous versions
-func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance *servingv1alpha1.KnativeServing) error {
-	resources := []*unstructured.Unstructured{
-		// istio-system resources from 0.3.
-		common.NamespacedResource("v1", "Service", "istio-system", "knative-ingressgateway"),
-		common.NamespacedResource("apps/v1", "Deployment", "istio-system", "knative-ingressgateway"),
-		common.NamespacedResource("autoscaling/v1", "HorizontalPodAutoscaler", "istio-system", "knative-ingressgateway"),
-		// config-controller from 0.5
-		common.NamespacedResource("v1", "ConfigMap", instance.GetNamespace(), "config-controller"),
+// Delete obsolete resources from previous versions, i.e. remove the
+// resources that do not exist in the passed target manifest
+func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	if instance.GetStatus().GetVersion() == "" {
+		return nil
 	}
-	for _, r := range resources {
-		if err := manifest.Client.Delete(r); err != nil {
-			return err
-		}
+	if common.TargetRelease(instance) == instance.GetStatus().GetVersion() {
+		return nil
+	}
+	logger := logging.FromContext(ctx)
+	m, err := common.FetchManifest(common.ManifestPath(instance.GetStatus().GetVersion(), common.PathElement(instance)))
+	if err != nil {
+		logger.Error(err, "Unable to fetch previous manifest; some obsolete resources may remain")
+		return nil
+	}
+	m = r.manifest.Append(m)
+	if err := r.transform(ctx, &m, instance); err != nil {
+		return err
+	}
+	return m.Filter(mf.None(mf.In(*manifest))).Delete()
+}
+
+// updateVersion sets the status version if all conditions are satisfied
+func (r *Reconciler) updateVersion(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	if instance.GetStatus().IsReady() {
+		instance.GetStatus().SetVersion(common.TargetRelease(instance))
 	}
 	return nil
 }

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -39,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/operator/test"
 	"knative.dev/pkg/test/logging"
 )
@@ -96,9 +97,8 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 
 // GetExpectedDeployments will return an array of deployment resources based on the version for the knative
 // component.
-
-func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manifest, []string) {
-	manifest, err := GetManifest(version, kcomponent)
+func GetExpectedDeployments(t *testing.T, instance v1alpha1.KComponent) (mf.Manifest, []string) {
+	manifest, err := common.InstalledManifest(instance)
 	if err != nil {
 		t.Fatalf("Failed to get the manifest for Knative: %v", err)
 	}
@@ -108,12 +108,6 @@ func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manife
 		deployments = append(deployments, resource.GetName())
 	}
 	return manifest, removeDuplications(deployments)
-}
-
-// GetManifest will return the manifest based on the version for the knative
-func GetManifest(version, kcomponent string) (mf.Manifest, error) {
-	manifestPath := common.ManifestPath(version, kcomponent)
-	return mf.NewManifest(manifestPath)
 }
 
 // SetKodataDir will set the env var KO_DATA_PATH into the path of the kodata of this repository.

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -112,7 +112,7 @@ func GetExpectedDeployments(t *testing.T, version, kcomponent string) (mf.Manife
 
 // GetManifest will return the manifest based on the version for the knative
 func GetManifest(version, kcomponent string) (mf.Manifest, error) {
-	manifestPath := common.RetrieveManifestPath(version, kcomponent)
+	manifestPath := common.ManifestPath(version, kcomponent)
 	return mf.NewManifest(manifestPath)
 }
 

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 
 	"knative.dev/operator/pkg/reconciler/common"
 	util "knative.dev/operator/pkg/reconciler/common/testing"
@@ -52,22 +53,23 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 	// Verify if resources match the requirement for the previous release before upgrade
 	t.Run("verify resources", func(t *testing.T) {
 		resources.AssertKEOperatorCRReadyStatus(t, clients, names)
-		kcomponent := "knative-eventing"
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		version := common.LatestRelease(kcomponent)
 		// Based on the latest release version, get the deployment resources.
-		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, version, kcomponent)
+		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, &v1alpha1.KnativeEventing{})
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 
-		preEventingVer := test.OperatorFlags.PreviousEventingVersion
-		if preEventingVer == "" {
-			preEventingVer = version
+		instance := &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: test.OperatorFlags.PreviousEventingVersion,
+				},
+			},
 		}
 		// Compare the previous manifest with the target manifest, we verify that all the obsolete resources
 		// do not exist any more.
-		preManifest, err := resources.GetManifest(preEventingVer, kcomponent)
+		preManifest, err := common.TargetManifest(instance)
 		if err != nil {
 			t.Fatalf("Failed to get KnativeEventing manifest: %v", err)
 		}

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -55,7 +55,7 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		kcomponent := "knative-eventing"
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		version := common.GetLatestRelease(kcomponent)
+		version := common.LatestRelease(kcomponent)
 		// Based on the latest release version, get the deployment resources.
 		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, version, kcomponent)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)

--- a/test/upgrade/knativeeventing_preupgrade_test.go
+++ b/test/upgrade/knativeeventing_preupgrade_test.go
@@ -59,7 +59,7 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the status.version, get the deployment resources.
 		defer os.Unsetenv(common.KoEnvKey)
-		_, expectedDeployments := resources.GetExpectedDeployments(t, keventing.Status.Version, "knative-eventing")
+		_, expectedDeployments := resources.GetExpectedDeployments(t, keventing)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 	})

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -55,7 +55,7 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		kcomponent := "knative-serving"
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		version := common.GetLatestRelease(kcomponent)
+		version := common.LatestRelease(kcomponent)
 		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, version, kcomponent)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)


### PR DESCRIPTION
Renamed some functions/files for consistency.

Trying to deal with both serving and eventing uniformly. They can
practically share all of the reconcile stages.

The biggest challenge right now is how to deal with FinalizeKind.
Essentially, which manifest do you use to delete the resources?
Specifically, what do you do when the CR is deleted *after*
spec.Version has been reconciled but *before* the install
completes (at which point status.Version is updated).

Much still to do...

