### PR TITLE
Introduce Stages abstraction to simplify manifest post-processing

### DIFF
--- a/pkg/reconciler/common/stages.go
+++ b/pkg/reconciler/common/stages.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/pkg/logging"
+)
+
+type Stage func(context.Context, *mf.Manifest, v1alpha1.KComponent) error
+type Stages []Stage
+
+func (stages Stages) Execute(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	for _, stage := range stages {
+		if err := stage(ctx, manifest, instance); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TargetStage(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	m, err := TargetManifest(instance)
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}
+
+func InstalledOrTargetStage(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	logger := logging.FromContext(ctx)
+	m, err := InstalledManifest(instance)
+	if err != nil {
+		// TODO: return the oldest instead of the latest?
+		logger.Error("Unable to fetch installed manifest, trying target", err)
+		m, err = TargetManifest(instance)
+	}
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(m)
+	return nil
+}

--- a/pkg/reconciler/common/stages.go
+++ b/pkg/reconciler/common/stages.go
@@ -24,9 +24,13 @@ import (
 	"knative.dev/pkg/logging"
 )
 
+// Stage represents a step in the reconcile process
 type Stage func(context.Context, *mf.Manifest, v1alpha1.KComponent) error
+
+// Stages are a list of steps
 type Stages []Stage
 
+// Execute each stage in sequence until one returns an error
 func (stages Stages) Execute(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	for _, stage := range stages {
 		if err := stage(ctx, manifest, instance); err != nil {
@@ -36,7 +40,9 @@ func (stages Stages) Execute(ctx context.Context, manifest *mf.Manifest, instanc
 	return nil
 }
 
-func TargetStage(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+// AppendTarget mutates the passed manifest by appending one
+// appropriate for the passed KComponent
+func AppendTarget(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	m, err := TargetManifest(instance)
 	if err != nil {
 		return err
@@ -45,7 +51,10 @@ func TargetStage(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.K
 	return nil
 }
 
-func InstalledOrTargetStage(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+// AppendInstalled mutates the passed manifest by appending one
+// appropriate for the passed KComponent, which may not be the one
+// corresponding to status.version
+func AppendInstalled(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	m, err := InstalledManifest(instance)
 	if err != nil {

--- a/pkg/reconciler/common/stages_test.go
+++ b/pkg/reconciler/common/stages_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestStagesExecute(t *testing.T) {
+	os.Setenv(KoEnvKey, "testdata/kodata")
+	defer os.Unsetenv(KoEnvKey)
+	manifest, _ := mf.ManifestFrom(mf.Slice{})
+	stages := Stages{TargetStage, InstalledOrTargetStage}
+	util.AssertEqual(t, len(manifest.Resources()), 0)
+	stages.Execute(context.TODO(), &manifest, &v1alpha1.KnativeServing{})
+	util.AssertEqual(t, len(manifest.Resources()), 2)
+}

--- a/pkg/reconciler/common/stages_test.go
+++ b/pkg/reconciler/common/stages_test.go
@@ -30,7 +30,7 @@ func TestStagesExecute(t *testing.T) {
 	os.Setenv(KoEnvKey, "testdata/kodata")
 	defer os.Unsetenv(KoEnvKey)
 	manifest, _ := mf.ManifestFrom(mf.Slice{})
-	stages := Stages{TargetStage, InstalledOrTargetStage}
+	stages := Stages{AppendTarget, AppendInstalled}
 	util.AssertEqual(t, len(manifest.Resources()), 0)
 	stages.Execute(context.TODO(), &manifest, &v1alpha1.KnativeServing{})
 	util.AssertEqual(t, len(manifest.Resources()), 2)

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -77,7 +77,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 
 	logger.Info("Deleting cluster-scoped resources")
 	manifest := r.manifest.Append()
-	stages := common.Stages{common.InstalledOrTargetStage, r.transform}
+	stages := common.Stages{common.AppendInstalled, r.transform}
 	if err := stages.Execute(ctx, &manifest, original); err != nil {
 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
 		return nil
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
 	stages := common.Stages{
-		common.TargetStage,
+		common.AppendTarget,
 		r.transform,
 		r.ensureFinalizerRemoval,
 		r.install,

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientset "knative.dev/operator/pkg/client/clientset/versioned"
 
-	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	knereconciler "knative.dev/operator/pkg/client/injection/reconciler/operator/v1alpha1/knativeeventing"
 	"knative.dev/operator/pkg/reconciler/common"
 	kec "knative.dev/operator/pkg/reconciler/knativeeventing/common"
@@ -59,7 +59,7 @@ var _ knereconciler.Interface = (*Reconciler)(nil)
 var _ knereconciler.Finalizer = (*Reconciler)(nil)
 
 // FinalizeKind removes all resources after deletion of a KnativeEventing.
-func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
+func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 
 	// List all KnativeEventings to determine if cluster-scoped resources should be deleted.
@@ -75,63 +75,47 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *eventingv1alpha
 		}
 	}
 
-	manifest, err := common.InstalledManifest(original)
-	if err != nil {
-		logger.Error("Unable to fetch installed manifest, some resources may not be finalized", err)
-		manifest, err = common.TargetManifest(original)
-	}
-	if err != nil {
-		logger.Error("Unable to fetch target manifest, no cluster-scoped resources will be finalized", err)
+	logger.Info("Deleting cluster-scoped resources")
+	manifest := r.manifest.Append()
+	stages := common.Stages{common.InstalledOrTargetStage, r.transform}
+	if err := stages.Execute(ctx, &manifest, original); err != nil {
+		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
 		return nil
 	}
-	manifest = r.manifest.Append(manifest)
-	if err := r.transform(ctx, &manifest, original); err != nil {
-		return err
-	}
-	logger.Info("Deleting cluster-scoped resources")
 	return common.Uninstall(&manifest)
 }
 
 // ReconcileKind compares the actual state with the desired, and attempts to
 // converge the two.
-func (r *Reconciler) ReconcileKind(ctx context.Context, ke *eventingv1alpha1.KnativeEventing) pkgreconciler.Event {
+func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEventing) pkgreconciler.Event {
 	logger := logging.FromContext(ctx)
 	ke.Status.InitializeConditions()
 	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
-	stages := []func(context.Context, *mf.Manifest, *eventingv1alpha1.KnativeEventing) error{
+	stages := common.Stages{
+		common.TargetStage,
 		r.transform,
 		r.ensureFinalizerRemoval,
 		r.install,
 		r.checkDeployments,
 		r.deleteObsoleteResources,
 	}
-
-	manifest, err := common.TargetManifest(ke)
-	if err != nil {
-		return err
-	}
-	manifest = r.manifest.Append(manifest)
-	for _, stage := range stages {
-		if err := stage(ctx, &manifest, ke); err != nil {
-			return err
-		}
-	}
-	logger.Infow("Reconcile stages complete", "status", ke.Status)
-	return nil
+	manifest := r.manifest.Append()
+	return stages.Execute(ctx, &manifest, ke)
 }
 
 // transform mutates the passed manifest to one with common and
 // platform transforms, plus any extras passed in
-func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
+	instance := comp.(*v1alpha1.KnativeEventing)
 	return common.Transform(ctx, manifest, instance, r.platform,
 		kec.DefaultBrokerConfigMapTransform(instance, logger))
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-eventing-manifest" is removed from the resource.
-func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, instance v1alpha1.KComponent) error {
 	patch, err := common.FinalizerRemovalPatch(instance, oldFinalizerName)
 	if err != nil {
 		return fmt.Errorf("failed to construct the patch: %w", err)
@@ -141,27 +125,27 @@ func (r *Reconciler) ensureFinalizerRemoval(_ context.Context, _ *mf.Manifest, i
 		return nil
 	}
 
-	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeEventings(instance.Namespace)
-	if _, err := patcher.Patch(instance.Name, types.MergePatchType, patch); err != nil {
+	patcher := r.operatorClientSet.OperatorV1alpha1().KnativeEventings(instance.GetNamespace())
+	if _, err := patcher.Patch(instance.GetName(), types.MergePatchType, patch); err != nil {
 		return fmt.Errorf("failed to patch finalizer away: %w", err)
 	}
 	return nil
 }
 
-func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) install(ctx context.Context, manifest *mf.Manifest, ke v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Installing manifest")
-	return common.Install(manifest, common.TargetVersion(ke), &ke.Status)
+	return common.Install(manifest, common.TargetVersion(ke), ke.GetStatus())
 }
 
-func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, ke *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) checkDeployments(ctx context.Context, manifest *mf.Manifest, ke v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Checking deployments")
-	return common.CheckDeployments(r.kubeClientSet, manifest, &ke.Status)
+	return common.CheckDeployments(r.kubeClientSet, manifest, ke.GetStatus())
 }
 
 // Delete obsolete resources from previous versions
-func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance *eventingv1alpha1.KnativeEventing) error {
+func (r *Reconciler) deleteObsoleteResources(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	resources := []*unstructured.Unstructured{
 		// Remove old resources from 0.12
 		// https://github.com/knative/eventing-operator/issues/90

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -80,7 +80,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 	manifest := r.manifest.Append()
 
 	// TODO: add ingress, etc
-	stages := common.Stages{common.InstalledOrTargetStage, r.transform}
+	stages := common.Stages{common.AppendInstalled, r.transform}
 
 	if err := stages.Execute(ctx, &manifest, original); err != nil {
 		logger.Error("Unable to fetch installed manifest; no cluster-scoped resources will be finalized", err)
@@ -98,7 +98,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
 	stages := common.Stages{
-		common.TargetStage,
+		common.AppendTarget,
 		r.transform,
 		r.ensureFinalizerRemoval,
 		r.install,


### PR DESCRIPTION
This enables all of the stages except the transform functions (which
are the only ones requiring downcasting of the KComponents) to be
moved out of the reconcilers into a common package.

It'll also be handy when obsolete resources are calculated from
diff'ing the target and installed manifests as all of the stages must
be applied to both.

Similarly, the ingress determination should be added to the stages in
FinalizeKind and (the forthcoming) deleteObsoleteResources functions,
along with any other stages that might potentially append to the
constructed manifests.
