### PR TITLE
Backport fix for infinite reconcile loop

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -135,6 +135,9 @@ spec:
           type: object
         status:
           properties:
+            observedGeneration:
+              description: The generation last processed by the controller
+              type: integer
             conditions:
               description: The latest available observations of a resource's current
                 state.

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -172,6 +172,9 @@ spec:
         status:
           description: Status defines the observed state of KnativeServing
           properties:
+            observedGeneration:
+              description: The generation last processed by the controller
+              type: integer
             conditions:
               description: The latest available observations of a resource's current
                 state.


### PR DESCRIPTION
Cherry-picking fixes from #203 to prevent a never-ending reconcile loop.