### PR TITLE
Add the postdowngrade tests, making sure the downgrade is complete

### DIFF
--- a/test/downgrade/knative_postdowngrade_test.go
+++ b/test/downgrade/knative_postdowngrade_test.go
@@ -1,0 +1,127 @@
+// +build postdowngrade
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	mf "github.com/manifestival/manifestival"
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+
+	"knative.dev/operator/pkg/reconciler/common"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+	"knative.dev/operator/test"
+	"knative.dev/operator/test/client"
+	"knative.dev/operator/test/resources"
+)
+
+// TestKnativeEventingPostDowngrade verifies the KnativeEventing creation, after downgraded to the previous version.
+func TestKnativeEventingPostDowngrade(t *testing.T) {
+	clients := client.Setup(t)
+
+	names := test.ResourceNames{
+		KnativeEventing: test.OperatorName,
+		Namespace:       test.EventingOperatorNamespace,
+	}
+
+	// Create a KnativeEventing
+	if _, err := resources.EnsureKnativeEventingExists(clients.KnativeEventing(), names); err != nil {
+		t.Fatalf("KnativeService %q failed to create: %v", names.KnativeEventing, err)
+	}
+
+	// Verify if resources match the requirement for the previous release after downgrade
+	t.Run("verify resources", func(t *testing.T) {
+		resources.AssertKEOperatorCRReadyStatus(t, clients, names)
+		resources.SetKodataDir()
+		defer os.Unsetenv(common.KoEnvKey)
+
+		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeEventing{})
+		if err != nil {
+			t.Fatalf("Failed to get the manifest for Knative: %v", err)
+		}
+
+		instance := &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: test.OperatorFlags.PreviousEventingVersion,
+				},
+			},
+		}
+
+		// Based on the previous release version, get the deployment resources.
+		preManifest, err := common.TargetManifest(instance)
+		if err != nil {
+			t.Fatalf("Failed to get KnativeEventing manifest: %v", err)
+		}
+		expectedDeployments := resources.GetExpectedDeployments(preManifest)
+		util.AssertEqual(t, len(expectedDeployments) > 0, true)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, test.OperatorFlags.PreviousEventingVersion,
+			expectedDeployments)
+		resources.AssertKnativeObsoleteResource(t, clients, names.Namespace,
+			targetManifest.Filter(mf.Not(mf.In(preManifest))).Resources())
+	})
+}
+
+// TestKnativeServingPostDowngrade verifies the KnativeServing creation, after downgraded to the previous version.
+func TestKnativeServingPostDowngrade(t *testing.T) {
+	clients := client.Setup(t)
+
+	names := test.ResourceNames{
+		KnativeServing: test.OperatorName,
+		Namespace:      test.ServingOperatorNamespace,
+	}
+
+	// Create a KnativeServing
+	if _, err := resources.EnsureKnativeServingExists(clients.KnativeServing(), names); err != nil {
+		t.Fatalf("KnativeService %q failed to create: %v", names.KnativeServing, err)
+	}
+
+	// Verify if resources match the requirement for the previous release after downgrade
+	t.Run("verify resources", func(t *testing.T) {
+		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
+		resources.SetKodataDir()
+		defer os.Unsetenv(common.KoEnvKey)
+
+		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeServing{})
+		if err != nil {
+			t.Fatalf("Failed to get the manifest for Knative: %v", err)
+		}
+
+		instance := &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: test.OperatorFlags.PreviousServingVersion,
+				},
+			},
+		}
+
+		// Based on the previous release version, get the deployment resources.
+		preManifest, err := common.TargetManifest(instance)
+		if err != nil {
+			t.Fatalf("Failed to get KnativeServing manifest: %v", err)
+		}
+		expectedDeployments := resources.GetExpectedDeployments(preManifest)
+		util.AssertEqual(t, len(expectedDeployments) > 0, true)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, test.OperatorFlags.PreviousServingVersion,
+			expectedDeployments)
+		resources.AssertKnativeObsoleteResource(t, clients, names.Namespace,
+			targetManifest.Filter(mf.Not(mf.In(preManifest))).Resources())
+	})
+}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -17,13 +17,9 @@
 # This script provides helper methods to perform cluster actions.
 source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/e2e-tests.sh
 
