### PR TITLE
HA for eventing + label to indicate HA deployments + config for leader elected components

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
@@ -2988,6 +2988,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: "v0.15.0"
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:
@@ -4103,6 +4104,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: "v0.15.0"
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:
@@ -4160,6 +4162,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: "v0.15.0"
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:

--- a/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
@@ -584,6 +584,7 @@ metadata:
   namespace: knative-eventing
   labels:
     eventing.knative.dev/release: "v0.15.0"
+    knative.dev/high-availability: "true"
 spec:
   replicas: 1
   selector:

--- a/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
@@ -1304,6 +1304,7 @@ metadata:
   namespace: knative-serving
   labels:
     serving.knative.dev/release: "v0.15.0"
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/cmd/operator/kodata/knative-serving/0.15.0/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/3-serving-hpa.yaml
@@ -141,6 +141,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.15.0"
     autoscaling.knative.dev/autoscaler-provider: hpa
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/cmd/operator/kodata/knative-serving/0.15.0/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/4-net-istio.yaml
@@ -288,6 +288,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.15.1"
     networking.knative.dev/ingress-provider: istio
+    knative.dev/high-availability: "true"
 spec:
   selector:
     matchLabels:

--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -93,6 +93,17 @@ spec:
               description: The default broker type to use for the brokers Knative creates.
                 If no value is provided, ChannelBasedBroker will be used.
               type: string
+            high-availability:
+              description: Allows specification of HA control plane
+              type: object
+              properties:
+                replicas:
+                  description: The number of replicas that HA parts of the control plane will be scaled to
+                  type: integer
+                  minimum: 1
+                leader-elected-components:
+                  description: The names of the components that will have HA enabled with leader-election.
+                  type: string
             resources:
               description: A mapping of deployment name to resource requirements
               type: array

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -129,6 +129,9 @@ spec:
                   description: The number of replicas that HA parts of the control plane will be scaled to
                   type: integer
                   minimum: 1
