### PR TITLE
Set the branch to 0.16 for knative in test case

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -26,7 +26,7 @@ readonly PREVIOUS_SERVING_RELEASE_VERSION="0.15.2"
 # different from PREVIOUS_OPERATOR_RELEASE_VERSION.
 readonly PREVIOUS_EVENTING_RELEASE_VERSION="0.15.3"
 # This is the branch name of serving and eventing repo, where we run the upgrade tests.
-readonly KNATIVE_REPO_BRANCH=${PULL_BASE_REF}
+readonly KNATIVE_REPO_BRANCH="release-0.16"
 # Istio version we test with
 readonly ISTIO_VERSION="1.5-latest"
 # Test without Istio mesh enabled


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* This PR pins the knative repo to release-0.16 in upgrade test cases, because operator has not catch up all the latest changes, leading to upgrade tests failure.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
