### PR TITLE
Update to latest manifestival 0.6.0+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.12.2 // indirect
 	github.com/manifestival/client-go-client v0.2.3-0.20200702141517-e255fbf14f6f
-	github.com/manifestival/manifestival v0.5.1-0.20200702141132-93669fa9179b
+	github.com/manifestival/manifestival v0.6.1-0.20200713203452-583e95ddeeb0
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.14.1
 	golang.org/x/mod v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/manifestival/client-go-client v0.2.3-0.20200702141517-e255fbf14f6f h1
 github.com/manifestival/client-go-client v0.2.3-0.20200702141517-e255fbf14f6f/go.mod h1:BISQjOz8kvcqMkGHFTRzO0hVEYolWScep7w1WT2bsV0=
 github.com/manifestival/manifestival v0.5.1-0.20200702141132-93669fa9179b h1:Je0eQ3VqreYrRlD7CZtYvYEPNPiALqZq7+V3tNDhGn0=
 github.com/manifestival/manifestival v0.5.1-0.20200702141132-93669fa9179b/go.mod h1:3Qq9cnPy7sv7FVhg2Kvw0ebb35R4OdctS4UjTjHlHm4=
+github.com/manifestival/manifestival v0.6.1-0.20200713203452-583e95ddeeb0 h1:0HnrNIteTVujCCSHXhuyWHS98/fMmAn00Qum7JNe9jw=
+github.com/manifestival/manifestival v0.6.1-0.20200713203452-583e95ddeeb0/go.mod h1:3Qq9cnPy7sv7FVhg2Kvw0ebb35R4OdctS4UjTjHlHm4=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=

