### PR TITLE
Comparing target & installed manifests to delete obsolete resources

### DIFF
--- a/pkg/reconciler/common/stages.go
+++ b/pkg/reconciler/common/stages.go
@@ -40,6 +40,11 @@ func (stages Stages) Execute(ctx context.Context, manifest *mf.Manifest, instanc
 	return nil
 }
 
+// NoOp does nothing
+func NoOp(context.Context, *mf.Manifest, v1alpha1.KComponent) error {
+	return nil
+}
+
 // AppendTarget mutates the passed manifest by appending one
 // appropriate for the passed KComponent
 func AppendTarget(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {


### PR DESCRIPTION
Fixes #148 but leaves some opportunity for refactoring the functions
in each controller to a shared package. I wasn't happy with any of my
efforts to deal with the "parent" manifests (with client/logger) and
build stages (e.g. ingress, transform), though.
