### PR TITLE
Add the logic to determine if upgrade or downgrade is eligible

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -33,6 +33,9 @@ const (
 	// DeploymentsAvailable is a Condition indicating whether or not the Deployments of
 	// the respective component have come up successfully.
 	DeploymentsAvailable apis.ConditionType = "DeploymentsAvailable"
+	// VersionMigrationEligible is a Condition indicating whether or not the current version of
+	// Knative component is eligible to upgrade or downgrade to the specified version.
+	VersionMigrationEligible apis.ConditionType = "VersionMigrationEligible"
 )
 
 // KComponent is a common interface for accessing meta, spec and status of all known types.
@@ -71,6 +74,12 @@ type KComponentStatus interface {
 	// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 	// it's waiting for deployments.
 	MarkDeploymentsNotReady()
+
+	// MarkVersionMigrationEligible marks the VersionMigrationEligible status as true.
+	MarkVersionMigrationEligible()
+	// MarkVersionMigrationNotEligible marks the VersionMigrationEligible status as false with
+	// the given message.
+	MarkVersionMigrationNotEligible(msg string)
 
 	// MarkDependenciesInstalled marks the DependenciesInstalled status as true.
 	MarkDependenciesInstalled()

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
@@ -28,6 +28,7 @@ var (
 		DependenciesInstalled,
 		DeploymentsAvailable,
 		InstallSucceeded,
+		VersionMigrationEligible,
 	)
 )
 
@@ -70,9 +71,22 @@ func (es *KnativeEventingStatus) MarkInstallFailed(msg string) {
 		"Install failed with message: %s", msg)
 }
 
-// MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.
+// MarkDeploymentsAvailable marks the VersionMigrationEligble status as true.
 func (es *KnativeEventingStatus) MarkDeploymentsAvailable() {
 	eventingCondSet.Manage(es).MarkTrue(DeploymentsAvailable)
+}
+
+// MarkVersionMigrationEligible marks the VersionMigrationEligible status as false with given message.
+func (es *KnativeEventingStatus) MarkVersionMigrationEligible() {
+	eventingCondSet.Manage(es).MarkTrue(VersionMigrationEligible)
+}
+
+// MarkVersionMigrationNotEligible marks the DeploymentsAvailable status as true.
+func (es *KnativeEventingStatus) MarkVersionMigrationNotEligible(msg string) {
+	eventingCondSet.Manage(es).MarkFalse(
+		VersionMigrationEligible,
+		"Error",
+		"Version migration is not eligible with message: %s", msg)
 }
 
 // MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -140,3 +140,11 @@ func TestKnativeEventingExternalDependency(t *testing.T) {
 	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
 }
+
+func TestKnativeEventingVersionMigrationNotEligible(t *testing.T) {
+	ke := &KnativeEventingStatus{}
+	ke.InitializeConditions()
+
+	ke.MarkVersionMigrationNotEligible("Version migration not eligible.")
+	apistest.CheckConditionFailed(ke, VersionMigrationEligible, t)
+}

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -43,6 +43,8 @@ func TestKnativeEventingHappyPath(t *testing.T) {
 	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ke, InstallSucceeded, t)
 
+	ke.MarkVersionMigrationEligible()
+
 	// Install succeeds.
 	ke.MarkInstallSucceeded()
 	// Dependencies are assumed successful too.
@@ -76,6 +78,8 @@ func TestKnativeEventingErrorPath(t *testing.T) {
 	apistest.CheckConditionOngoing(ke, DependenciesInstalled, t)
 	apistest.CheckConditionOngoing(ke, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ke, InstallSucceeded, t)
+
+	ke.MarkVersionMigrationEligible()
 
 	// Install fails.
 	ke.MarkInstallFailed("test")

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
@@ -28,6 +28,7 @@ var (
 		DependenciesInstalled,
 		DeploymentsAvailable,
 		InstallSucceeded,
+		VersionMigrationEligible,
 	)
 )
 
