### PR TITLE
WIP: Set status.version once all expected deployments are ready

### DIFF
--- a/pkg/reconciler/common/deployments.go
+++ b/pkg/reconciler/common/deployments.go
@@ -50,6 +50,7 @@ func CheckDeployments(ctx context.Context, manifest *mf.Manifest, instance v1alp
 		}
 	}
 	status.MarkDeploymentsAvailable()
+	status.SetVersion(TargetVersion(instance))
 	return nil
 }
 

--- a/pkg/reconciler/common/deployments_test.go
+++ b/pkg/reconciler/common/deployments_test.go
@@ -105,7 +105,13 @@ func TestCheckDeployments(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to generate manifest: %v", err)
 			}
-			ks := &v1alpha1.KnativeServing{}
+			ks := &v1alpha1.KnativeServing{
+				Spec: v1alpha1.KnativeServingSpec{
+					CommonSpec: v1alpha1.CommonSpec{
+						Version: "0.16.0",
+					},
+				},
+			}
 			ks.Status.InitializeConditions()
 
 			err = CheckDeployments(context.TODO(), &manifest, ks)
@@ -117,6 +123,7 @@ func TestCheckDeployments(t *testing.T) {
 			if condition == nil || condition.Status != test.wantStatus {
 				t.Fatalf("DeploymentAvailable = %v, want %v", condition, test.wantStatus)
 			}
+
 		})
 	}
 }

--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -52,7 +52,6 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComp
 		return fmt.Errorf("failed to apply non rbac manifest: %w", err)
 	}
 	status.MarkInstallSucceeded()
-	status.SetVersion(TargetVersion(instance))
 	return nil
 }
 

--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -70,10 +70,6 @@ func TestInstall(t *testing.T) {
 	if condition == nil || condition.Status != corev1.ConditionTrue {
 		t.Fatalf("InstallSucceeded = %v, want %v", condition, corev1.ConditionTrue)
 	}
-
-	if got, want := instance.GetStatus().GetVersion(), version; got != want {
-		t.Fatalf("GetVersion() = %s, want %s", got, want)
-	}
 }
 
 func TestInstallError(t *testing.T) {
@@ -105,10 +101,6 @@ func TestInstallError(t *testing.T) {
 	condition := instance.Status.GetCondition(v1alpha1.InstallSucceeded)
 	if condition == nil || condition.Status != corev1.ConditionFalse {
 		t.Fatalf("InstallSucceeded = %v, want %v", condition, corev1.ConditionFalse)
-	}
-
-	if got, want := instance.GetStatus().GetVersion(), oldVersion; got != want {
-		t.Fatalf("GetVersion() = %s, want %s", got, want)
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* This PR fixed the unstable downgrade in prow.
* We need to relocate the line setting the status.version. It should be moved behind we make sure deployments are available. If not, then any error in `CheckDeployments` function will break the `DeleteObsoleteResources`, since any error before will lead to no call of `DeleteObsoleteResources`, but status.version is changed. In that situation, we will never get manifests compared(The status.version has been set to the new version in the previous reconciling loop. The old version is set to target version. They are always equal.), and never remove the diffs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
