### PR TITLE
Add spec version into operator CRD's 

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -59,6 +59,9 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeEventing
           properties:
+            version:
+              description: The version of Knative Eventing to be installed
+              type: string
             config:
               additionalProperties:
                 additionalProperties:

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -59,6 +59,9 @@ spec:
         spec:
           description: Spec defines the desired state of KnativeServing
           properties:
+            version:
+              description: The version of Knative Serving to be installed
+              type: string
             config:
               additionalProperties:
                 additionalProperties:


### PR DESCRIPTION
One version of operator bundles multiple available knative released versions.  Users can pick up one available version of knative to install.

## Proposed Changes

* This PRs added the filed `spec.version` into the operator CRD's, giving users the option to specify the official release to install with operator.  
