### PR TITLE
Further extension enhancements

### DIFF
--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -22,9 +22,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-// NilException is a convenient null object
-var NilExtension = nilExtension{}
-
 // Extension enables platform-specific features
 type Extension interface {
 	Transformers(v1alpha1.KComponent) []mf.Transformer
@@ -36,8 +33,8 @@ type Extension interface {
 type ExtensionGenerator func(context.Context) Extension
 
 // NoPlatform "generates" a NilExtension
-func NoPlatform(context.Context) Extension {
-	return NilExtension
+func NoExtension(context.Context) Extension {
+	return nilExtension{}
 }
 
 type nilExtension struct{}
@@ -50,21 +47,4 @@ func (nilExtension) Reconcile(context.Context, v1alpha1.KComponent) error {
 }
 func (nilExtension) Finalize(context.Context, v1alpha1.KComponent) error {
 	return nil
-}
-
-// pfKey is used as the key for associating Platforms with the context.
-type pfKey struct{}
-
-// WithPlatform attaches the given Platform to the provided context.
-func WithPlatform(ctx context.Context, platform Extension) context.Context {
-	return context.WithValue(ctx, pfKey{}, platform)
-}
-
-// GetPlatforms extracts the Platforms from the context.
-func GetPlatform(ctx context.Context) Extension {
-	untyped := ctx.Value(pfKey{})
-	if untyped == nil {
-		return nil
-	}
-	return untyped.(Extension)
 }

--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -27,7 +27,7 @@ var NilExtension = nilExtension{}
 
 // Extension enables platform-specific features
 type Extension interface {
-	Transformers(v1alpha1.KComponent) ([]mf.Transformer, error)
+	Transformers(v1alpha1.KComponent) []mf.Transformer
 	Reconcile(context.Context, v1alpha1.KComponent) error
 	Finalize(context.Context, v1alpha1.KComponent) error
 }
@@ -42,8 +42,8 @@ func NoPlatform(context.Context) Extension {
 
 type nilExtension struct{}
 
-func (nilExtension) Transformers(v1alpha1.KComponent) ([]mf.Transformer, error) {
-	return nil, nil
+func (nilExtension) Transformers(v1alpha1.KComponent) []mf.Transformer {
+	return nil
 }
 func (nilExtension) Reconcile(context.Context, v1alpha1.KComponent) error {
 	return nil

--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -22,10 +22,34 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
+// NilException is a convenient null object
+var NilExtension = nilExtension{}
+
+// Extension enables platform-specific features
 type Extension interface {
 	Transformers(v1alpha1.KComponent) ([]mf.Transformer, error)
 	Reconcile(context.Context, v1alpha1.KComponent) error
 	Finalize(context.Context, v1alpha1.KComponent) error
+}
+
+// ExtensionGenerator creates an Extension from a Context
+type ExtensionGenerator func(context.Context) Extension
+
+// NoPlatform "generates" a NilExtension
+func NoPlatform(context.Context) Extension {
+	return NilExtension
+}
+
+type nilExtension struct{}
+
+func (nilExtension) Transformers(v1alpha1.KComponent) ([]mf.Transformer, error) {
+	return nil, nil
+}
+func (nilExtension) Reconcile(context.Context, v1alpha1.KComponent) error {
+	return nil
+}
+func (nilExtension) Finalize(context.Context, v1alpha1.KComponent) error {
+	return nil
 }
 
 // pfKey is used as the key for associating Platforms with the context.

--- a/pkg/reconciler/common/extensions_test.go
+++ b/pkg/reconciler/common/extensions_test.go
@@ -22,7 +22,6 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
-	util "knative.dev/operator/pkg/reconciler/common/testing"
 )
 
 type TestExtension string
@@ -55,19 +54,27 @@ func TestExtensions(t *testing.T) {
 		platform: TestExtension("fail"),
 		length:   0,
 	}, {
-		name:     "no path",
+		name:     "nil path",
 		platform: nil,
+		length:   0,
+	}, {
+		name:     "no path",
+		platform: NoExtension(nil),
 		length:   0,
 	}}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := WithPlatform(context.Background(), test.platform)
-			ext := GetPlatform(ctx)
-			util.AssertEqual(t, ext, test.platform)
+			ext := test.platform
 			if ext != nil {
 				transformers := ext.Transformers(nil)
 				if len(transformers) != test.length {
+					t.Error("Unexpected result")
+				}
+				if ext.Reconcile(nil, nil) != nil {
+					t.Error("Unexpected result")
+				}
+				if ext.Finalize(nil, nil) != nil {
 					t.Error("Unexpected result")
 				}
 			}

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -38,16 +38,21 @@ func transformers(ctx context.Context, obj v1alpha1.KComponent) []mf.Transformer
 func Transform(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent, platform Extension, extra ...mf.Transformer) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Transforming manifest")
+
+	// common transforms
 	transformers := transformers(ctx, instance)
+
+	// component transforms
 	transformers = append(transformers, extra...)
-	if platform != nil {
-		pfts, err := platform.Transformers(instance)
-		if err != nil {
-			instance.GetStatus().MarkInstallFailed(err.Error())
-			return err
-		}
-		transformers = append(transformers, pfts...)
+
+	// platform transforms
+	pfts, err := platform.Transformers(instance)
+	if err != nil {
+		instance.GetStatus().MarkInstallFailed(err.Error())
+		return err
 	}
+	transformers = append(transformers, pfts...)
+
 	m, err := manifest.Transform(transformers...)
 	if err != nil {
 		instance.GetStatus().MarkInstallFailed(err.Error())

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -35,23 +35,12 @@ func transformers(ctx context.Context, obj v1alpha1.KComponent) []mf.Transformer
 
 // Transform will mutate the passed-by-reference manifest with one
 // transformed by platform, common, and any extra passed in
-func Transform(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent, platform Extension, extra ...mf.Transformer) error {
+func Transform(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent, extra ...mf.Transformer) error {
 	logger := logging.FromContext(ctx)
 	logger.Debug("Transforming manifest")
 
-	// common transforms
 	transformers := transformers(ctx, instance)
-
-	// component transforms
 	transformers = append(transformers, extra...)
-
-	// platform transforms
-	pfts, err := platform.Transformers(instance)
-	if err != nil {
-		instance.GetStatus().MarkInstallFailed(err.Error())
-		return err
-	}
-	transformers = append(transformers, pfts...)
 
 	m, err := manifest.Transform(transformers...)
 	if err != nil {

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -40,7 +40,7 @@ func TestCommonTransformers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
-	if err := Transform(context.Background(), &manifest, component, NilExtension); err != nil {
+	if err := Transform(context.Background(), &manifest, component); err != nil {
 		t.Fatalf("Failed to transform manifest: %v", err)
 	}
 	resource := &manifest.Resources()[0]
@@ -51,14 +51,14 @@ func TestCommonTransformers(t *testing.T) {
 	}
 
 	// Transform with a platform extension
-	platform := TestExtension("fubar")
-	if err := Transform(context.Background(), &manifest, component, platform); err != nil {
+	ext := TestExtension("fubar")
+	if err := Transform(context.Background(), &manifest, component, ext.Transformers(component)...); err != nil {
 		t.Fatalf("Failed to transform manifest: %v", err)
 	}
 	resource = &manifest.Resources()[0]
 
 	// Verify namespace is transformed
-	if got, want := resource.GetNamespace(), string(platform); got != want {
+	if got, want := resource.GetNamespace(), string(ext); got != want {
 		t.Fatalf("GetNamespace() = %s, want %s", got, want)
 	}
 

--- a/pkg/reconciler/common/transformers_test.go
+++ b/pkg/reconciler/common/transformers_test.go
@@ -40,7 +40,7 @@ func TestCommonTransformers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to generate manifest: %v", err)
 	}
-	if err := Transform(context.Background(), &manifest, component, nil); err != nil {
+	if err := Transform(context.Background(), &manifest, component, NilExtension); err != nil {
 		t.Fatalf("Failed to transform manifest: %v", err)
 	}
 	resource := &manifest.Resources()[0]

--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -39,7 +39,7 @@ import (
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	return NewExtendedController(common.NoPlatform)(ctx, cmw)
+	return NewExtendedController(common.NoExtension)(ctx, cmw)
 }
 
 // NewExtendedController returns a controller extended to a specific platform
@@ -65,7 +65,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),
-			platform:          generator(ctx),
+			extension:         generator(ctx),
 			manifest:          manifest,
 		}
 		impl := knereconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -50,7 +50,7 @@ type Reconciler struct {
 	// client & logger
 	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform
-	platform common.Extension
+	extension common.Extension
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -74,7 +74,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 		}
 	}
 
-	if err := r.platform.Finalize(ctx, original); err != nil {
+	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}
 	logger.Info("Deleting cluster-scoped resources")
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
-	if err := r.platform.Reconcile(ctx, ke); err != nil {
+	if err := r.extension.Reconcile(ctx, ke); err != nil {
 		return err
 	}
 	stages := common.Stages{
@@ -115,7 +115,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	logger := logging.FromContext(ctx)
 	instance := comp.(*v1alpha1.KnativeEventing)
 	extra := []mf.Transformer{kec.DefaultBrokerConfigMapTransform(instance, logger)}
-	extra = append(extra, r.platform.Transformers(instance)...)
+	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)
 }
 

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -109,13 +109,14 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	return stages.Execute(ctx, &manifest, ke)
 }
 
-// transform mutates the passed manifest to one with common and
-// platform transforms, plus any extras passed in
+// transform mutates the passed manifest to one with common, component
+// and platform transformations applied
 func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	instance := comp.(*v1alpha1.KnativeEventing)
-	return common.Transform(ctx, manifest, instance, r.platform,
-		kec.DefaultBrokerConfigMapTransform(instance, logger))
+	extra := []mf.Transformer{kec.DefaultBrokerConfigMapTransform(instance, logger)}
+	extra = append(extra, r.platform.Transformers(instance)...)
+	return common.Transform(ctx, manifest, instance, extra...)
 }
 
 // ensureFinalizerRemoval ensures that the obsolete "delete-knative-eventing-manifest" is removed from the resource.

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -74,6 +74,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 		}
 	}
 
+	if err := r.platform.Finalize(ctx, original); err != nil {
+		logger.Error("Failed to finalize platform resources", err)
+	}
 	logger.Info("Deleting cluster-scoped resources")
 	manifest, err := r.installed(ctx, original)
 	if err != nil {
@@ -91,6 +94,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	ke.Status.ObservedGeneration = ke.Generation
 
 	logger.Infow("Reconciling KnativeEventing", "status", ke.Status)
+	if err := r.platform.Reconcile(ctx, ke); err != nil {
+		return err
+	}
 	stages := common.Stages{
 		common.AppendTarget,
 		r.transform,

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -39,7 +39,7 @@ import (
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	return NewExtendedController(common.NoPlatform)(ctx, cmw)
+	return NewExtendedController(common.NoExtension)(ctx, cmw)
 }
 
 // NewExtendedController returns a controller extended to a specific platform
@@ -65,7 +65,7 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),
-			platform:          generator(ctx),
+			extension:         generator(ctx),
 			manifest:          manifest,
 		}
 		impl := knsreconciler.NewImpl(ctx, c)

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -39,39 +39,46 @@ import (
 // NewController initializes the controller and is called by the generated code
 // Registers eventhandlers to enqueue events
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	knativeServingInformer := knativeServinginformer.Get(ctx)
-	deploymentInformer := deploymentinformer.Get(ctx)
-	kubeClient := kubeclient.Get(ctx)
-	logger := logging.FromContext(ctx)
+	return NewExtendedController(common.NoPlatform)(ctx, cmw)
+}
 
-	// Clean up old non-unified operator resources before even starting the controller.
-	if err := reconciler.RemovePreUnifiedResources(kubeClient, "knative-serving-operator"); err != nil {
-		logger.Fatalw("Failed to remove old resources", zap.Error(err))
+// NewExtendedController returns a controller extended to a specific platform
+func NewExtendedController(generator common.ExtensionGenerator) injection.ControllerConstructor {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		knativeServingInformer := knativeServinginformer.Get(ctx)
+		deploymentInformer := deploymentinformer.Get(ctx)
+		kubeClient := kubeclient.Get(ctx)
+		logger := logging.FromContext(ctx)
+
+		// Clean up old non-unified operator resources before even starting the controller.
+		if err := reconciler.RemovePreUnifiedResources(kubeClient, "knative-serving-operator"); err != nil {
+			logger.Fatalw("Failed to remove old resources", zap.Error(err))
+		}
+
+		mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
+		if err != nil {
+			logger.Fatalw("Error creating client from injected config", zap.Error(err))
+		}
+		mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
+		manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
+
+		c := &Reconciler{
+			kubeClientSet:     kubeClient,
+			operatorClientSet: operatorclient.Get(ctx),
+			platform:          generator(ctx),
+			manifest:          manifest,
+		}
+		impl := knsreconciler.NewImpl(ctx, c)
+
+		logger.Info("Setting up event handlers")
+
+		knativeServingInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+		deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("KnativeServing")),
+			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+		})
+
+		return impl
 	}
-
-	mfclient, err := mfc.NewClient(injection.GetConfig(ctx))
-	if err != nil {
-		logger.Fatalw("Error creating client from injected config", zap.Error(err))
-	}
-	mflogger := zapr.NewLogger(logger.Named("manifestival").Desugar())
-	manifest, _ := mf.ManifestFrom(mf.Slice{}, mf.UseClient(mfclient), mf.UseLogger(mflogger))
-
-	c := &Reconciler{
-		kubeClientSet:     kubeClient,
-		operatorClientSet: operatorclient.Get(ctx),
-		platform:          common.GetPlatform(ctx),
-		manifest:          manifest,
-	}
-	impl := knsreconciler.NewImpl(ctx, c)
-
-	logger.Info("Setting up event handlers")
-
-	knativeServingInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
-
-	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("KnativeServing")),
-		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
-	})
-
-	return impl
 }

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -74,6 +74,9 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 		}
 	}
 
