### PR TITLE
Change test cases to use the same namespace for serving and eventing

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,17 +18,17 @@
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
 # The previous operator release.
-readonly PREVIOUS_OPERATOR_RELEASE_VERSION="0.14.2"
+readonly PREVIOUS_OPERATOR_RELEASE_VERSION="0.15.2"
 # The previous serving release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
 # different from PREVIOUS_OPERATOR_RELEASE_VERSION.
-readonly PREVIOUS_SERVING_RELEASE_VERSION="0.14.0"
+readonly PREVIOUS_SERVING_RELEASE_VERSION="0.15.2"
 # The previous eventing release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
 # different from PREVIOUS_OPERATOR_RELEASE_VERSION.
-readonly PREVIOUS_EVENTING_RELEASE_VERSION="0.14.2"
+readonly PREVIOUS_EVENTING_RELEASE_VERSION="0.15.2"
 # This is the branch name of serving and eventing repo, where we run the upgrade tests.
 readonly KNATIVE_REPO_BRANCH=${PULL_BASE_REF}
 # Istio version we test with
-readonly ISTIO_VERSION="1.4-latest"
+readonly ISTIO_VERSION="1.5-latest"
 # Test without Istio mesh enabled
 readonly ISTIO_MESH=0
 # This environment variable is the namespace used to run the test cases in operator.

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,9 +32,9 @@ readonly ISTIO_VERSION="1.4-latest"
 # Test without Istio mesh enabled
 readonly ISTIO_MESH=0
 # Namespace used for tests
-readonly TEST_NAMESPACE="knative-serving-operator-test"
+readonly TEST_NAMESPACE="knative-operator-test"
 # Namespace used for tests
-readonly TEST_EVENTING_NAMESPACE="knative-eventing"
+readonly TEST_EVENTING_NAMESPACE="knative-eventing-test"
 # Boolean used to indicate whether to generate serving YAML based on the latest code in the branch KNATIVE_REPO_BRANCH.
 GENERATE_SERVING_YAML=0
 
@@ -48,8 +48,12 @@ readonly TMP_DIR
 
 readonly KNATIVE_DEFAULT_NAMESPACE="knative-serving"
 
-# This the namespace used to install Knative.
+# This environment variable is the namespace used to install Knative Serving.
 export SYSTEM_NAMESPACE
+SYSTEM_NAMESPACE=${TEST_NAMESPACE}
+
+# This environment variable is the namespace used to install Knative Eventing.
+export TEST_EVENTING_NAMESPACE
 SYSTEM_NAMESPACE=${TEST_NAMESPACE}
 
 # Add function call to trap

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -54,6 +54,9 @@ SYSTEM_NAMESPACE=${TEST_NAMESPACE}
 export TEST_EVENTING_NAMESPACE
 TEST_EVENTING_NAMESPACE=${TEST_NAMESPACE}
 
+# This environment variable is the CR name for knativeserving and knativeeventing.
+export TEST_RESOURCE="knative"
+
 # Add function call to trap
 # Parameters: $1 - Function to call
 #             $2...$n - Signals for trap

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -32,7 +32,7 @@ readonly ISTIO_VERSION="1.4-latest"
 # Test without Istio mesh enabled
 readonly ISTIO_MESH=0
 # Namespace used for tests
-readonly TEST_NAMESPACE="knative-serving"
+readonly TEST_NAMESPACE="knative-serving-operator-test"
 # Namespace used for tests
 readonly TEST_EVENTING_NAMESPACE="knative-eventing"
 # Boolean used to indicate whether to generate serving YAML based on the latest code in the branch KNATIVE_REPO_BRANCH.
