### PR TITLE
Add the label to all the operator resources

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: knativeeventings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
 spec:
   additionalPrinterColumns:
     - JSONPath: .status.version

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: knativeservings.operator.knative.dev
+  labels:
+    operator.knative.dev/release: devel
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.version

--- a/config/operator.yaml
+++ b/config/operator.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: knative-operator
   namespace: default
+  labels:
+    operator.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/config/role.yaml
+++ b/config/role.yaml
@@ -15,6 +15,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-serving-operator-aggregated
+  labels:
+    operator.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
 # This (along with escalate below) allows the Operator to pick up any
@@ -28,6 +30,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-operator
+  labels:
+    operator.knative.dev/release: devel
 rules:
 - apiGroups:
   - operator.knative.dev
@@ -208,6 +212,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: knative-eventing-operator-aggregated
+  labels:
+    operator.knative.dev/release: devel
 aggregationRule:
   clusterRoleSelectors:
     # This (along with escalate below) allows the Operator to pick up any
@@ -221,6 +227,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-eventing-operator
+  labels:
+    operator.knative.dev/release: devel
 rules:
   - apiGroups:
       - operator.knative.dev

--- a/config/role_binding.yaml
+++ b/config/role_binding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator
+  labels:
+    operator.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -29,6 +31,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-serving-operator-aggregated
+  labels:
+    operator.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -43,6 +47,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator
+  labels:
+    operator.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -56,6 +62,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-eventing-operator-aggregated
+  labels:
+    operator.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/service_account.yaml
+++ b/config/service_account.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: knative-operator
   namespace: default
+  labels:
+    operator.knative.dev/release: devel


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #142

## Proposed Changes

* The label `operator.knative.dev/release: devel` is added to all resources.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