+	if err := r.platform.Finalize(ctx, original); err != nil {
+		logger.Error("Failed to finalize platform resources", err)
+	}
 	logger.Info("Deleting cluster-scoped resources")
 	manifest, err := r.installed(ctx, original)
 	if err != nil {
@@ -91,6 +94,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 	ks.Status.ObservedGeneration = ks.Generation
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
+	if err := r.platform.Reconcile(ctx, ks); err != nil {
+		return err
+	}
 	stages := common.Stages{
 		common.AppendTarget,
 		r.transform,

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -50,7 +50,7 @@ type Reconciler struct {
 	// client & logger
 	manifest mf.Manifest
 	// Platform-specific behavior to affect the transform
-	platform common.Extension
+	extension common.Extension
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -74,7 +74,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1alpha1.Knativ
 		}
 	}
 
-	if err := r.platform.Finalize(ctx, original); err != nil {
+	if err := r.extension.Finalize(ctx, original); err != nil {
 		logger.Error("Failed to finalize platform resources", err)
 	}
 	logger.Info("Deleting cluster-scoped resources")
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 	ks.Status.ObservedGeneration = ks.Generation
 
 	logger.Infow("Reconciling KnativeServing", "status", ks.Status)
-	if err := r.platform.Reconcile(ctx, ks); err != nil {
+	if err := r.extension.Reconcile(ctx, ks); err != nil {
 		return err
 	}
 	stages := common.Stages{
@@ -120,7 +120,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		ksc.HighAvailabilityTransform(instance, logger),
 		ksc.AggregationRuleTransform(manifest.Client),
 	}
-	extra = append(extra, r.platform.Transformers(instance)...)
+	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)
 }
 


### PR DESCRIPTION
Introduced a `NewExtendedController` constructor that takes an `ExtensionGenerator` argument which can return an `Extension` tailored to a specific platform, e.g. OpenShift, GKE or Minikube.

Both the eventing and serving controllers can now be extended with platform-specific behavior in the reconcile, finalize, and transform phases.
