### PR TITLE
Skip the verification of CRD's and webhooks

### DIFF
--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -180,7 +181,11 @@ func IsKnativeObsoleteResourceGone(clients *test.Clients, namespace string, obsR
 			// This is a namespaced resource
 			_, err = clients.Dynamic.Resource(gvr).Namespace(namespace).Get(resource.GetName(), metav1.GetOptions{})
 		} else {
-			// This is a clustered resource
+			// Verify all clustered resources, except CRDs and webhooks.
+			switch strings.ToLower(resource.GetKind()) {
+			case "customresourcedefinition", "validatingwebhookconfiguration", "mutatingwebhookconfiguration":
+				continue
+			}
 			_, err = clients.Dynamic.Resource(gvr).Get(resource.GetName(), metav1.GetOptions{})
 		}
 		if !apierrs.IsNotFound(err) {

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -113,7 +113,7 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 // GetExpectedDeployments will return an array of deployment resources based on the version for the knative
 // component.
 func GetExpectedDeployments(t *testing.T, instance v1alpha1.KComponent) (mf.Manifest, []string) {
-	manifest, err := common.InstalledManifest(instance)
+	manifest, err := common.TargetManifest(instance)
 	if err != nil {
 		t.Fatalf("Failed to get the manifest for Knative: %v", err)
 	}

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"testing"
 	"time"
 
 	"knative.dev/pkg/apis"
@@ -40,7 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	"knative.dev/operator/test"
 	"knative.dev/pkg/test/logging"
 )
@@ -113,17 +111,12 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 
 // GetExpectedDeployments will return an array of deployment resources based on the version for the knative
 // component.
-func GetExpectedDeployments(t *testing.T, instance v1alpha1.KComponent) (mf.Manifest, []string) {
-	manifest, err := common.TargetManifest(instance)
-	if err != nil {
-		t.Fatalf("Failed to get the manifest for Knative: %v", err)
-	}
-
+func GetExpectedDeployments(manifest mf.Manifest) []string {
 	deployments := []string{}
 	for _, resource := range manifest.Filter(mf.ByKind("Deployment")).Resources() {
 		deployments = append(deployments, resource.GetName())
 	}
-	return manifest, removeDuplications(deployments)
+	return removeDuplications(deployments)
 }
 
 // SetKodataDir will set the env var KO_DATA_PATH into the path of the kodata of this repository.

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -53,7 +53,11 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the latest release version, get the deployment resources.
-		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, &v1alpha1.KnativeEventing{})
+		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeEventing{})
+		if err != nil {
+			t.Fatalf("Failed to get the manifest for Knative: %v", err)
+		}
+		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 

--- a/test/upgrade/knativeeventing_preupgrade_test.go
+++ b/test/upgrade/knativeeventing_preupgrade_test.go
@@ -56,7 +56,11 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the status.version, get the deployment resources.
 		defer os.Unsetenv(common.KoEnvKey)
-		_, expectedDeployments := resources.GetExpectedDeployments(t, keventing)
+		manifest, err := common.InstalledManifest(keventing)
+		if err != nil {
+			t.Fatalf("Failed to get the manifest for Knative: %v", err)
+		}
+		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 	})

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -52,7 +52,11 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		targetManifest, expectedDeployments := resources.GetExpectedDeployments(t, &v1alpha1.KnativeServing{})
+		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeServing{})
+		if err != nil {
+			t.Fatalf("Failed to get the manifest for Knative: %v", err)
+		}
+		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
 		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)


### PR DESCRIPTION

Fixes #189

## Proposed Changes

* If version is the only difference between two CRD's or webhooks, manifestival considers them as different, but they should still exist in the cluster after upgrade. There is no need to verify them in the postupgrade tests. 