@@ -42,6 +42,15 @@ readonly OPERATOR_DIR=$(dirname $(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
 readonly KNATIVE_DIR=$(dirname ${OPERATOR_DIR})
 release_yaml="$(mktemp)"
 release_eventing_yaml="$(mktemp)"
+
+TMP_DIR=$(mktemp -d -t ci-$(date +%Y-%m-%d-%H-%M-%S)-XXXXXXXXXX)
+readonly TMP_DIR
+
+readonly KNATIVE_DEFAULT_NAMESPACE="knative-serving"
+
+# This the namespace used to install Knative.
+export SYSTEM_NAMESPACE
+SYSTEM_NAMESPACE=${TEST_NAMESPACE}
 
 # Add function call to trap
 # Parameters: $1 - Function to call

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -100,7 +100,12 @@ function test_setup() {
   fi
   echo ">> Creating test resources (test/config/) in Knative Serving repository"
   cd ${KNATIVE_DIR}/serving
-  ko apply ${KO_FLAGS} -f test/config/ || return 1
+  local SERVING_TEST_CONFIG_DIR=${TMP_DIR}/serving/test/config
+  mkdir -p ${SERVING_TEST_CONFIG_DIR}
+  cp -r test/config/* ${SERVING_TEST_CONFIG_DIR}
+  find ${SERVING_TEST_CONFIG_DIR} -type f -name "*.yaml" -exec sed -i "s/${KNATIVE_DEFAULT_NAMESPACE}/${TEST_NAMESPACE}/g" {} +
+
+  ko apply ${KO_FLAGS} -f ${SERVING_TEST_CONFIG_DIR} || return 1
 
   echo ">> Uploading test images..."
   # We only need to build and publish two images among all the test images

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -79,7 +79,7 @@ apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing
 metadata:
   name: knative-eventing
-  namespace: ${TEST_EVENTING_NAMESPACE}
+  namespace: ${TEST_NAMESPACE}
 EOF
 }
 
@@ -90,7 +90,6 @@ function knative_setup() {
   donwload_knative "eventing" ${KNATIVE_REPO_BRANCH}
   create_custom_resource
   wait_until_pods_running ${TEST_NAMESPACE}
-  wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 }
 
 # Create test resources and images
@@ -180,7 +179,6 @@ go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade || fail_test
 
 header "Listing all the pods of the previous release"
 wait_until_pods_running ${TEST_NAMESPACE}
-wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
 header "Running preupgrade tests"
 
@@ -199,6 +197,8 @@ echo "Prober PID Serving is ${PROBER_PID_SERVING}"
 
 # Go to the knative eventing repo
 cd ${KNATIVE_DIR}/eventing
+echo "check env var"
+set
 go_test_e2e -tags=preupgrade -timeout="${TIMEOUT}" ./test/upgrade || fail_test
 
 header "Starting prober test for eventing"
@@ -221,7 +221,6 @@ cd ${OPERATOR_DIR}
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
   --preservingversion="${PREVIOUS_SERVING_RELEASE_VERSION}" --preeventingversion="${PREVIOUS_EVENTING_RELEASE_VERSION}" || failed=1
 wait_until_pods_running ${TEST_NAMESPACE}
-wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
 header "Running postupgrade tests for Knative Serving"
 # Run the postupgrade tests under serving
@@ -234,7 +233,6 @@ go_test_e2e -tags=postupgrade -timeout="${TIMEOUT}" ./test/upgrade || fail_test
 
 install_previous_operator_release
 wait_until_pods_running ${TEST_NAMESPACE}
-wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
 header "Running postdowngrade tests for Knative Serving"
 cd ${KNATIVE_DIR}/serving

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -56,6 +56,10 @@ function install_previous_operator_release() {
 
 function create_custom_resource() {
   echo ">> Creating the custom resource of Knative Serving:"
+}
+
+function create_custom_resource1() {
+  echo ">> Creating the custom resource of Knative Serving:"
   cat <<EOF | kubectl apply -f -
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
@@ -89,7 +93,7 @@ function knative_setup() {
   donwload_knative "serving" ${KNATIVE_REPO_BRANCH}
   donwload_knative "eventing" ${KNATIVE_REPO_BRANCH}
   create_custom_resource
-  wait_until_pods_running ${TEST_NAMESPACE}
+  #wait_until_pods_running ${TEST_NAMESPACE}
 }
 
 # Create test resources and images

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -60,7 +60,7 @@ function create_custom_resource() {
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
-  name: knative-serving
+  name: ${TEST_RESOURCE}
   namespace: ${TEST_NAMESPACE}
 spec:
   config:
@@ -78,7 +78,7 @@ EOF
 apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing
 metadata:
-  name: knative-eventing
+  name: ${TEST_RESOURCE}
   namespace: ${TEST_NAMESPACE}
 EOF
 }

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -26,9 +26,9 @@ import (
 
 var (
 	// ServingOperatorNamespace is the default namespace for serving operator e2e tests
-	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-serving-operator-test")
+	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-operator-test")
 	// EventingOperatorNamespace is the default namespace for serving operator e2e tests
-	EventingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-eventing")
+	EventingOperatorNamespace = ServingOperatorNamespace
 	// OperatorName is the default operator name for serving operator e2e tests
 	OperatorName = getenv("TEST_RESOURCE", "knative")
 	// OperatorFlags holds the flags or defaults for knative/operator settings in the user's environment.

--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// ServingOperatorNamespace is the default namespace for serving operator e2e tests
-	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-serving")
+	ServingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-serving-operator-test")
 	// EventingOperatorNamespace is the default namespace for serving operator e2e tests
 	EventingOperatorNamespace = getenv("TEST_NAMESPACE", "knative-eventing")
 	// OperatorName is the default operator name for serving operator e2e tests

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -76,22 +76,21 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 	if err != nil {
 		return false, err
 	}
-	if len(dpList.Items) != len(expectedDeployments) {
-		logf("The expected number of deployments is %v, and got %v.", len(expectedDeployments), len(dpList.Items))
-		return false, nil
-	}
-	for _, deployment := range dpList.Items {
-		if !stringInList(deployment.Name, expectedDeployments) {
-			logf("The deployment %v is not found in the expected list of deployment.", deployment.Name)
+
+	for _, deploymentName := range expectedDeployments {
+		dep := deploymentInList(deploymentName, dpList.Items)
+		if dep == nil {
+			logf("The deployment %v is not found.", deploymentName)
 			return false, nil
 		}
-		for _, c := range deployment.Status.Conditions {
+		for _, c := range dep.Status.Conditions {
 			if c.Type == v1.DeploymentAvailable && c.Status != corev1.ConditionTrue {
-				logf("The deployment %v is not ready.", deployment.Name)
+				logf("The deployment %v is not ready.", dep.Name)
 				return false, nil
 			}
 		}
 	}
+
 	return true, nil
 }
 

--- a/test/resources/knativeserving.go
+++ b/test/resources/knativeserving.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -120,11 +121,11 @@ func getTestKSOperatorCRSpec() v1alpha1.KnativeServingSpec {
 	}
 }
 
-func stringInList(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
+func deploymentInList(a string, deploymentList []appsv1.Deployment) *appsv1.Deployment {
+	for _, deployment := range deploymentList {
+		if deployment.Name == a {
+			return &deployment
 		}
 	}
-	return false
+	return nil
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* As we are about to run both knative serving and eventing under the same namespace, test cases verification needs to be changed.
* This PR dropped the verification for the number of deployments, but verify whether the expected deployments are available.
* Knative serving ns is set by the env var SYSTEM_NAMESPACE, and Knative eventing ns is set by the env var TEST_EVENTING_NAMESPACE in shell scripts.

