### PR TITLE
sinkBindingSelectionMode in CR spec

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -146,6 +146,14 @@ spec:
                       ephemeral-storage:
                         type: string
                         pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+            sinkBindingSelectionMode:
+              description: Specifies the NamespaceSelector and ObjectSelector for the sinkbinding webhook.
+                If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+                will be considered by the sinkbinding webhook;
+                If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+                will NOT be considered by the sinkbinding webhook.
+                The default is `exclusion`.
+              type: string
           type: object
         status:
           properties:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,6 +39,7 @@ These are the configurable fields in each resource:
       - [imagePullSecrets](#specregistryimagepullsecrets)
     - [resources](#specresources)
     - [defaultBrokerClass](#specdefaultbrokerclass)
+    - [sinkBindingSelectionMode](#specsinkbindingselectionmode)
 
 ## spec.config
 
@@ -297,4 +298,23 @@ metadata:
   namespace: knative-eventing
 spec:
   defaultBrokerClass: MTChannelBasedBroker
+```
+
+## spec.sinkBindingSelectionMode
+
+Specifies the NamespaceSelector and ObjectSelector for the sinkbinding webhook.
+If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+will be considered by the sinkbinding webhook;
+If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+will NOT be considered by the sinkbinding webhook.
+The default is `exclusion`.
+
+```
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  sinkBindingSelectionMode: exclusion
 ```

--- a/pkg/apis/operator/v1alpha1/knativeeventing_types.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_types.go
@@ -56,6 +56,16 @@ type KnativeEventingSpec struct {
 	// If no value is provided, MTChannelBasedBroker will be used.
 	// +optional
 	DefaultBrokerClass string `json:"defaultBrokerClass,omitempty"`
+
+	// SinkBindingSelectionMode specifies the NamespaceSelector and ObjectSelector
+	// for the sinkbinding webhook.
+	// If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+	// will be considered by the sinkbinding webhook;
+	// If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+	// will NOT be considered by the sinkbinding webhook.
+	// The default is `exclusion`.
+	// +optional
+	SinkBindingSelectionMode string `json:"sinkBindingSelectionMode,omitempty"`
 }
 
 // KnativeEventingStatus defines the observed state of KnativeEventing

--- a/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode.go
+++ b/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
+)
+
+// SinkBindingSelectionModeTransform updates the eventing-webhook's SINK_BINDING_SELECTION_MODE env var with the value in the spec
+func SinkBindingSelectionModeTransform(instance *eventingv1alpha1.KnativeEventing, log *zap.SugaredLogger) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "Deployment" && u.GetName() == "eventing-webhook" {
+			var deployment = &appsv1.Deployment{}
+			err := scheme.Scheme.Convert(u, deployment, nil)
+			if err != nil {
+				log.Error(err, "Error converting Unstructured to Deployment", "unstructured", u, "deployment", deployment)
+				return err
+			}
+
+			sinkBindingSelectionMode := instance.Spec.SinkBindingSelectionMode
+			if sinkBindingSelectionMode == "" {
+				sinkBindingSelectionMode = "exclusion"
+			}
+
+			for i, _ := range deployment.Spec.Template.Spec.Containers {
+				found := false
+				c := &deployment.Spec.Template.Spec.Containers[i]
+				for j, _ := range c.Env {
+					envVar := &c.Env[j]
+					if envVar.Name == "SINK_BINDING_SELECTION_MODE" {
+						envVar.Value = sinkBindingSelectionMode
+						found = true
+						break
+					}
+				}
+				if !found {
+					c.Env = append(c.Env, corev1.EnvVar{Name: "SINK_BINDING_SELECTION_MODE", Value: sinkBindingSelectionMode})
+				}
+			}
+
+			err = scheme.Scheme.Convert(deployment, u, nil)
+			if err != nil {
+				return err
+			}
+			// The zero-value timestamp defaulted by the conversion causes
+			// superfluous updates
+			u.SetCreationTimestamp(metav1.Time{})
+			log.Debugw("Finished updating eventing-webhook deployment for sinkBindingSelectionMode", "name", u.GetName(), "unstructured", u.Object)
+		}
+		return nil
+	}
+}

--- a/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode_test.go
+++ b/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestSinkBindingSelectionModeTransform(t *testing.T) {
+	tests := []struct {
+		name                     string
+		deployment               appsv1.Deployment
+		sinkBindingSelectionMode string
+		expected                 appsv1.Deployment
+	}{{
+		name: "UsesDefaultWhenNotSpecified",
+		deployment: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "toBeOverridden",
+			}},
+		}}),
+		sinkBindingSelectionMode: "",
+		expected: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "exclusion",
+			}},
+		}}),
+	}, {
+		name: "UsesTheSpecifiedValueWhenSpecified",
+		deployment: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "toBeOverridden",
+			}},
+		}}),
+		sinkBindingSelectionMode: "inclusion",
+		expected: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "inclusion",
+			}},
+		}}),
+	}, {
+		name: "DoesNotTouchOtherDeployments",
+		deployment: makeDeployment("some-other-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "notToBeOverridden",
+			}},
+		}}),
+		sinkBindingSelectionMode: "inclusion",
+		expected: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "notToBeOverridden",
+			}},
+		}}),
+	}, {
+		name: "CreatesTheEnvVarIfMissing",
+		deployment: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env:  []corev1.EnvVar{},
+		}}),
+		sinkBindingSelectionMode: "inclusion",
+		expected: makeDeployment("eventing-webhook", []corev1.Container{{
+			Name: "foo",
+			Env: []corev1.EnvVar{{
+				Name:  "SINK_BINDING_SELECTION_MODE",
+				Value: "inclusion",
+			}},
+		}}),
+	}, {
+		name: "UpdatesAllContainers",
+		deployment: makeDeployment("eventing-webhook", []corev1.Container{
+			{
+				Name: "container1",
+				Env:  []corev1.EnvVar{},
+			}, {
+				Name: "container2",
+				Env:  []corev1.EnvVar{},
+			},
+		}),
+		sinkBindingSelectionMode: "inclusion",
+		expected: makeDeployment("eventing-webhook", []corev1.Container{
+			{
+				Name: "container1",
+				Env: []corev1.EnvVar{{
+					Name:  "SINK_BINDING_SELECTION_MODE",
+					Value: "inclusion",
+				}},
+			}, {
+				Name: "container2",
+				Env: []corev1.EnvVar{{
+					Name:  "SINK_BINDING_SELECTION_MODE",
+					Value: "inclusion",
+				}},
+			},
+		}),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unstructuredDeployment := util.MakeUnstructured(t, &tt.deployment)
+			instance := &v1alpha1.KnativeEventing{
+				Spec: v1alpha1.KnativeEventingSpec{
+					SinkBindingSelectionMode: tt.sinkBindingSelectionMode,
+				},
+			}
+			transform := SinkBindingSelectionModeTransform(instance, log)
+			transform(&unstructuredDeployment)
+
+			var deployment = &appsv1.Deployment{}
+			err := scheme.Scheme.Convert(&unstructuredDeployment, deployment, nil)
+			util.AssertEqual(t, err, nil)
+			util.AssertDeepEqual(t, deployment.Spec, tt.expected.Spec)
+		})
+	}
+}
+
+func makeDeployment(name string, containers []corev1.Container) appsv1.Deployment {
+	return appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: containers,
+				},
+			},
+		},
+	}
+}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -118,7 +118,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp v1alpha1.KComponent) error {
 	logger := logging.FromContext(ctx)
 	instance := comp.(*v1alpha1.KnativeEventing)
-	extra := []mf.Transformer{kec.DefaultBrokerConfigMapTransform(instance, logger)}
+	extra := []mf.Transformer{
+		kec.DefaultBrokerConfigMapTransform(instance, logger),
+		kec.SinkBindingSelectionModeTransform(instance, logger),
+	}
 	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #231

## Proposed Changes

* New CR spec field: `sinkBindingSelectionMode`
* Instead of coming up with a generic way of overriding env vars using some maps, came up with a proper strongly-typed spec field

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
KnativeEventing CR now supports setting the `sinkBindingSelectionMode`
```

Try with this:
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeEventing
metadata:
  name: knative-eventing
  namespace: knative-eventing
spec:
  sinkBindingSelectionMode: "inclusion"
```