--- a/vendor/github.com/manifestival/manifestival/CHANGELOG.md
+++ b/vendor/github.com/manifestival/manifestival/CHANGELOG.md
@@ -5,6 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- Support for generated names: if `metadata.generateName` is set and
+  `metadata.name` is *not* set on any resource in a manifest, that resource will
+  always be _created_ when the manifest is _applied_. [#65](https://github.com/manifestival/manifestival/issues/65)
+
+### Changed
+
+- Fixed the `In` predicate to not incorporate the API version in its comparison
+  of manifest resources. Only Group, Kind, Namespace, and Name are used to test
+  for equality. [#67](https://github.com/manifestival/manifestival/issues/67)
+
+### Removed
+
+
+## [0.6.0] - 2020-07-07
+
 ### Changed
 
 - Migrated from [dep](https://github.com/golang/dep) to [go
@@ -16,10 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fixed the `InjectNamespace` transformer to properly update the
   `spec.conversion` field in a `CustomResourceDefinition`
   [#55](https://github.com/manifestival/manifestival/issues/55)
-- `None` was removed and replaced with `Not`, which only accepts a single
-  predicate.
-- `Any` and `All` now require at least one predicate since it wasn't
-  clear how they should behave without one.
+- Predicate changes: `None` was removed and replaced with `Not`, which
+  only accepts a single predicate. `Any` and `All` now require at
+  least one predicate since it wasn't clear how they should behave
+  without one. [#56](https://github.com/manifestival/manifestival/pull/56)
+- Fixed bug where manifestival wasn't deleting namespaces it created.
+  (It should never delete a namespace it didn't create)
+  [#61](https://github.com/manifestival/manifestival/issues/61)
 
 ### Added
 
@@ -40,6 +60,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - New filter `Predicate`, `ByAnnotation`, that does for annotations
   what `ByLabel` did for labels!
   [#52](https://github.com/manifestival/manifestival/pull/52)
+- Defaulting the `FieldManager` for create/updates to "manifestival"
+  to help reconcile changes in `metadata.managedFields`, in
+  anticipation of server-side apply. [#64](https://github.com/manifestival/manifestival/pull/64)
 
 ### Removed
 
@@ -208,7 +231,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 [controller-runtime]: https://github.com/manifestival/controller-runtime-client
 [client-go]: https://github.com/manifestival/client-go-client
-[unreleased]: https://github.com/manifestival/manifestival/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/manifestival/manifestival/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/manifestival/manifestival/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/manifestival/manifestival/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/manifestival/manifestival/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/manifestival/manifestival/compare/v0.3.0...v0.3.1

--- a/vendor/github.com/manifestival/manifestival/README.md
+++ b/vendor/github.com/manifestival/manifestival/README.md
@@ -221,11 +221,11 @@ override in your unit tests. For example,
 ```go
 func verifySomething(t *testing.T, expected *unstructured.Unstructured) {
     client := fake.Client{
-        Stubs{
+        fake.Stubs{
             Create: func(u *unstructured.Unstructured) error {
                 if !reflect.DeepEqual(u, expected) {
-    				t.Error("You did it wrong!")
-    			}
+                    t.Error("You did it wrong!")
+                }
                 return nil
             },
         },

--- a/vendor/github.com/manifestival/manifestival/client.go
+++ b/vendor/github.com/manifestival/manifestival/client.go
@@ -5,6 +5,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const (
+	defaultManager = FieldManager("manifestival")
+)
+
 // Client includes the operations required by the Manifestival interface
 type Client interface {
 	Create(obj *unstructured.Unstructured, options ...ApplyOption) error
@@ -19,6 +23,7 @@ func ApplyWith(options []ApplyOption) *ApplyOptions {
 		ForUpdate: &metav1.UpdateOptions{},
 		Overwrite: true,
 	}
+	defaultManager.ApplyWith(result)
 	for _, f := range options {
 		f.ApplyWith(result)
 	}

--- a/vendor/github.com/manifestival/manifestival/filter.go
+++ b/vendor/github.com/manifestival/manifestival/filter.go
@@ -131,10 +131,10 @@ func ByGVK(gvk schema.GroupVersionKind) Predicate {
 }
 
 // In(m) returns a Predicate that tests for membership in m, using
-// "gvk|namespace/name" as a unique identifier
+// "gk|ns/name" as a unique identifier
 func In(manifest Manifest) Predicate {
 	key := func(u *unstructured.Unstructured) string {
-		return fmt.Sprintf("%s|%s/%s", u.GroupVersionKind(), u.GetNamespace(), u.GetName())
+		return fmt.Sprintf("%s|%s/%s", u.GroupVersionKind().GroupKind(), u.GetNamespace(), u.GetName())
 	}
 	index := sets.NewString()
 	for _, u := range manifest.resources {

--- a/vendor/github.com/manifestival/manifestival/go.sum
+++ b/vendor/github.com/manifestival/manifestival/go.sum
@@ -13,7 +13,6 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550 h1:mV9jbLoSW/8m4VK16ZkHTozJa8sesK5u5kTMFysTYac=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch/v5 v5.0.0 h1:dKTrUeykyQwKb/kx7Z+4ukDs6l+4L41HqG1XHnhX7WE=
 github.com/evanphx/json-patch/v5 v5.0.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/vendor/github.com/manifestival/manifestival/manifestival.go
+++ b/vendor/github.com/manifestival/manifestival/manifestival.go
@@ -131,9 +131,9 @@ func (m Manifest) apply(spec *unstructured.Unstructured, opts ...ApplyOption) er
 	}
 	if current == nil {
 		m.logResource("Creating", spec)
+		annotate(spec, "manifestival", resourceCreated)
 		current = spec.DeepCopy()
 		annotate(current, v1.LastAppliedConfigAnnotation, lastApplied(current))
-		annotate(current, "manifestival", resourceCreated)
 		return m.Client.Create(current, opts...)
 	} else {
 		diff, err := patch.New(current, spec)
@@ -177,6 +177,10 @@ func (m Manifest) delete(spec *unstructured.Unstructured, opts ...DeleteOption) 
 // get collects a full resource body (or `nil`) from a partial
 // resource supplied in `spec`
 func (m Manifest) get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if spec.GetName() == "" && spec.GetGenerateName() != "" {
+		// expected to be created; never fetched
+		return nil, nil
+	}
 	result, err := m.Client.Get(spec)
 	if err != nil {
 		result = nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,7 +152,7 @@ github.com/mailru/easyjson/jwriter
 ## explicit
 github.com/manifestival/client-go-client
 github.com/manifestival/client-go-client/pkg/dynamic
-# github.com/manifestival/manifestival v0.5.1-0.20200702141132-93669fa9179b
+# github.com/manifestival/manifestival v0.6.1-0.20200713203452-583e95ddeeb0
 ## explicit
 github.com/manifestival/manifestival
 github.com/manifestival/manifestival/fake


### PR DESCRIPTION
Fixes #184, fixes #189

It also adds support for generated names -- they will always be
created when the manifest is applied.