-# The previous operator release.
-readonly PREVIOUS_OPERATOR_RELEASE_VERSION="0.15.3"
-# The previous serving release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
-# different from PREVIOUS_OPERATOR_RELEASE_VERSION.
+# The previous serving release, installed by the operator.
 readonly PREVIOUS_SERVING_RELEASE_VERSION="0.15.2"
-# The previous eventing release, installed by the operator at PREVIOUS_OPERATOR_RELEASE_VERSION. This can be
-# different from PREVIOUS_OPERATOR_RELEASE_VERSION.
+# The previous eventing release, installed by the operator.
 readonly PREVIOUS_EVENTING_RELEASE_VERSION="0.15.3"
 # This is the branch name of serving and eventing repo, where we run the upgrade tests.
 readonly KNATIVE_REPO_BRANCH="release-0.16"

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -235,6 +235,11 @@ install_previous_operator_release
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
+header "Running postdowngrade tests for Knative Operator"
+cd ${OPERATOR_DIR}
+go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/downgrade \
+  --preservingversion="${PREVIOUS_SERVING_RELEASE_VERSION}" --preeventingversion="${PREVIOUS_EVENTING_RELEASE_VERSION}" || failed=1
+
 header "Running postdowngrade tests for Knative Serving"
 cd ${KNATIVE_DIR}/serving
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -41,23 +41,58 @@ readonly EVENTING_PROBER_FILE="/tmp/prober-signal-eventing"
 # TODO: remove when components can coexist in same namespace
 export TEST_EVENTING_NAMESPACE=knative-eventing
 
-function download_install_previous_operator_release() {
-  local full_url="https://github.com/knative/operator/releases/download/v${PREVIOUS_OPERATOR_RELEASE_VERSION}/operator.yaml"
-
-  wget "${full_url}" -O "${release_yaml}" \
-      || fail_test "Unable to download latest Knative Operator release."
-
-  install_istio || fail_test "Istio installation failed"
-  install_previous_operator_release
-}
-
 function install_previous_operator_release() {
-  header "Installing Knative operator of the previous public release"
-  kubectl apply -f "${release_yaml}" || fail_test "Knative Operator previous release installation failed"
-  wait_until_pods_running default || fail_test "Operator did not come up"
+  install_istio || fail_test "Istio installation failed"
+  install_operator
+  install_previous_knative
 }
 
