### PR TITLE
correct defaultBrokerClass name in  eventing crd description

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -93,7 +93,7 @@ spec:
                         type: string
             defaultBrokerClass:
               description: The default broker type to use for the brokers Knative creates.
-                If no value is provided, ChannelBasedBroker will be used.
+                If no value is provided, MTChannelBasedBroker will be used.
               type: string
             resources:
               description: A mapping of deployment name to resource requirements


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* the MTChannelBasedBroker is the new default broker

**Release Note**
None
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
