### PR TITLE
[RELEASE-0.14] Don't delete deployments first explicitly.

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -273,9 +273,6 @@ func (r *Reconciler) delete(ctx context.Context, instance *servingv1alpha1.Knati
 	logger.Info("Deleting resources")
 	var RBAC = mf.Any(mf.ByKind("Role"), mf.ByKind("ClusterRole"), mf.ByKind("RoleBinding"), mf.ByKind("ClusterRoleBinding"))
 	if len(r.servings) == 0 {
-		if err := r.config.Filter(mf.ByKind("Deployment")).Delete(); err != nil {
-			return err
-		}
 		if err := r.config.Filter(mf.NoCRDs, mf.None(RBAC)).Delete(); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

I've seen cases where this causes us to subsequent deletes of resources because the validating webhooks are no longer reachable.

/assign @jcrossley3 @houshengbo 