-function create_custom_resource() {
+function install_previous_knative() {
+  header "Create the custom resources for Knative of the previous version"
+  create_knative_serving ${PREVIOUS_SERVING_RELEASE_VERSION}
+  create_knative_eventing ${PREVIOUS_EVENTING_RELEASE_VERSION}
+  wait_until_pods_running ${TEST_NAMESPACE}
+  wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
+}
+
+function create_knative_serving() {
+  version=${1}
+  echo ">> Creating the custom resource of Knative Serving:"
+  cat <<EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${TEST_NAMESPACE}
+spec:
+  version: ${version}
+  config:
+    defaults:
+      revision-timeout-seconds: "300"  # 5 minutes
+    autoscaler:
+      stable-window: "60s"
+    deployment:
+      registriesSkippingTagResolving: "ko.local,dev.local"
+    logging:
+      loglevel.controller: "debug"
+EOF
+}
+
+function create_knative_eventing() {
+  version=${1}
+  echo ">> Creating the custom resource of Knative Eventing:"
+  cat <<-EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: ${TEST_EVENTING_NAMESPACE}
+spec:
+  version: ${version}
+EOF
+}
+
+function create_latest_custom_resource() {
   echo ">> Creating the custom resource of Knative Serving:"
   cat <<EOF | kubectl apply -f -
 apiVersion: operator.knative.dev/v1alpha1
@@ -88,12 +123,9 @@ EOF
 
 function knative_setup() {
   create_namespace
-  download_install_previous_operator_release
+  install_previous_operator_release
   donwload_knative "serving" ${KNATIVE_REPO_BRANCH}
   donwload_knative "eventing" ${KNATIVE_REPO_BRANCH}
-  create_custom_resource
-  wait_until_pods_running ${TEST_NAMESPACE}
-  wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 }
 
 # Create test resources and images
@@ -207,7 +239,7 @@ go_test_e2e -tags=probe -timeout="${TIMEOUT}" ./test/upgrade --pipefile="${EVENT
 PROBER_PID_EVENTING=$!
 echo "Prober PID Serving is ${PROBER_PID_EVENTING}"
 
-install_operator
+create_latest_custom_resource
 
 # If we got this far, the operator installed Knative of the latest source code.
 header "Running tests for Knative Operator"
@@ -231,7 +263,7 @@ header "Running postupgrade tests for Knative Eventing"
 cd ${KNATIVE_DIR}/eventing
 go_test_e2e -tags=postupgrade -timeout="${TIMEOUT}" ./test/upgrade || fail_test
 
-install_previous_operator_release
+install_previous_knative
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -257,8 +257,8 @@ func AssertKnativeObsoleteResource(t *testing.T, clients *test.Clients, namespac
 }
 
 // AssertKnativeDeploymentStatus verifies if the Knative deployments reach the READY status.
-func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, expectedDeployments []string) {
-	if err := WaitForKnativeDeploymentState(clients, namespace, expectedDeployments, t.Logf,
+func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, version string, expectedDeployments []string) {
+	if err := WaitForKnativeDeploymentState(clients, namespace, version, expectedDeployments, t.Logf,
 		IsKnativeDeploymentReady); err != nil {
 		t.Fatalf("Knative Serving deployments failed to meet the expected deployments: %v", err)
 	}

--- a/test/upgrade/knativeeventing_postupgrade_test.go
+++ b/test/upgrade/knativeeventing_postupgrade_test.go
@@ -53,13 +53,15 @@ func TestKnativeEventingUpgrade(t *testing.T) {
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the latest release version, get the deployment resources.
-		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeEventing{})
+		ke := &v1alpha1.KnativeEventing{}
+		targetManifest, err := common.TargetManifest(ke)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ke),
+			expectedDeployments)
 
 		instance := &v1alpha1.KnativeEventing{
 			Spec: v1alpha1.KnativeEventingSpec{

--- a/test/upgrade/knativeeventing_preupgrade_test.go
+++ b/test/upgrade/knativeeventing_preupgrade_test.go
@@ -53,7 +53,6 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 			t.Fatalf("Failed to get KnativeEventing CR: %v", err)
 		}
 		resources.SetKodataDir()
-		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the status.version, get the deployment resources.
 		defer os.Unsetenv(common.KoEnvKey)
 		manifest, err := common.InstalledManifest(keventing)
@@ -62,6 +61,7 @@ func TestKnativeEventingPreUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, keventing.GetStatus().GetVersion(),
+			expectedDeployments)
 	})
 }

--- a/test/upgrade/servingoperator_postupgrade_test.go
+++ b/test/upgrade/servingoperator_postupgrade_test.go
@@ -52,13 +52,15 @@ func TestKnativeServingPostUpgrade(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		targetManifest, err := common.TargetManifest(&v1alpha1.KnativeServing{})
+		ks := &v1alpha1.KnativeServing{}
+		targetManifest, err := common.TargetManifest(ks)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, expectedDeployments)
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ks),
+			expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
 
 		instance := &v1alpha1.KnativeServing{


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* This PR improves the test cases by adding and running postdowngrade tests, after downgrading to the previous operator version.
* Upgrade and downgrade can by done by leveraging spec.version set to different values.