@@ -67,6 +68,19 @@ func (is *KnativeServingStatus) MarkInstallFailed(msg string) {
 		InstallSucceeded,
 		"Error",
 		"Install failed with message: %s", msg)
+}
+
+// MarkVersionMigrationEligible marks the VersionMigrationEligible status as false with given message.
+func (is *KnativeServingStatus) MarkVersionMigrationEligible() {
+	servingCondSet.Manage(is).MarkTrue(VersionMigrationEligible)
+}
+
+// MarkVersionMigrationNotEligible marks the DeploymentsAvailable status as true.
+func (is *KnativeServingStatus) MarkVersionMigrationNotEligible(msg string) {
+	servingCondSet.Manage(is).MarkFalse(
+		VersionMigrationEligible,
+		"Error",
+		"Version migration is not eligible with message: %s", msg)
 }
 
 // MarkDeploymentsAvailable marks the DeploymentsAvailable status as true.

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
@@ -140,3 +140,11 @@ func TestKnativeServingExternalDependency(t *testing.T) {
 	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
 }
+
+func TestKnativeServingVersionMigrationNotEligible(t *testing.T) {
+	ks := &KnativeServingStatus{}
+	ks.InitializeConditions()
+
+	ks.MarkVersionMigrationNotEligible("Version migration not eligible.")
+	apistest.CheckConditionFailed(ks, VersionMigrationEligible, t)
+}

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
@@ -43,6 +43,8 @@ func TestKnativeServingHappyPath(t *testing.T) {
 	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
 
+	ks.MarkVersionMigrationEligible()
+
 	// Install succeeds.
 	ks.MarkInstallSucceeded()
 	// Dependencies are assumed successful too.
@@ -76,6 +78,8 @@ func TestKnativeServingErrorPath(t *testing.T) {
 	apistest.CheckConditionOngoing(ks, DependenciesInstalled, t)
 	apistest.CheckConditionOngoing(ks, DeploymentsAvailable, t)
 	apistest.CheckConditionOngoing(ks, InstallSucceeded, t)
+
+	ks.MarkVersionMigrationEligible()
 
 	// Install fails.
 	ks.MarkInstallFailed("test")

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -85,13 +85,12 @@ func IsUpDowngradeEligible(instance v1alpha1.KComponent) bool {
 		return false
 	}
 
-	var err error
-	currentMinor, err := strconv.Atoi(strings.TrimPrefix(semver.MajorMinor(current), currentMajor+"."))
+	currentMinor, err := strconv.Atoi(strings.Split(current, ".")[1])
 	if err != nil {
 		return false
 	}
 
-	targetMinor, err := strconv.Atoi(strings.TrimPrefix(semver.MajorMinor(target), targetMajor+"."))
+	targetMinor, err := strconv.Atoi(strings.Split(target, ".")[1])
 	if err != nil {
 		return false
 	}

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -69,8 +69,8 @@ func InstalledManifest(instance v1alpha1.KComponent) (mf.Manifest, error) {
 // the target manifest.
 func IsUpDowngradeEligible(instance v1alpha1.KComponent) bool {
 	current := instance.GetStatus().GetVersion()
+	// If there is no manifest installed, return true, because the target manifest is able to install.
 	if current == "" {
-		// If there is no manifest installed, return true, because the target manifest is able to install.
 		return true
 	}
 	current = sanitizeSemver(current)
@@ -96,7 +96,8 @@ func IsUpDowngradeEligible(instance v1alpha1.KComponent) bool {
 		return false
 	}
 
-	if abs(currentMinor-targetMinor) == 1 {
+	// If the diff between minor versions are less than 2, return true.
+	if abs(currentMinor-targetMinor) < 2 {
 		return true
 	}
 

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -139,3 +139,80 @@ func TestListReleases(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUpDowngradeEligible(t *testing.T) {
+	koPath := "testdata/kodata"
+	tests := []struct {
+		name      string
+		component v1alpha1.KComponent
+		expected  bool
+	}{{
+		name: "knative-serving without status.version",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.14.2",
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name: "knative-serving upgrading one minor version",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.14.2",
+				},
+			},
+			Status: v1alpha1.KnativeServingStatus{
+				Version: "0.13.0",
+			},
+		},
+		expected: true,
+	}, {
+		name: "knative-serving upgrading across multiple minor versions",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.15.0",
+				},
+			},
+			Status: v1alpha1.KnativeServingStatus{
+				Version: "0.13.0",
+			},
+		},
+		expected: false,
+	}, {
+		name: "knative-serving upgrading to the latest version across multiple minor versions",
+		component: &v1alpha1.KnativeServing{
+			Status: v1alpha1.KnativeServingStatus{
+				Version: "0.13.0",
+			},
+		},
+		// The latest version is 0.15.0
+		expected: false,
+	}, {
+		name: "knative-serving upgrading to the latest version",
+		component: &v1alpha1.KnativeServing{
+			Status: v1alpha1.KnativeServingStatus{
+				Version: "0.14.0",
+			},
+		},
+		// The latest version is 0.15.0
+		expected: true,
+	}, {
+		name:      "knative-serving with latest version and empty status.version",
+		component: &v1alpha1.KnativeServing{},
+		expected:  true,
+	}}
+
+	os.Setenv(KoEnvKey, koPath)
+	defer os.Unsetenv(KoEnvKey)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := IsUpDowngradeEligible(test.component)
+			util.AssertEqual(t, result, test.expected)
+		})
+	}
+}

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -204,6 +204,19 @@ func TestIsUpDowngradeEligible(t *testing.T) {
 		name:      "knative-serving with latest version and empty status.version",
 		component: &v1alpha1.KnativeServing{},
 		expected:  true,
+	}, {
+		name: "knative-serving with the same status.version and spec.version",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.15.0",
+				},
+			},
+			Status: v1alpha1.KnativeServingStatus{
+				Version: "0.15.0",
+			},
+		},
+		expected: true,
 	}}
 
 	os.Setenv(KoEnvKey, koPath)

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -89,6 +89,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
+
+	if !common.IsUpDowngradeEligible(ke) {
+		logger.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
+			"installed KnativeEventing version is %v.", ke.Status.Version)
+		return nil
+	}
+
 	if err := r.extension.Reconcile(ctx, ke); err != nil {
 		return err
 	}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -91,9 +91,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
 
 	if !common.IsUpDowngradeEligible(ke) {
-		logger.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
+		msg := fmt.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
 			"installed KnativeEventing version is %v.", ke.Status.Version)