+                leader-elected-components:
+                  description: The names of the components that will have HA enabled with leader-election.
+                  type: string
             resources:
               description: A mapping of deployment name to resource requirements
               type: array

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ These are the configurable fields in each resource:
       * [default](#specregistrydefault)
       * [override](#specregistryoverride)
       * [imagePullSecrets](#specregistryimagepullsecrets)
+    * [high-availability](#spechigh-availability)
     * [resources](#specresources)
     * [defaultBrokerClass](#specdefaultbrokerclass)
 
@@ -242,25 +243,36 @@ spec:
 
 ## spec.high-availability
 
-By default, Knative Serving runs a single instance of each controller.
+By default, a single instance of each controller is run.
 This field allows you to configure the number of replicas for the
-following master-elected controllers: `controller`, `autoscaler-hpa`,
-and `networking-istio`, as well as the `HorizontalPodAutoscaler`
-resources for the data plane (`activator`):
+following:
+
+* Serving leader-elected controllers: `controller`, `autoscaler-hpa`, `networking-certmanager`, `networking-ns-cert`, `networking-istio`
+* Serving `HorizontalPodAutoscaler` resources for the data plane (`activator`)
+* Eventing leader-elected controllers: `controller`
+* Eventing `HorizontalPodAutoscaler` resources for the data plane (`broker-ingress-hpa`, `broker-filter-hpa`)
+
 
 The following configuration specifies a replica count of 3 for the
 controllers and a minimum of 3 activators (which may scale higher if
 needed):
 
 ```
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: knative-serving
 spec:
   high-availability:
     replicas: 3
+```
+
+The leader-elected components that can be configured by `leader-elected-components` field.
+The following configuration will specify that in addition to default Knative Serving leader-elected
+`controller`, `autoscaler-hpa`, `networking-certmanager`, `networking-ns-cert` and `networking-istio` components,
+`nscontroller`  component will also be leader-elected:
+
+```
+spec:
+  high-availability:
+    replicas: 3
+    leader-elected-components: "controller,autoscaler-hpa,networking-certmanager,networking-ns-cert,networking-istio,nscontroller"
 ```
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,7 +249,7 @@ following:
 
 * Serving leader-elected controllers: `controller`, `autoscaler-hpa`, `networking-certmanager`, `networking-ns-cert`, `networking-istio`
 * Serving `HorizontalPodAutoscaler` resources for the data plane (`activator`)
-* Eventing leader-elected controllers: `controller`
+* Eventing leader-elected controllers: `controller`, `broker-controller`, `inmemorychannel-dispatcher` and `inmemorychannel-controller`
 * Eventing `HorizontalPodAutoscaler` resources for the data plane (`broker-ingress-hpa`, `broker-filter-hpa`)
 
 

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -54,6 +54,8 @@ type KComponentSpec interface {
 	GetRegistry() *Registry
 	// GetResources returns a list of container resource overrides.
 	GetResources() []ResourceRequirementsOverride
+	// GetHighAvailability returns the specification of HA control plane
+	GetHighAvailability() *HighAvailability
 }
 
 // KComponentStatus is a common interface for status mutations of all known types.
@@ -85,6 +87,20 @@ type KComponentStatus interface {
 	SetVersion(version string)
 }
 
+// HighAvailability specifies options for deploying Knative Serving control
+// plane in a highly available manner. Note that HighAvailability is still in
+// progress and does not currently provide a completely HA control plane.
+type HighAvailability struct {
+	// Replicas is the number of replicas that HA parts of the control plane
+	// will be scaled to.
+	Replicas int32 `json:"replicas"`
+
+	// LeaderElectedComponents is the names of the components that will have HA enabled with leader-election.
+	// Other HA components such as HPA-enabled components and stateless deployments will not be affected
+	// by the value of this field.
+	LeaderElectedComponents string `json:"leader-elected-components,omitempty"`
+}
+
 // CommonSpec unifies common fields and functions on the Spec.
 type CommonSpec struct {
 	// A means to override the corresponding entries in the upstream configmaps
@@ -99,6 +115,10 @@ type CommonSpec struct {
 	// Override containers' resource requirements
 	// +optional
 	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
+
+	// Allows specification of HA control plane
+	// +optional
+	HighAvailability *HighAvailability `json:"high-availability,omitempty"`
 }
 
 // GetConfig implements KComponentSpec.
@@ -114,6 +134,11 @@ func (c *CommonSpec) GetRegistry() *Registry {
 // GetResources implements KComponentSpec.
 func (c *CommonSpec) GetResources() []ResourceRequirementsOverride {
 	return c.Resources
+}
+
+// GetHighAvailability implements KComponentSpec.
+func (c *CommonSpec) GetHighAvailability() *HighAvailability {
+	return c.HighAvailability
 }
 
 // ConfigMapData is a nested map of maps representing all upstream ConfigMaps. The first

--- a/pkg/apis/operator/v1alpha1/knativeeventing_defaults.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_defaults.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+// SetDefaults implements apis.Defaultable
+func (c *KnativeEventing) SetDefaults(ctx context.Context) {
+	ctx = apis.WithinParent(ctx, c.ObjectMeta)
+	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+}
+
+// SetDefaults implements apis.Defaultable
+func (cs *KnativeEventingSpec) SetDefaults(_ context.Context) {
+	if cs.HighAvailability == nil {
+		return
+	}
+	if cs.HighAvailability.LeaderElectedComponents == "" {
+		cs.HighAvailability.LeaderElectedComponents = "controller"
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeeventing_defaults.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_defaults.go
@@ -34,6 +34,6 @@ func (cs *KnativeEventingSpec) SetDefaults(_ context.Context) {
 		return
 	}
 	if cs.HighAvailability.LeaderElectedComponents == "" {
-		cs.HighAvailability.LeaderElectedComponents = "controller"
+		cs.HighAvailability.LeaderElectedComponents = "controller,broker-controller,inmemorychannel-dispatcher,inmemorychannel-controller"
 	}
 }

--- a/pkg/apis/operator/v1alpha1/knativeeventing_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_defaults_test.go
@@ -55,7 +55,7 @@ func TestKnativeEventingDefaults(t *testing.T) {
 			expected: KnativeEventingSpec{
 				CommonSpec: CommonSpec{
 					HighAvailability: &HighAvailability{
-						LeaderElectedComponents: "controller",
+						LeaderElectedComponents: "controller,broker-controller,inmemorychannel-dispatcher,inmemorychannel-controller",
 					},
 				},
 			},

--- a/pkg/apis/operator/v1alpha1/knativeeventing_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_defaults_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKnativeEventingDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		initial  KnativeEventingSpec
+		expected KnativeEventingSpec
+	}{
+		"nil spec": {
+			initial:  KnativeEventingSpec{},
+			expected: KnativeEventingSpec{},
+		},
+		"nil HighAvailability": {
+			initial: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: nil,
+				},
+			},
+			expected: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: nil,
+				},
+			},
+		},
+		"nil HighAvailability.LeaderElectedComponents": {
+			initial: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "",
+					},
+				},
+			},
+			expected: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "controller",
+					},
+				},
+			},
+		},
+		"non-nil HighAvailability.LeaderElectedComponents": {
+			initial: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "foo",
+					},
+				},
+			},
+			expected: KnativeEventingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tc.initial.SetDefaults(context.TODO())
+			if diff := cmp.Diff(tc.expected, tc.initial); diff != "" {
+				t.Fatalf("Unexpected defaults (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeeventing_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_types.go
@@ -18,12 +18,15 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var (
 	_ KComponent     = (*KnativeEventing)(nil)
 	_ KComponentSpec = (*KnativeEventingSpec)(nil)
+
+	_ apis.Defaultable = (*KnativeEventing)(nil)
 )
 
 // KnativeEventing is the Schema for the eventings API

--- a/pkg/apis/operator/v1alpha1/knativeserving_defaults.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_defaults.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+// SetDefaults implements apis.Defaultable
+func (c *KnativeServing) SetDefaults(ctx context.Context) {
+	ctx = apis.WithinParent(ctx, c.ObjectMeta)
+	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+}
+
+// SetDefaults implements apis.Defaultable
+func (cs *KnativeServingSpec) SetDefaults(_ context.Context) {
+	if cs.HighAvailability == nil {
+		return
+	}
+	if cs.HighAvailability.LeaderElectedComponents == "" {
+		cs.HighAvailability.LeaderElectedComponents = "controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller"
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeserving_defaults_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_defaults_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestKnativeServingDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		initial  KnativeServingSpec
+		expected KnativeServingSpec
+	}{
+		"nil spec": {
+			initial:  KnativeServingSpec{},
+			expected: KnativeServingSpec{},
+		},
+		"nil HighAvailability": {
+			initial: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: nil,
+				},
+			},
+			expected: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: nil,
+				},
+			},
+		},
+		"nil HighAvailability.LeaderElectedComponents": {
+			initial: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "",
+					},
+				},
+			},
+			expected: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "controller,hpaautoscaler,certcontroller,istiocontroller,nscontroller",
+					},
+				},
+			},
+		},
+		"non-nil HighAvailability.LeaderElectedComponents": {
+			initial: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "foo",
+					},
+				},
+			},
+			expected: KnativeServingSpec{
+				CommonSpec: CommonSpec{
+					HighAvailability: &HighAvailability{
+						LeaderElectedComponents: "foo",
+					},
+				},
+			},
+		},
+	}
+
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tc.initial.SetDefaults(context.TODO())
+			if diff := cmp.Diff(tc.expected, tc.initial); diff != "" {
+				t.Fatalf("Unexpected defaults (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeserving_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_types.go
@@ -18,12 +18,15 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
 var (
 	_ KComponent     = (*KnativeServing)(nil)
 	_ KComponentSpec = (*KnativeServingSpec)(nil)
+
+	_ apis.Defaultable = (*KnativeServing)(nil)
 )
 
 // KnativeServing is the Schema for the knativeservings API
@@ -60,10 +63,6 @@ type KnativeServingSpec struct {
 
 	// Enables controller to trust registries with self-signed certificates
 	ControllerCustomCerts CustomCerts `json:"controller-custom-certs,omitempty"`
-
-	// Allows specification of HA control plane
-	// +optional
-	HighAvailability *HighAvailability `json:"high-availability,omitempty"`
 }
 
 // KnativeServingStatus defines the observed state of KnativeServing
@@ -97,13 +96,4 @@ type CustomCerts struct {
 
 	// The name of the ConfigMap or Secret
 	Name string `json:"name"`
-}
-
-// HighAvailability specifies options for deploying Knative Serving control
-// plane in a highly available manner. Note that HighAvailability is still in
-// progress and does not currently provide a completely HA control plane.
-type HighAvailability struct {
-	// Replicas is the number of replicas that HA parts of the control plane
-	// will be scaled to.
-	Replicas int32 `json:"replicas"`
 }

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -53,6 +53,11 @@ func (in *CommonSpec) DeepCopyInto(out *CommonSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HighAvailability != nil {
+		in, out := &in.HighAvailability, &out.HighAvailability
+		*out = new(HighAvailability)
+		**out = **in
+	}
 	return
 }
 
@@ -316,11 +321,6 @@ func (in *KnativeServingSpec) DeepCopyInto(out *KnativeServingSpec) {
 	in.KnativeIngressGateway.DeepCopyInto(&out.KnativeIngressGateway)
 	in.ClusterLocalGateway.DeepCopyInto(&out.ClusterLocalGateway)
 	out.ControllerCustomCerts = in.ControllerCustomCerts
-	if in.HighAvailability != nil {
-		in, out := &in.HighAvailability, &out.HighAvailability
-		*out = new(HighAvailability)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -39,7 +39,7 @@ func HighAvailabilityTransform(ha *operatorv1alpha1.HighAvailability, log *zap.S
 		}
 
 		// Transform the leader election config.
-		if u.GetKind() == "ConfigMap" && u.GetName() == "config-leader-election" {
+		if u.GetKind() == "ConfigMap" && u.GetName() == configMapName {
 			data, ok, err := unstructured.NestedStringMap(u.UnstructuredContent(), "data")
 			if err != nil {
 				return nil

--- a/pkg/reconciler/common/testing/util.go
+++ b/pkg/reconciler/common/testing/util.go
@@ -85,3 +85,11 @@ func AssertDeepEqual(t *testing.T, actual, expected interface{}) {
 	}
 	t.Fatalf("expected does not deep equal actual. \nExpected: %T %+v\nActual:   %T %+v", expected, expected, actual, actual)
 }
+
+func AssertDeepEqualWithName(t *testing.T, name string, actual, expected interface{}) {
+	t.Helper()
+	if reflect.DeepEqual(actual, expected) {
+		return
+	}
+	t.Fatalf("%s: expected does not deep equal actual. \nExpected: %T %+v\nActual:   %T %+v", name, expected, expected, actual, actual)
+}

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -30,7 +30,8 @@ func transformers(ctx context.Context, obj v1alpha1.KComponent) []mf.Transformer
 		mf.InjectNamespace(obj.GetNamespace()),
 		ImageTransform(obj.GetSpec().GetRegistry(), logger),
 		ConfigMapTransform(obj.GetSpec().GetConfig(), logger),
-		ResourceRequirementsTransform(obj.GetSpec().GetResources(), logger)}
+		ResourceRequirementsTransform(obj.GetSpec().GetResources(), logger),
+		HighAvailabilityTransform(obj.GetSpec().GetHighAvailability(), logger)}
 }
 
 // Transform will mutate the passed-by-reference manifest with one

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -88,6 +88,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+	ke.SetDefaults(ctx)
 	ke.Status.InitializeConditions()
 	ke.Status.ObservedGeneration = ke.Generation
 

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -118,7 +118,6 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, insta
 	return common.Transform(ctx, manifest, instance, r.platform,
 		ksc.GatewayTransform(instance, logger),
 		ksc.CustomCertsTransform(instance, logger),
-		ksc.HighAvailabilityTransform(instance, logger),
 		ksc.AggregationRuleTransform(manifest.Client))
 }
 

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -88,6 +88,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *servingv1alpha1
 // converge the two.
 func (r *Reconciler) ReconcileKind(ctx context.Context, ks *servingv1alpha1.KnativeServing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
+	ks.SetDefaults(ctx)
 	ks.Status.InitializeConditions()
 	ks.Status.ObservedGeneration = ks.Generation
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is a big PR that does multiple things at the same time. I initially created separate PRs but the intermediate state of the code was always bad.

Fixes #71, #73, #112 

## Proposed Changes

* HA for eventing  #71 
* Label to indicate HA deployments #73 
* Config for leader elected components #122 

Notes:
- KnativeServing CRD's `HighAvailiablity` field is now moved to common KComponentSpec which means KnativeEventing CRD is also has it
- `HighAvailiablity` field now has a `LeaderElectedComponents` field. The default values for this field is the hardcoded stuff before.
- KnativeServing and KnativeEventing types now implement `apis.Defaultable` for defaulting the `LeaderElectedComponents` field.
- HA transformer is now made generic that works with KnativeEventing or KnativeServing's `HighAvailiablity` type
- HA transformer now looks for `knative.dev/high-availability: "true"` label for the deployments and scales the deployments that have it
- HA transform is now moved to common transformers

PRs for HA deployment labels:
- https://github.com/knative/eventing/pull/3311 and https://github.com/knative/eventing/pull/3324
- https://github.com/knative/serving/pull/8297
- https://github.com/knative/net-istio/pull/142

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
HA is enabled for Knative eventing.
A new `leader-elected-components` field is added in `spec.high-availability` for both `KnativeEventing` and `KnativeServing` CRDs. With this field, names of the components that will have HA enabled with leader-election can be passed.               
```