+		ke.Status.MarkVersionMigrationNotEligible(msg.Error())
 		return nil
+	} else {
+		ke.Status.MarkVersionMigrationEligible()
 	}
 
 	if err := r.extension.Reconcile(ctx, ke); err != nil {

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -94,9 +94,12 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
 
 	if !common.IsUpDowngradeEligible(ks) {
-		logger.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
+		msg := fmt.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
 			"installed KnativeServing version is %v.", ks.Status.Version)
+		ks.Status.MarkVersionMigrationNotEligible(msg.Error())
 		return nil
+	} else {
+		ks.Status.MarkVersionMigrationEligible()
 	}
 
 	if err := r.extension.Reconcile(ctx, ks); err != nil {

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -92,6 +92,13 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 	ks.Status.ObservedGeneration = ks.Generation
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
+
+	if !common.IsUpDowngradeEligible(ks) {
+		logger.Errorf("It is not supported to upgrade or downgrade across multiple MINOR versions. The "+
+			"installed KnativeServing version is %v.", ks.Status.Version)
+		return nil
+	}
+
 	if err := r.extension.Reconcile(ctx, ks); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #139

## Proposed Changes

* This PR added the logic to determine if upgrade or downgrade is eligible. If the target version is within +-1 version of the installed version, the logic function returns true.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
