### PR TITLE
Add 0.17.3 eventing and 0.17.2 serving manifests

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.17.3/1-eventing-crds.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/1-eventing-crds.yaml
@@ -1,0 +1,2303 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    # TODO add schemas and descriptions
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.apiserver.resource.add" },
+        { "type": "dev.knative.apiserver.resource.delete" },
+        { "type": "dev.knative.apiserver.resource.update" },
+        { "type": "dev.knative.apiserver.ref.add" },
+        { "type": "dev.knative.apiserver.ref.delete" },
+        { "type": "dev.knative.apiserver.ref.update" }
+      ]
+  name: apiserversources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'ApiServerSource is an event source that brings Kubernetes API
+          server events into Knative.'
+        properties:
+          spec:
+            type: object
+            description: 'ApiServerSourceSpec defines the desired state of ApiServerSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              mode:
+                description: 'Mode is the mode the receive adapter controller runs
+                  under: Ref or Resource. `Ref` sends only the reference to the resource.
+                  `Resource` send the full resource.'
+                type: string
+              owner:
+                description: 'ResourceOwner is an additional filter to only track
+                  resources that are owned by a specific resource type. If ResourceOwner
+                  matches Resources[n] then Resources[n] is allowed to pass the ResourceOwner
+                  filter.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'APIVersion - the API version of the resource to
+                      watch.'
+                    type: string
+                  kind:
+                    description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+              resources:
+                description: 'Resources is the list of resources to watch'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'API version of the resource to watch.'
+                      type: string
+                    controller:
+                      description: 'If true, send an event referencing the object
+                        controlling the resource Deprecated: Per-resource controller
+                        flag will no longer be supported in v1alpha2, please use Spec.Owner
+                        as a GKV.'
+                      type: boolean
+                    controllerSelector:
+                      description: 'ControllerSelector restricts this source to objects
+                        with a controlling owner reference of the specified kind.
+                        Only apiVersion and kind are used. Both are optional. Deprecated:
+                        Per-resource owner refs will no longer be supported in v1alpha2,
+                        please use Spec.Owner as a GKV.'
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: 'API version of the referent.'
+                          type: string
+                        blockOwnerDeletion:
+                          description: 'If true, AND if the owner has the "foregroundDeletion"
+                            finalizer, then the owner cannot be deleted from the key-value
+                            store until this reference is removed. Defaults to false.
+                            To set this field, a user needs "delete" permission of
+                            the owner, otherwise 422 (Unprocessable Entity) will be
+                            returned.'
+                          type: boolean
+                        controller:
+                          description: 'If true, this reference points to the managing
+                            controller.'
+                          type: boolean
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                    kind:
+                      description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    labelSelector:
+                      description: 'LabelSelector restricts this source to objects
+                        with the selected labels More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: 'matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.'
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                description: 'key is the label key that the selector
+                                  applies to.'
+                                type: string
+                              operator:
+                                description: 'operator represents a key''s relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.'
+                                type: string
+                              values:
+                                description: 'values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.'
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: 'matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this source.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a domain name to use as the sink.'
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'ApiServerSourceStatus defines the observed state of ApiServerSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1alpha2
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'ApiServerSource is an event source that brings Kubernetes API
+          server events into Knative.'
+        properties:
+          spec:
+            type: object
+            description: 'ApiServerSourceSpec defines the desired state of ApiServerSource
+              (from the client).'
+            required:
+            - resources
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              mode:
+                description: 'EventMode controls the format of the event. `Reference`
+                  sends a dataref event type for the resource under watch. `Resource`
+                  send the full resource lifecycle event. Defaults to `Reference`'
+                type: string
+              owner:
+                description: 'ResourceOwner is an additional filter to only track
+                  resources that are owned by a specific resource type. If ResourceOwner
+                  matches Resources[n] then Resources[n] is allowed to pass the ResourceOwner
+                  filter.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'APIVersion - the API version of the resource to
+                      watch.'
+                    type: string
+                  kind:
+                    description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+              resources:
+                description: 'Resource are the resources this source will track and
+                  send related lifecycle events from the Kubernetes ApiServer, with
+                  an optional label selector to help filter.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion - the API version of the resource to
+                        watch.'
+                      type: string
+                    kind:
+                      description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    selector:
+                      description: 'LabelSelector filters this source to objects to
+                        those resources pass the label selector. More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: 'matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.'
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                description: 'key is the label key that the selector
+                                  applies to.'
+                                type: string
+                              operator:
+                                description: 'operator represents a key''s relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.'
+                                type: string
+                              values:
+                                description: 'values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.'
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: 'matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this source. Defaults to default if not set.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'ApiServerSourceStatus defines the observed state of ApiServerSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    # the schema of v1beta1 is exactly the same as v1alpha2 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: ApiServerSource
+    plural: apiserversources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokers.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'Broker collects a pool of events that are consumable using Triggers.
+          Brokers provide a well-known endpoint for event delivery that senders can
+          use with minimal knowledge of the event routing strategy. Subscribers use
+          Triggers to request delivery of events from a Broker''s pool to a specific
+          URL or Addressable endpoint.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the Broker.'
+            type: object
+            properties:
+              config:
+                description: 'Config is a KReference to the configuration that specifies
+                  configuration options for this Broker. For example, this could be
+                  a pointer to a ConfigMap.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      This is optional field, it gets defaulted to the object holding
+                      it if left out.'
+                    type: string
+              delivery:
+                description: 'Delivery is the delivery specification for Events within
+                  the Broker mesh. This includes things like retries, DLQ, etc.'
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                      information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                      - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                      backoff delay is the time interval between retries. For exponential
+                      policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: ' BackoffPolicy is the retry backoff policy (linear,
+                      exponential).'
+                    type: string
+                  deadLetterSink:
+                    description: 'DeadLetterSink is the sink receiving event that
+                      could not be sent to a destination.'
+                    type: object
+                    properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted to the object
+                              holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty scheme
+                          and non-empty host) pointing to the target or a relative
+                          URI. Relative URIs will be resolved using the base URI retrieved
+                          from Ref.'
+                        type: string
+                  retry:
+                    description: 'Retry is the minimum number of retries the sender
+                      should attempt when sending an event before moving it to the
+                      dead letter sink.'
+                    type: integer
+                    format: int32
+          status:
+            description: 'Status represents the current state of the Broker. This
+              data may be out of date.'
+            type: object
+            properties:
+              address:
+                description: 'Broker is Addressable. It exposes the endpoint as an
+                  URI to get events delivered into the Broker mesh.'
+                type: object
+                properties:
+                  url:
+                    type: string
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    # the schema of v1 is exactly the same as v1beta1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: Broker
+    plural: brokers
+    singular: broker
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: channels.messaging.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Channel
+    plural: channels
+    singular: channel
+    categories:
+    - all
+    - knative
+    - messaging
+    - channel
+    shortNames:
+    - ch
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  name: containersources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: ContainerSource
+    plural: containersources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eventtypes.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'EventType represents a type of event that can be consumed from
+          a Broker.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the EventType.'
+            type: object
+            properties:
+              broker:
+                type: string
+              description:
+                description: 'Description is an optional field used to describe the
+                  EventType, in any meaningful way.'
+                type: string
+              schema:
+                description: 'Schema is a URI, it represents the CloudEvents schemaurl
+                  extension attribute. It may be a JSON schema, a protobuf schema,
+                  etc. It is optional.'
+                type: string
+              schemaData:
+                description: 'SchemaData allows the CloudEvents schema to be stored
+                  directly in the EventType. Content is dependent on the encoding.
+                  Optional attribute. The contents are not validated or manipulated
+                  by the system.'
+                type: string
+              source:
+                description: 'Source is a URI, it represents the CloudEvents source.'
+                type: string
+              type:
+                description: 'Type represents the CloudEvents type. It is authoritative.'
+                type: string
+          status:
+            description: 'Status represents the current state of the EventType. This
+              data may be out of date.'
+            type: object
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      jsonPath: ".spec.type"
+    - name: Source
+      type: string
+      jsonPath: ".spec.source"
+    - name: Schema
+      type: string
+      jsonPath: ".spec.schema"
+    - name: Broker
+      type: string
+      jsonPath: ".spec.broker"
+    - name: Description
+      type: string
+      jsonPath: ".spec.description"
+    - # TODO remove Status https://github.com/knative/eventing/issues/2750
+      name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: true
+    # the schema of v1beta1 is exactly the same as v1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: EventType
+    plural: eventtypes
+    singular: eventtype
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: parallels.flows.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: flows.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Parallel
+    plural: parallels
+    singular: parallel
+    categories:
+    - all
+    - knative
+    - flows
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    # TODO add schemas and descriptions
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.sources.ping" }
+      ]
+  name: pingsources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'PingSource describes an event source with a fixed payload produced
+          on a specified cron schedule.'
+        properties:
+          spec:
+            type: object
+            description: 'PingSourceSpec defines the desired state of the PingSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-kubernetes-preserve-unknown-fields: true
+              jsonData:
+                description: 'JsonData is json encoded data used as the body of the
+                  event posted to the sink. Default is empty. If set, datacontenttype
+                  will also be set to "application/json".'
+                type: string
+              schedule:
+                description: 'Schedule is the cronjob schedule. Defaults to `* * *
+                  * *`.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'PingSourceStatus defines the observed state of PingSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'PingSource describes an event source with a fixed payload produced
+          on a specified cron schedule.'
+        properties:
+          spec:
+            type: object
+            description: 'PingSourceSpec defines the desired state of the PingSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-kubernetes-preserve-unknown-fields: true
+              jsonData:
+                description: 'JsonData is json encoded data used as the body of the
+                  event posted to the sink. Default is empty. If set, datacontenttype
+                  will also be set to "application/json".'
+                type: string
+              schedule:
+                description: 'Schedule is the cronjob schedule. Defaults to `* * *
+                  * *`.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              timezone:
+                description: 'Timezone modifies the actual time relative to the specified
+                  timezone. Defaults to the system time zone. More general information
+                  about time zones: https://www.iana.org/time-zones List of valid
+                  timezone values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'
+                type: string
+          status:
+            type: object
+            description: 'PingSourceStatus defines the observed state of PingSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: PingSource
+    plural: pingsources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sequences.flows.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: flows.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Sequence
+    plural: sequences
+    singular: sequence
+    categories:
+    - all
+    - knative
+    - flows
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    duck.knative.dev/binding: "true"
+    knative.dev/crd-install: "true"
+  name: sinkbindings.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1alpha2
+    served: true
+    storage: false
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'SinkBinding describes a Binding that is also a Source. The `sink`
+          (from the Source duck) is resolved to a URL and then projected into the
+          `subject` by augmenting the runtime contract of the referenced containers
+          to have a `K_SINK` environment variable holding the endpoint to which to
+          send cloud events.'
+        properties:
+          spec:
+            type: object
+            description: 'SinkBindingSpec holds the desired state of the SinkBinding
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              subject:
+                description: 'Subject references the resource(s) whose "runtime contract"
+                  should be augmented by Binding implementations.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent.'
+                    type: string
+                  name:
+                    description: 'Name of the referent. Mutually exclusive with Selector.'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent.'
+                    type: string
+                  selector:
+                    description: 'Selector of the referents. Mutually exclusive with
+                      Name.'
+                    type: object
+                    properties:
+                      matchExpressions:
+                        description: 'matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.'
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              description: 'key is the label key that the selector
+                                applies to.'
+                              type: string
+                            operator:
+                              description: 'operator represents a key''s relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.'
+                              type: string
+                            values:
+                              description: 'values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.'
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        description: 'matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.'
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            description: 'SinkBindingStatus communicates the observed state of the
+              SinkBinding (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    - bindings
+    kind: SinkBinding
+    plural: sinkbindings
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.messaging.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'Subscription routes events received on a Channel to a DNS name
+          and corresponds to the subscriptions.channels.knative.dev CRD.'
+        properties:
+          spec:
+            type: object
+            description: 'Specifies the Channel for incoming events, a Subscriber
+              target for processing those events and where to put the result of the
+              processing. Only From (where the events are coming from) is always required.
+              You can optionally only Process the events (results in no output events)
+              by leaving out the Result. You can also perform an identity transformation
+              on the incoming events by leaving out the Subscriber and only specifying
+              Result.
+
+              The following are all valid specifications: channel --[subscriber]-->
+              reply Sink, no outgoing events: channel -- subscriber no-op function
+              (identity transformation): channel --> reply'
+            properties:
+              channel:
+                description: 'Reference to a channel that will be used to create the
+                  subscription You can specify only the following fields of the ObjectReference:
+                  - Kind - APIVersion - Name The resource pointed by this ObjectReference
+                  must meet the contract to the ChannelableSpec duck type. If the
+                  resource does not meet this contract it will be reflected in the
+                  Subscription''s status.  This field is immutable. We have no good
+                  answer on what happens to the events that are currently in the channel
+                  being consumed from and what the semantics there should be. For
+                  now, you can always delete the Subscription and recreate it to point
+                  to a different channel, giving the user more control over what semantics
+                  should be used (drain the channel first, possibly have events dropped,
+                  etc.)'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              delivery:
+                description: 'Delivery configuration'
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                      information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                      - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                      backoff delay is the time interval between retries. For exponential
+                      policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: 'BackoffPolicy is the retry backoff policy (linear,
+                      exponential).'
+                    type: string
+                  deadLetterSink:
+                    description: 'DeadLetterSink is the sink receiving event that
+                      could not be sent to a destination.'
+                    type: object
+                    properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted to the object
+                              holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty scheme
+                          and non-empty host) pointing to the target or a relative
+                          URI. Relative URIs will be resolved using the base URI retrieved
+                          from Ref.'
+                        type: string
+                  retry:
+                    description: 'Retry is the minimum number of retries the sender
+                      should attempt when sending an event before moving it to the
+                      dead letter sink.'
+                    type: integer
+                    format: int32
+              reply:
+                description: 'Reply specifies (optionally) how to handle events returned
+                  from the Subscriber target.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              subscriber:
+                description: 'Subscriber is reference to (optional) function for processing
+                  events. Events from the Channel will be delivered here and replies
+                  are sent to a Destination as specified by the Reply.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: Status (computed) for a subscription
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              physicalSubscription:
+                description: 'PhysicalSubscription is the fully resolved values that
+                  this Subscription represents.'
+                type: object
+                properties:
+                  deadLetterSinkUri:
+                    description: 'ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.'
+                    type: string
+                  replyUri:
+                    description: 'ReplyURI is the fully resolved URI for the spec.reply.'
+                    type: string
+                  subscriberUri:
+                    description: 'SubscriberURI is the fully resolved URI for spec.subscriber.'
+                    type: string
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    # the schema of v1 is exactly the same as v1beta1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: Subscription
+    plural: subscriptions
+    singular: subscription
+    categories:
+    - all
+    - knative
+    - messaging
+    shortNames:
+    - sub
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: triggers.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Broker
+      type: string
+      jsonPath: .spec.broker
+    - name: Subscriber_URI
+      type: string
+      jsonPath: .status.subscriberUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            required:
+            - subscriber
+            type: object
+            properties:
+              broker:
+                type: string
+                description: 'Broker that this trigger receives events from. If not
+                  specified, will default to ''default''.'
+              filter:
+                type: object
+                properties:
+                  attributes:
+                    type: object
+                    description: 'Map of CloudEvents attributes used for filtering
+                      events. If not specified, will default to all events'
+                    additionalProperties:
+                      type: string
+              subscriber:
+                type: object
+                description: 'the destination that should receive events.'
+                properties:
+                  ref:
+                    type: object
+                    description: 'a reference to a Kubernetes object from which to
+                      retrieve the target URI.'
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    properties:
+                      apiVersion:
+                        type: string
+                        minLength: 1
+                      kind:
+                        type: string
+                        minLength: 1
+                      namespace:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
+                  uri:
+                    type: string
+                    description: 'the target URI or, if ref is provided, a relative
+                      URI reference that will be combined with ref to produce a target
+                      URI.'
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'Trigger represents a request to have events delivered to a subscriber
+          from a Broker''s event pool.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the Trigger.'
+            required:
+            - subscriber
+            - broker
+            type: object
+            properties:
+              broker:
+                type: string
+                description: 'Broker that this trigger receives events from.'
+              filter:
+                type: object
+                description: 'Filter is the filter to apply against all events from
+                  the Broker. Only events that pass this filter will be sent to the
+                  Subscriber. If not specified, will default to allowing all events.'
+                properties:
+                  attributes:
+                    type: object
+                    description: 'Map of CloudEvents attributes used for filtering
+                      events. If not specified, will default to all events'
+                    additionalProperties:
+                      type: string
+              subscriber:
+                type: object
+                description: 'the destination that should receive events.'
+                properties:
+                  ref:
+                    type: object
+                    description: 'a reference to a Kubernetes object from which to
+                      retrieve the target URI.'
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    properties:
+                      apiVersion:
+                        type: string
+                        minLength: 1
+                      kind:
+                        type: string
+                        minLength: 1
+                      namespace:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
+                  uri:
+                    type: string
+                    description: 'the target URI or, if ref is provided, a relative
+                      URI reference that will be combined with ref to produce a target
+                      URI.'
+          status:
+            description: 'Status represents the current state of the Trigger. This
+              data may be out of date.'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Trigger
+    plural: triggers
+    singular: trigger
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
@@ -1,0 +1,4096 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventing-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: addressable-resolver
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller-source-observer
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: source-observer
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller-sources-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-sources-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-controller-manipulator
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: channelable-manipulator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pingsource-mt-adapter
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-pingsource-mt-adapter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: pingsource-mt-adapter
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-pingsource-mt-adapter
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventing-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-webhook
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-webhook
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-webhook
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-webhook-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-webhook
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: addressable-resolver
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-webhook-podspecable-binding
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-webhook
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: podspecable-binding
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-br-default-channel
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+data:
+  channelTemplateSpec: |
+    apiVersion: messaging.knative.dev/v1beta1
+    kind: InMemoryChannel
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-br-defaults
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+data:
+  # Configuration for defaulting channels that do not specify CRD implementations.
+  default-br-config: |
+    clusterDefault:
+      brokerClass: MTChannelBasedBroker
+      apiVersion: v1
+      kind: ConfigMap
+      name: config-br-default-channel
+      namespace: knative-eventing
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-ch-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+data:
+  # Configuration for defaulting channels that do not specify CRD implementations.
+  default-ch-config: |
+    clusterDefault:
+      apiVersion: messaging.knative.dev/v1beta1
+      kind: InMemoryChannel
+    namespaceDefaults:
+      some-namespace:
+        apiVersion: messaging.knative.dev/v1beta1
+        kind: InMemoryChannel
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+  annotations:
+    knative.dev/example-checksum: "6cf53e10"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+data:
+  # Common configuration for all Knative codebase
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  # For all components changes are be picked up immediately.
+  loglevel.controller: "info"
+  loglevel.webhook: "info"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+  annotations:
+    knative.dev/example-checksum: "f46cf09d"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. If non-empty, it enables queue proxy to send request metrics.
+    # Currently supported values: prometheus, stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_broker", "knative_trigger", and "knative_source" resource types.
+    # Setting this flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Eventing pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+
+    # sink-event-error-reporting.enable whether the adapter reports a kube event to the CRD indicating
+    # a failure to send a cloud event to the sink.
+    sink-event-error-reporting.enable: "false"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/config-propagation: original
+    knative.dev/config-category: eventing
+  annotations:
+    knative.dev/example-checksum: "4002b4c2"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eventing-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: eventing-controller
+  template:
+    metadata:
+      labels:
+        app: eventing-controller
+        eventing.knative.dev/release: "v0.17.3"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: eventing-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: eventing-controller
+      containers:
+      - name: eventing-controller
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/controller@sha256:e4f06a3deefc1bbce98ed5dc1e6fc72cf6a98612d2beb9f3067bc935f39a3e1a
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/eventing
+        - # PingSource
+          name: PING_IMAGE
+          value: gcr.io/knative-releases/knative.dev/eventing/cmd/ping@sha256:9468214680ee784c39ba43727a2371aef2c360037a4232b98dbfcd13472ea829
+        - name: MT_PING_IMAGE
+          value: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:2a7c5fe5bbed24bd40f1dbfc3e0fcf327ee72a77aece9d5ef1e0297f9ac5820a
+        - # APIServerSource
+          name: APISERVER_RA_IMAGE
+          value: gcr.io/knative-releases/knative.dev/eventing/cmd/apiserver_receive_adapter@sha256:f5069b8cf91b6fc25a1d60ca21ccff2eee4ebabb785b805f85b848aeaa7bf413
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eventing-webhook
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      app: eventing-webhook
+      role: eventing-webhook
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: eventing-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: eventing-webhook
+      containers:
+      - name: eventing-webhook
+        terminationMessagePolicy: FallbackToLogsOnError
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/webhook@sha256:c959ba96a0c7e8a71de94c267e50f2a3f7265db12690290adb0db1ac86c06288
+        resources:
+          requests:
+            # taken from serving.
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            # taken from serving.
+            cpu: 200m
+            memory: 200Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: METRICS_DOMAIN
+          value: knative.dev/eventing
+        - name: WEBHOOK_NAME
+          value: eventing-webhook
+        - name: WEBHOOK_PORT
+          value: "8443"
+          # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
+          # for the sinkbinding webhook.
+          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # will be considered by the sinkbinding webhook;
+          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # will NOT be considered by the sinkbinding webhook.
+          # The default is `exclusion`.
+        - name: SINK_BINDING_SELECTION_MODE
+          value: "exclusion"
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: https-webhook
+          containerPort: 8443
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe: *probe
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    role: eventing-webhook
+  name: eventing-webhook
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    role: eventing-webhook
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    # TODO add schemas and descriptions
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.apiserver.resource.add" },
+        { "type": "dev.knative.apiserver.resource.delete" },
+        { "type": "dev.knative.apiserver.resource.update" },
+        { "type": "dev.knative.apiserver.ref.add" },
+        { "type": "dev.knative.apiserver.ref.delete" },
+        { "type": "dev.knative.apiserver.ref.update" }
+      ]
+  name: apiserversources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'ApiServerSource is an event source that brings Kubernetes API
+          server events into Knative.'
+        properties:
+          spec:
+            type: object
+            description: 'ApiServerSourceSpec defines the desired state of ApiServerSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              mode:
+                description: 'Mode is the mode the receive adapter controller runs
+                  under: Ref or Resource. `Ref` sends only the reference to the resource.
+                  `Resource` send the full resource.'
+                type: string
+              owner:
+                description: 'ResourceOwner is an additional filter to only track
+                  resources that are owned by a specific resource type. If ResourceOwner
+                  matches Resources[n] then Resources[n] is allowed to pass the ResourceOwner
+                  filter.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'APIVersion - the API version of the resource to
+                      watch.'
+                    type: string
+                  kind:
+                    description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+              resources:
+                description: 'Resources is the list of resources to watch'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'API version of the resource to watch.'
+                      type: string
+                    controller:
+                      description: 'If true, send an event referencing the object
+                        controlling the resource Deprecated: Per-resource controller
+                        flag will no longer be supported in v1alpha2, please use Spec.Owner
+                        as a GKV.'
+                      type: boolean
+                    controllerSelector:
+                      description: 'ControllerSelector restricts this source to objects
+                        with a controlling owner reference of the specified kind.
+                        Only apiVersion and kind are used. Both are optional. Deprecated:
+                        Per-resource owner refs will no longer be supported in v1alpha2,
+                        please use Spec.Owner as a GKV.'
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: 'API version of the referent.'
+                          type: string
+                        blockOwnerDeletion:
+                          description: 'If true, AND if the owner has the "foregroundDeletion"
+                            finalizer, then the owner cannot be deleted from the key-value
+                            store until this reference is removed. Defaults to false.
+                            To set this field, a user needs "delete" permission of
+                            the owner, otherwise 422 (Unprocessable Entity) will be
+                            returned.'
+                          type: boolean
+                        controller:
+                          description: 'If true, this reference points to the managing
+                            controller.'
+                          type: boolean
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                    kind:
+                      description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    labelSelector:
+                      description: 'LabelSelector restricts this source to objects
+                        with the selected labels More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: 'matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.'
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                description: 'key is the label key that the selector
+                                  applies to.'
+                                type: string
+                              operator:
+                                description: 'operator represents a key''s relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.'
+                                type: string
+                              values:
+                                description: 'values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.'
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: 'matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this source.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a domain name to use as the sink.'
+                type: object
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead
+                          of an entire object, this string should contain a valid
+                          JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within
+                          a pod, this would take on a value like: "spec.containers{name}"
+                          (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]"
+                          (container with index 2 in this pod). This syntax is chosen
+                          only to have some well-defined way of referencing a part
+                          of an object.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference
+                          is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'ApiServerSourceStatus defines the observed state of ApiServerSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1alpha2
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'ApiServerSource is an event source that brings Kubernetes API
+          server events into Knative.'
+        properties:
+          spec:
+            type: object
+            description: 'ApiServerSourceSpec defines the desired state of ApiServerSource
+              (from the client).'
+            required:
+            - resources
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              mode:
+                description: 'EventMode controls the format of the event. `Reference`
+                  sends a dataref event type for the resource under watch. `Resource`
+                  send the full resource lifecycle event. Defaults to `Reference`'
+                type: string
+              owner:
+                description: 'ResourceOwner is an additional filter to only track
+                  resources that are owned by a specific resource type. If ResourceOwner
+                  matches Resources[n] then Resources[n] is allowed to pass the ResourceOwner
+                  filter.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'APIVersion - the API version of the resource to
+                      watch.'
+                    type: string
+                  kind:
+                    description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+              resources:
+                description: 'Resource are the resources this source will track and
+                  send related lifecycle events from the Kubernetes ApiServer, with
+                  an optional label selector to help filter.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion - the API version of the resource to
+                        watch.'
+                      type: string
+                    kind:
+                      description: 'Kind of the resource to watch. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    selector:
+                      description: 'LabelSelector filters this source to objects to
+                        those resources pass the label selector. More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                      type: object
+                      properties:
+                        matchExpressions:
+                          description: 'matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.'
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key:
+                                description: 'key is the label key that the selector
+                                  applies to.'
+                                type: string
+                              operator:
+                                description: 'operator represents a key''s relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.'
+                                type: string
+                              values:
+                                description: 'values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.'
+                                type: array
+                                items:
+                                  type: string
+                        matchLabels:
+                          description: 'matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.'
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+              serviceAccountName:
+                description: 'ServiceAccountName is the name of the ServiceAccount
+                  to use to run this source. Defaults to default if not set.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'ApiServerSourceStatus defines the observed state of ApiServerSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    # the schema of v1beta1 is exactly the same as v1alpha2 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: ApiServerSource
+    plural: apiserversources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: brokers.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'Broker collects a pool of events that are consumable using Triggers.
+          Brokers provide a well-known endpoint for event delivery that senders can
+          use with minimal knowledge of the event routing strategy. Subscribers use
+          Triggers to request delivery of events from a Broker''s pool to a specific
+          URL or Addressable endpoint.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the Broker.'
+            type: object
+            properties:
+              config:
+                description: 'Config is a KReference to the configuration that specifies
+                  configuration options for this Broker. For example, this could be
+                  a pointer to a ConfigMap.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      This is optional field, it gets defaulted to the object holding
+                      it if left out.'
+                    type: string
+              delivery:
+                description: 'Delivery is the delivery specification for Events within
+                  the Broker mesh. This includes things like retries, DLQ, etc.'
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                      information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                      - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                      backoff delay is the time interval between retries. For exponential
+                      policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: ' BackoffPolicy is the retry backoff policy (linear,
+                      exponential).'
+                    type: string
+                  deadLetterSink:
+                    description: 'DeadLetterSink is the sink receiving event that
+                      could not be sent to a destination.'
+                    type: object
+                    properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted to the object
+                              holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty scheme
+                          and non-empty host) pointing to the target or a relative
+                          URI. Relative URIs will be resolved using the base URI retrieved
+                          from Ref.'
+                        type: string
+                  retry:
+                    description: 'Retry is the minimum number of retries the sender
+                      should attempt when sending an event before moving it to the
+                      dead letter sink.'
+                    type: integer
+                    format: int32
+          status:
+            description: 'Status represents the current state of the Broker. This
+              data may be out of date.'
+            type: object
+            properties:
+              address:
+                description: 'Broker is Addressable. It exposes the endpoint as an
+                  URI to get events delivered into the Broker mesh.'
+                type: object
+                properties:
+                  url:
+                    type: string
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    # the schema of v1 is exactly the same as v1beta1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: Broker
+    plural: brokers
+    singular: broker
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: channels.messaging.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Channel
+    plural: channels
+    singular: channel
+    categories:
+    - all
+    - knative
+    - messaging
+    - channel
+    shortNames:
+    - ch
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  name: containersources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: ContainerSource
+    plural: containersources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: eventtypes.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: false
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'EventType represents a type of event that can be consumed from
+          a Broker.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the EventType.'
+            type: object
+            properties:
+              broker:
+                type: string
+              description:
+                description: 'Description is an optional field used to describe the
+                  EventType, in any meaningful way.'
+                type: string
+              schema:
+                description: 'Schema is a URI, it represents the CloudEvents schemaurl
+                  extension attribute. It may be a JSON schema, a protobuf schema,
+                  etc. It is optional.'
+                type: string
+              schemaData:
+                description: 'SchemaData allows the CloudEvents schema to be stored
+                  directly in the EventType. Content is dependent on the encoding.
+                  Optional attribute. The contents are not validated or manipulated
+                  by the system.'
+                type: string
+              source:
+                description: 'Source is a URI, it represents the CloudEvents source.'
+                type: string
+              type:
+                description: 'Type represents the CloudEvents type. It is authoritative.'
+                type: string
+          status:
+            description: 'Status represents the current state of the EventType. This
+              data may be out of date.'
+            type: object
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      jsonPath: ".spec.type"
+    - name: Source
+      type: string
+      jsonPath: ".spec.source"
+    - name: Schema
+      type: string
+      jsonPath: ".spec.schema"
+    - name: Broker
+      type: string
+      jsonPath: ".spec.broker"
+    - name: Description
+      type: string
+      jsonPath: ".spec.description"
+    - # TODO remove Status https://github.com/knative/eventing/issues/2750
+      name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: true
+    # the schema of v1beta1 is exactly the same as v1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: EventType
+    plural: eventtypes
+    singular: eventtype
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: parallels.flows.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: flows.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Parallel
+    plural: parallels
+    singular: parallel
+    categories:
+    - all
+    - knative
+    - flows
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    knative.dev/crd-install: "true"
+  annotations:
+    # TODO add schemas and descriptions
+    registry.knative.dev/eventTypes: |
+      [
+        { "type": "dev.knative.sources.ping" }
+      ]
+  name: pingsources.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha2
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'PingSource describes an event source with a fixed payload produced
+          on a specified cron schedule.'
+        properties:
+          spec:
+            type: object
+            description: 'PingSourceSpec defines the desired state of the PingSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-kubernetes-preserve-unknown-fields: true
+              jsonData:
+                description: 'JsonData is json encoded data used as the body of the
+                  event posted to the sink. Default is empty. If set, datacontenttype
+                  will also be set to "application/json".'
+                type: string
+              schedule:
+                description: 'Schedule is the cronjob schedule. Defaults to `* * *
+                  * *`.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: 'PingSourceStatus defines the observed state of PingSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: .status.sinkUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'PingSource describes an event source with a fixed payload produced
+          on a specified cron schedule.'
+        properties:
+          spec:
+            type: object
+            description: 'PingSourceSpec defines the desired state of the PingSource
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+                    x-kubernetes-preserve-unknown-fields: true
+              jsonData:
+                description: 'JsonData is json encoded data used as the body of the
+                  event posted to the sink. Default is empty. If set, datacontenttype
+                  will also be set to "application/json".'
+                type: string
+              schedule:
+                description: 'Schedule is the cronjob schedule. Defaults to `* * *
+                  * *`.'
+                type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              timezone:
+                description: 'Timezone modifies the actual time relative to the specified
+                  timezone. Defaults to the system time zone. More general information
+                  about time zones: https://www.iana.org/time-zones List of valid
+                  timezone values: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones'
+                type: string
+          status:
+            type: object
+            description: 'PingSourceStatus defines the observed state of PingSource
+              (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the "Generation" of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    kind: PingSource
+    plural: pingsources
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sequences.flows.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: flows.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: Sequence
+    plural: sequences
+    singular: sequence
+    categories:
+    - all
+    - knative
+    - flows
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    eventing.knative.dev/source: "true"
+    duck.knative.dev/source: "true"
+    duck.knative.dev/binding: "true"
+    knative.dev/crd-install: "true"
+  name: sinkbindings.sources.knative.dev
+spec:
+  group: sources.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Sink
+      type: string
+      jsonPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1alpha2
+    served: true
+    storage: false
+  - !!merge <<: *version
+    name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'SinkBinding describes a Binding that is also a Source. The `sink`
+          (from the Source duck) is resolved to a URL and then projected into the
+          `subject` by augmenting the runtime contract of the referenced containers
+          to have a `K_SINK` environment variable holding the endpoint to which to
+          send cloud events.'
+        properties:
+          spec:
+            type: object
+            description: 'SinkBindingSpec holds the desired state of the SinkBinding
+              (from the client).'
+            properties:
+              ceOverrides:
+                description: 'CloudEventOverrides defines overrides to control the
+                  output format and modifications of the event sent to the sink.'
+                type: object
+                properties:
+                  extensions:
+                    description: 'Extensions specify what attribute are added or overridden
+                      on the outbound event. Each `Extensions` key-value pair are
+                      set on the event as an attribute extension independently.'
+                    type: object
+                    additionalProperties:
+                      type: string
+              sink:
+                description: 'Sink is a reference to an object that will resolve to
+                  a uri to use as the sink.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              subject:
+                description: 'Subject references the resource(s) whose "runtime contract"
+                  should be augmented by Binding implementations.'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent.'
+                    type: string
+                  name:
+                    description: 'Name of the referent. Mutually exclusive with Selector.'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent.'
+                    type: string
+                  selector:
+                    description: 'Selector of the referents. Mutually exclusive with
+                      Name.'
+                    type: object
+                    properties:
+                      matchExpressions:
+                        description: 'matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.'
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              description: 'key is the label key that the selector
+                                applies to.'
+                              type: string
+                            operator:
+                              description: 'operator represents a key''s relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.'
+                              type: string
+                            values:
+                              description: 'values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.'
+                              type: array
+                              items:
+                                type: string
+                      matchLabels:
+                        description: 'matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.'
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            description: 'SinkBindingStatus communicates the observed state of the
+              SinkBinding (from the controller).'
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              ceAttributes:
+                description: 'CloudEventAttributes are the specific attributes that
+                  the Source uses as part of its CloudEvents.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    source:
+                      description: 'Source is the CloudEvents source attribute.'
+                      type: string
+                    type:
+                      description: 'Type refers to the CloudEvent type attribute.'
+                      type: string
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  required:
+                  - type
+                  - status
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              sinkUri:
+                description: 'SinkURI is the current active sink URI that has been
+                  configured for the Source.'
+                type: string
+  names:
+    categories:
+    - all
+    - knative
+    - sources
+    - bindings
+    kind: SinkBinding
+    plural: sinkbindings
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: subscriptions.messaging.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema: &openAPIV3Schema
+        type: object
+        description: 'Subscription routes events received on a Channel to a DNS name
+          and corresponds to the subscriptions.channels.knative.dev CRD.'
+        properties:
+          spec:
+            type: object
+            description: 'Specifies the Channel for incoming events, a Subscriber
+              target for processing those events and where to put the result of the
+              processing. Only From (where the events are coming from) is always required.
+              You can optionally only Process the events (results in no output events)
+              by leaving out the Result. You can also perform an identity transformation
+              on the incoming events by leaving out the Subscriber and only specifying
+              Result.
+
+              The following are all valid specifications: channel --[subscriber]-->
+              reply Sink, no outgoing events: channel -- subscriber no-op function
+              (identity transformation): channel --> reply'
+            properties:
+              channel:
+                description: 'Reference to a channel that will be used to create the
+                  subscription You can specify only the following fields of the ObjectReference:
+                  - Kind - APIVersion - Name The resource pointed by this ObjectReference
+                  must meet the contract to the ChannelableSpec duck type. If the
+                  resource does not meet this contract it will be reflected in the
+                  Subscription''s status.  This field is immutable. We have no good
+                  answer on what happens to the events that are currently in the channel
+                  being consumed from and what the semantics there should be. For
+                  now, you can always delete the Subscription and recreate it to point
+                  to a different channel, giving the user more control over what semantics
+                  should be used (drain the channel first, possibly have events dropped,
+                  etc.)'
+                type: object
+                properties:
+                  apiVersion:
+                    description: 'API version of the referent.'
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              delivery:
+                description: 'Delivery configuration'
+                type: object
+                properties:
+                  backoffDelay:
+                    description: 'BackoffDelay is the delay before retrying. More
+                      information on Duration format: - https://www.iso.org/iso-8601-date-and-time-format.html
+                      - https://en.wikipedia.org/wiki/ISO_8601  For linear policy,
+                      backoff delay is the time interval between retries. For exponential
+                      policy , backoff delay is backoffDelay*2^<numberOfRetries>.'
+                    type: string
+                  backoffPolicy:
+                    description: 'BackoffPolicy is the retry backoff policy (linear,
+                      exponential).'
+                    type: string
+                  deadLetterSink:
+                    description: 'DeadLetterSink is the sink receiving event that
+                      could not be sent to a destination.'
+                    type: object
+                    properties:
+                      ref:
+                        description: 'Ref points to an Addressable.'
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: 'API version of the referent.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                              This is optional field, it gets defaulted to the object
+                              holding it if left out.'
+                            type: string
+                      uri:
+                        description: 'URI can be an absolute URL(non-empty scheme
+                          and non-empty host) pointing to the target or a relative
+                          URI. Relative URIs will be resolved using the base URI retrieved
+                          from Ref.'
+                        type: string
+                  retry:
+                    description: 'Retry is the minimum number of retries the sender
+                      should attempt when sending an event before moving it to the
+                      dead letter sink.'
+                    type: integer
+                    format: int32
+              reply:
+                description: 'Reply specifies (optionally) how to handle events returned
+                  from the Subscriber target.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+              subscriber:
+                description: 'Subscriber is reference to (optional) function for processing
+                  events. Events from the Channel will be delivered here and replies
+                  are sent to a Destination as specified by the Reply.'
+                type: object
+                properties:
+                  ref:
+                    description: 'Ref points to an Addressable.'
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: 'API version of the referent.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          This is optional field, it gets defaulted to the object
+                          holding it if left out.'
+                        type: string
+                  uri:
+                    description: 'URI can be an absolute URL(non-empty scheme and
+                      non-empty host) pointing to the target or a relative URI. Relative
+                      URIs will be resolved using the base URI retrieved from Ref.'
+                    type: string
+          status:
+            type: object
+            description: Status (computed) for a subscription
+            properties:
+              annotations:
+                description: 'Annotations is additional Status fields for the Resource
+                  to save some additional State as well as convey more information
+                  to the user. This is roughly akin to Annotations on any k8s resource,
+                  just the reconciler conveying richer information outwards.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              conditions:
+                description: 'Conditions the latest available observations of a resource''s
+                  current state.'
+                type: array
+                items:
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: 'LastTransitionTime is the last time the condition
+                        transitioned from one status to another. We use VolatileTime
+                        in place of metav1.Time to exclude this from creating equality.Semantic
+                        differences (all other things held constant).'
+                      type: string
+                    message:
+                      description: 'A human readable message indicating details about
+                        the transition.'
+                      type: string
+                    reason:
+                      description: 'The reason for the condition''s last transition.'
+                      type: string
+                    severity:
+                      description: 'Severity with which to treat failures of this
+                        type of condition. When this is not specified, it defaults
+                        to Error.'
+                      type: string
+                    status:
+                      description: 'Status of the condition, one of True, False, Unknown.'
+                      type: string
+                    type:
+                      description: 'Type of condition.'
+                      type: string
+              observedGeneration:
+                description: 'ObservedGeneration is the ''Generation'' of the Service
+                  that was last processed by the controller.'
+                type: integer
+                format: int64
+              physicalSubscription:
+                description: 'PhysicalSubscription is the fully resolved values that
+                  this Subscription represents.'
+                type: object
+                properties:
+                  deadLetterSinkUri:
+                    description: 'ReplyURI is the fully resolved URI for the spec.delivery.deadLetterSink.'
+                    type: string
+                  replyUri:
+                    description: 'ReplyURI is the fully resolved URI for the spec.reply.'
+                    type: string
+                  subscriberUri:
+                    description: 'SubscriberURI is the fully resolved URI for spec.subscriber.'
+                    type: string
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    # the schema of v1 is exactly the same as v1beta1 schema
+    schema:
+      openAPIV3Schema:
+        !!merge <<: *openAPIV3Schema
+  names:
+    kind: Subscription
+    plural: subscriptions
+    singular: subscription
+    categories:
+    - all
+    - knative
+    - messaging
+    shortNames:
+    - sub
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: triggers.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+spec:
+  group: eventing.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Broker
+      type: string
+      jsonPath: .spec.broker
+    - name: Subscriber_URI
+      type: string
+      jsonPath: .status.subscriberUri
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            required:
+            - subscriber
+            type: object
+            properties:
+              broker:
+                type: string
+                description: 'Broker that this trigger receives events from. If not
+                  specified, will default to ''default''.'
+              filter:
+                type: object
+                properties:
+                  attributes:
+                    type: object
+                    description: 'Map of CloudEvents attributes used for filtering
+                      events. If not specified, will default to all events'
+                    additionalProperties:
+                      type: string
+              subscriber:
+                type: object
+                description: 'the destination that should receive events.'
+                properties:
+                  ref:
+                    type: object
+                    description: 'a reference to a Kubernetes object from which to
+                      retrieve the target URI.'
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    properties:
+                      apiVersion:
+                        type: string
+                        minLength: 1
+                      kind:
+                        type: string
+                        minLength: 1
+                      namespace:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
+                  uri:
+                    type: string
+                    description: 'the target URI or, if ref is provided, a relative
+                      URI reference that will be combined with ref to produce a target
+                      URI.'
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: 'Trigger represents a request to have events delivered to a subscriber
+          from a Broker''s event pool.'
+        properties:
+          spec:
+            description: 'Spec defines the desired state of the Trigger.'
+            required:
+            - subscriber
+            - broker
+            type: object
+            properties:
+              broker:
+                type: string
+                description: 'Broker that this trigger receives events from.'
+              filter:
+                type: object
+                description: 'Filter is the filter to apply against all events from
+                  the Broker. Only events that pass this filter will be sent to the
+                  Subscriber. If not specified, will default to allowing all events.'
+                properties:
+                  attributes:
+                    type: object
+                    description: 'Map of CloudEvents attributes used for filtering
+                      events. If not specified, will default to all events'
+                    additionalProperties:
+                      type: string
+              subscriber:
+                type: object
+                description: 'the destination that should receive events.'
+                properties:
+                  ref:
+                    type: object
+                    description: 'a reference to a Kubernetes object from which to
+                      retrieve the target URI.'
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    properties:
+                      apiVersion:
+                        type: string
+                        minLength: 1
+                      kind:
+                        type: string
+                        minLength: 1
+                      namespace:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
+                  uri:
+                    type: string
+                    description: 'the target URI or, if ref is provided, a relative
+                      URI reference that will be combined with ref to produce a target
+                      URI.'
+          status:
+            description: 'Status represents the current state of the Trigger. This
+              data may be out of date.'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+  names:
+    kind: Trigger
+    plural: triggers
+    singular: trigger
+    categories:
+    - all
+    - knative
+    - eventing
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need readonly access to "Addressables"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/addressable: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: serving-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: channel-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels
+  - channels/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels/finalizers
+  verbs:
+  - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: broker-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - brokers
+  - brokers/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: messaging-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - sequences
+  - sequences/status
+  - parallels
+  - parallels/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flows-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - flows.knative.dev
+  resources:
+  - sequences
+  - sequences/status
+  - parallels
+  - parallels/status
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-broker-filter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "eventing.knative.dev"
+  resources:
+  - "triggers"
+  - "triggers/status"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-broker-ingress
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: eventing-config-reader
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need read and update permissions on "Channelables".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: channelable-manipulator
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/channelable: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: meta-channelable-manipulator
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/channelable: "true"
+# Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - channels
+  - channels/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-namespaced-admin
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["eventing.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-messaging-namespaced-admin
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["messaging.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-flows-namespaced-admin
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["flows.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-sources-namespaced-admin
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["sources.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-bindings-namespaced-admin
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups: ["bindings.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev",
+    "flows.knative.dev", "bindings.knative.dev"]
+  resources: ["*"]
+  verbs: ["create", "update", "patch", "delete"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-eventing-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups: ["eventing.knative.dev", "messaging.knative.dev", "sources.knative.dev",
+    "flows.knative.dev", "bindings.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  - "secrets"
+  - "configmaps"
+  - "services"
+  - "endpoints"
+  - "events"
+  - "serviceaccounts"
+  - "pods"
+  verbs: &everything
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+- # Brokers and the namespace annotation controllers manipulate Deployments.
+  apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs: *everything
+- # PingSource controller manipulates Deployment owner reference
+  apiGroups:
+  - "apps"
+  resources:
+  - "deployments/finalizers"
+  verbs:
+  - "update"
+- # The namespace annotation controller needs to manipulate RoleBindings.
+  apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - "rolebindings"
+  verbs: *everything
+- # Our own resources and statuses we care about.
+  apiGroups:
+  - "eventing.knative.dev"
+  resources:
+  - "brokers"
+  - "brokers/status"
+  - "triggers"
+  - "triggers/status"
+  - "eventtypes"
+  - "eventtypes/status"
+  verbs: *everything
+- # Eventing resources and finalizers we care about.
+  apiGroups:
+  - "eventing.knative.dev"
+  resources:
+  - "brokers/finalizers"
+  - "triggers/finalizers"
+  verbs:
+  - "update"
+- # Our own resources and statuses we care about.
+  apiGroups:
+  - "messaging.knative.dev"
+  resources:
+  - "sequences"
+  - "sequences/status"
+  - "channels"
+  - "channels/status"
+  - "parallels"
+  - "parallels/status"
+  - "subscriptions"
+  - "subscriptions/status"
+  verbs: *everything
+- # Flow resources and statuses we care about.
+  apiGroups:
+  - "flows.knative.dev"
+  resources:
+  - "sequences"
+  - "sequences/status"
+  - "parallels"
+  - "parallels/status"
+  verbs: *everything
+- # Messaging resources and finalizers we care about.
+  apiGroups:
+  - "messaging.knative.dev"
+  resources:
+  - "sequences/finalizers"
+  - "parallels/finalizers"
+  - "channels/finalizers"
+  verbs:
+  - "update"
+- # Flows resources and finalizers we care about.
+  apiGroups:
+  - "flows.knative.dev"
+  resources:
+  - "sequences/finalizers"
+  - "parallels/finalizers"
+  verbs:
+  - "update"
+- # The subscription controller needs to retrieve and watch CustomResourceDefinitions.
+  apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - "customresourcedefinitions"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- # For leader election
+  apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs: *everything
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-pingsource-adapter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules: []
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-pingsource-mt-adapter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - pingsources
+  - pingsources/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - pingsources/finalizers
+  verbs:
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - "create"
+  - "patch"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need readonly access to "Addressables"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: podspecable-binding
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/podspecable: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: builtin-podspecable-binding
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/podspecable: "true"
+# Do not use this role directly. These rules will be added to the "podspecable-binding role.
+rules:
+- # To patch the subjects of our bindings
+  apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  - "daemonsets"
+  - "statefulsets"
+  - "replicasets"
+  verbs:
+  - "list"
+  - "watch"
+  - "patch"
+- apiGroups:
+  - "batch"
+  resources:
+  - "jobs"
+  verbs:
+  - "list"
+  - "watch"
+  - "patch"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need to read "Sources".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: source-observer
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      duck.knative.dev/source: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-sources-source-observer
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/source: "true"
+# Do not use this role directly. These rules will be added to the "source-observer" role.
+rules:
+- apiGroups:
+  - sources.knative.dev
+  resources:
+  - apiserversources
+  - pingsources
+  - sinkbindings
+  - containersources
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-sources-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  - "configmaps"
+  - "services"
+  verbs: &everything
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+- # Deployments admin
+  apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs: *everything
+- # Source resources and statuses we care about.
+  apiGroups:
+  - "sources.knative.dev"
+  resources:
+  - "sinkbindings"
+  - "sinkbindings/status"
+  - "sinkbindings/finalizers"
+  - "apiserversources"
+  - "apiserversources/status"
+  - "apiserversources/finalizers"
+  - "pingsources"
+  - "pingsources/status"
+  - "pingsources/finalizers"
+  - "containersources"
+  - "containersources/status"
+  - "containersources/finalizers"
+  verbs: *everything
+- # Knative Services admin
+  apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs: *everything
+- # EventTypes admin
+  apiGroups:
+  - eventing.knative.dev
+  resources:
+  - eventtypes
+  verbs: *everything
+- # Events admin
+  apiGroups:
+  - ""
+  resources:
+  - events
+  verbs: *everything
+- # Authorization checker
+  apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-webhook
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- # For watching logging configuration and getting certs.
+  apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- # For manipulating certs into secrets.
+  apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  - "namespaces"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "list"
+  - "watch"
+  - "patch"
+- # For getting our Deployment so we can decorate with ownerref.
+  apiGroups:
+  - "apps"
+  resources:
+  - "deployments"
+  verbs:
+  - "get"
+- apiGroups:
+  - "apps"
+  resources:
+  - "deployments/finalizers"
+  verbs:
+  - update
+- # For actually registering our webhook.
+  apiGroups:
+  - "admissionregistration.k8s.io"
+  resources:
+  - "mutatingwebhookconfigurations"
+  - "validatingwebhookconfigurations"
+  verbs: &everything
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+- # For running the SinkBinding reconciler.
+  apiGroups:
+  - "sources.knative.dev"
+  resources:
+  - "sinkbindings"
+  - "sinkbindings/status"
+  - "sinkbindings/finalizers"
+  verbs: *everything
+- # For leader election
+  apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs: *everything
+- # Necessary for conversion webhook. These are copied from the serving
+  # TODO: Do we really need all these permissions?
+  apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: eventing-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: config.webhook.eventing.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: eventing.knative.dev/release
+      operator: Exists
+  timeoutSeconds: 2
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: eventing-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: webhook.eventing.knative.dev
+  timeoutSeconds: 2
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.eventing.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: eventing-webhook
+      namespace: knative-eventing
+  sideEffects: None
+  failurePolicy: Fail
+  name: validation.webhook.eventing.knative.dev
+  timeoutSeconds: 2
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: eventing-webhook-certs
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+# The data is populated at install time.
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: sinkbindings.webhook.sources.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: eventing-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  sideEffects: None
+  name: sinkbindings.webhook.sources.knative.dev
+  timeoutSeconds: 2
+
+---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/3-in-memory-channel.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/3-in-memory-channel.yaml
@@ -1,0 +1,583 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-imc-event-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+data:
+  MaxIdleConnections: "1000"
+  MaxIdleConnectionsPerHost: "100"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-addressable-resolver
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  - inmemorychannels/status
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-channelable-manipulator
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    duck.knative.dev/channelable: "true"
+# Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  - inmemorychannels/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  - inmemorychannels/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - serviceaccounts
+  verbs: &everything
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - rolebindings
+  verbs: *everything
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: *everything
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs: *everything
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-dispatcher
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels
+  - inmemorychannels/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "" # Core API group.
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  # Updates the status to reflect subscribable status.
+- apiGroups:
+  - messaging.knative.dev
+  resources:
+  - inmemorychannels/status
+  verbs:
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: imc-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    messaging.knative.dev/channel: in-memory-channel
+    messaging.knative.dev/role: dispatcher
+spec:
+  selector:
+    messaging.knative.dev/channel: in-memory-channel
+    messaging.knative.dev/role: dispatcher
+  ports:
+  - name: http-dispatcher
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imc-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: imc-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: imc-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: imc-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: imc-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: imc-dispatcher
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: imc-dispatcher
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: imc-dispatcher
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: inmemorychannels.messaging.knative.dev
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/crd-install: "true"
+    messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: messaging.knative.dev
+  versions:
+  - &version
+    name: v1beta1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.address.url
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  - !!merge <<: *version
+    name: v1
+    served: true
+    storage: false
+  names:
+    kind: InMemoryChannel
+    plural: inmemorychannels
+    singular: inmemorychannel
+    categories:
+    - all
+    - knative
+    - messaging
+    - channel
+    shortNames:
+    - imc
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: eventing-webhook
+          namespace: knative-eventing
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imc-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      messaging.knative.dev/channel: in-memory-channel
+      messaging.knative.dev/role: controller
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: imc-controller
+      containers:
+      - name: controller
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_controller@sha256:46ac99edb4007e9d36693eb089d083217b65d16013afab8ab4427ed94cbc506a
+        env:
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/inmemorychannel-controller
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: DISPATCHER_IMAGE
+          value: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:1205bbb41af394e5b452313eebd21fcdc0c06f303bdd9c60237aafe4e7283543
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: imc-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+    knative.dev/high-availability: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      messaging.knative.dev/channel: in-memory-channel
+      messaging.knative.dev/role: dispatcher
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: imc-dispatcher
+      containers:
+      - name: dispatcher
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/in_memory/channel_dispatcher@sha256:1205bbb41af394e5b452313eebd21fcdc0c06f303bdd9c60237aafe4e7283543
+        env:
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/inmemorychannel-dispatcher
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 9090
+          name: metrics
+
+---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/4-mt-channel-broker.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/4-mt-channel-broker.yaml
@@ -1,0 +1,605 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-mt-channel-broker-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- # Configs resources and status we care about.
+  apiGroups:
+  - ""
+  resources:
+  - "namespaces/finalizers"
+  verbs:
+  - "update"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - "get"
+  - "list"
+  - "create"
+  - "update"
+  - "delete"
+  - "patch"
+  - "watch"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-mt-broker-filter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - triggers
+  - triggers/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mt-broker-filter
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: knative-eventing-mt-broker-ingress
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+rules:
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - brokers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mt-broker-ingress
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eventing-mt-channel-broker-controller
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: eventing-controller
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-mt-channel-broker-controller
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-mt-broker-filter
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: mt-broker-filter
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-mt-broker-filter
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-eventing-mt-broker-ingress
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+subjects:
+- kind: ServiceAccount
+  name: mt-broker-ingress
+  namespace: knative-eventing
+roleRef:
+  kind: ClusterRole
+  name: knative-eventing-mt-broker-ingress
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mt-broker-filter
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  selector:
+    matchLabels:
+      eventing.knative.dev/brokerRole: filter
+  template:
+    metadata:
+      labels:
+        eventing.knative.dev/brokerRole: filter
+        eventing.knative.dev/release: "v0.17.3"
+    spec:
+      serviceAccountName: mt-broker-filter
+      containers:
+      - name: filter
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/filter@sha256:da41162de14c08ed27594522aceb21d2e555e3f7de9128c96071efcb21e0351d
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: CONTAINER_NAME
+          value: filter
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/eventing
+        - name: FILTER_PORT
+          value: "8080"
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    eventing.knative.dev/brokerRole: filter
+    eventing.knative.dev/release: "v0.17.3"
+  name: broker-filter
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: http-metrics
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  selector:
+    eventing.knative.dev/brokerRole: filter
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mt-broker-ingress
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  selector:
+    matchLabels:
+      eventing.knative.dev/brokerRole: ingress
+  template:
+    metadata:
+      labels:
+        eventing.knative.dev/brokerRole: ingress
+        eventing.knative.dev/release: "v0.17.3"
+    spec:
+      serviceAccountName: mt-broker-ingress
+      containers:
+      - name: ingress
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtbroker/ingress@sha256:babdb0d1ea84969f8d14a232cb521624ffa2e51b4e5476652a890eb304602214
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 9090
+          name: metrics
+          protocol: TCP
+        terminationMessagePath: /dev/termination-log
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: CONTAINER_NAME
+          value: ingress
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/internal/eventing
+        - name: INGRESS_PORT
+          value: "8080"
+        securityContext:
+          allowPrivilegeEscalation: false
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    eventing.knative.dev/brokerRole: ingress
+    eventing.knative.dev/release: "v0.17.3"
+  name: broker-ingress
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: http-metrics
+    port: 9092
+    protocol: TCP
+    targetPort: 9092
+  selector:
+    eventing.knative.dev/brokerRole: ingress
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mt-broker-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mt-broker-controller
+  template:
+    metadata:
+      labels:
+        app: mt-broker-controller
+        eventing.knative.dev/release: "v0.17.3"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: mt-broker-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: eventing-controller
+      containers:
+      - name: mt-broker-controller
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtchannel_broker@sha256:8e21e508f2aa7bfaaebeac2efefec3ccb97abd7a5e4e340cc8d5ed37dd23c5a7
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/eventing
+        - # Due to the trivial per-Broker cost, we _can_ inject Brokers into every
+          # namespace by default. To change this default simply change this
+          # to "true".  To opt namespaces out of Broker injection, label
+          # them with:
+          #    knative-eventing-injection: disabled
+          name: BROKER_INJECTION_DEFAULT
+          value: "false"
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: broker-ingress-hpa
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mt-broker-ingress
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+---
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: broker-filter-hpa
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mt-broker-filter
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+
+---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/5-eventing-sugar-controller.yaml
@@ -1,0 +1,54 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sugar-controller
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      eventing.knative.dev/role: sugar-controller
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: eventing-controller
+      containers:
+      - name: controller
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:61688d31b938f337f45a87674df54cd903c25aad3e71a2100fa5cef1b7071e42
+        env:
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: METRICS_DOMAIN
+          value: knative.dev/sugar-controller
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/6-eventing-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/6-eventing-post-install-jobs.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: v0.17.0-pingsource-cleanup
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: "v0.17.3"
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      serviceAccountName: eventing-controller
+      restartPolicy: Never
+      containers:
+      - name: pingsource
+        image: gcr.io/knative-releases/knative.dev/eventing/cmd/v0.17/pingsource-cleanup@sha256:f5e6361c69ff96ff9fa5f52a56234ce9de99afdb498fc731c6b6fccabc002aba
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+
+# Note the following ENVVAR settings exist:
+# SYSTEM_NAMESPACE - the namespace of the control plane, defaults to knative-eventing
+# DRY_RUN - a flag to run the script without deleting or updating, defaults to false.
+
+---

--- a/cmd/operator/kodata/knative-serving/0.17.2/1-serving-crds.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/1-serving-crds.yaml
@@ -1,0 +1,652 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kcert
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: LatestCreated
+      type: string
+      jsonPath: .status.latestCreatedRevisionName
+    - name: LatestReady
+      type: string
+      jsonPath: .status.latestReadyRevisionName
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - config
+    - cfg
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kingress
+    - king
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+    - knative-internal
+    - autoscaling
+  scope: Namespaced
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: DesiredScale
+      type: integer
+      jsonPath: ".status.desiredScale"
+    - name: ActualScale
+      type: integer
+      jsonPath: ".status.actualScale"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+    - knative-internal
+    - autoscaling
+    shortNames:
+    - kpa
+    - pa
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Config Name
+      type: string
+      jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+    - name: K8s Service Name
+      type: string
+      jsonPath: ".status.serviceName"
+    - name: Generation
+      type: string # int in string form :(
+      jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rev
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.url
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Mode
+      type: string
+      jsonPath: ".spec.mode"
+    - name: Activators
+      type: integer
+      jsonPath: ".spec.numActivators"
+    - name: ServiceName
+      type: string
+      jsonPath: ".status.serviceName"
+    - name: PrivateServiceName
+      type: string
+      jsonPath: ".status.privateServiceName"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - sks
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.url
+    - name: LatestCreated
+      type: string
+      jsonPath: .status.latestCreatedRevisionName
+    - name: LatestReady
+      type: string
+      jsonPath: .status.latestReadyRevisionName
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+
+---

--- a/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
@@ -1,0 +1,2651 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+  subresources:
+    status: {}
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-admin
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      serving.knative.dev/controller: "true"
+rules: [] # Rules are automatically filled in by the controller manager.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-admin
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: queue-proxy
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  # This is the Go import path for the binary that is containerized
+  # and substituted here.
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:492eff7822d56ff86e29c35eb2fcc2c9edceb2a11ba129a783cec9a1bac806b3
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "7b6520ae"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # The Revision ContainerConcurrency field specifies the maximum number
+    # of requests the Container can handle at once. Container concurrency
+    # target percentage is how much of that maximum to use in a stable
+    # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # on average.
+    # Note: this limit will be applied to container concurrency set at every
+    # level (ConfigMap, Revision Spec or Annotation).
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    # NOTE: that this value does not affect actual number of concurrent requests
+    #       the user container may receive, but only the average number of requests
+    #       that the revision pods will receive.
+    container-concurrency-target-percentage: "70"
+
+    # The container concurrency target default is what the Autoscaler will
+    # try to maintain when concurrency is used as the scaling metric for the
+    # Revision and the Revision specifies unlimited concurrency.
+    # When revision explicitly specifies container concurrency, that value
+    # will be used as a scaling target for autoscaler.
+    # When specifying unlimited concurrency, the autoscaler will
+    # horizontally scale the application based on this target concurrency.
+    # This is what we call "soft limit" in the documentation, i.e. it only
+    # affects number of pods and does not affect the number of requests
+    # individual pod processes.
+    # The value must be a positive number such that the value multiplied
+    # by container-concurrency-target-percentage is greater than 0.01.
+    # NOTE: that this value will be adjusted by application of
+    #       container-concurrency-target-percentage, i.e. by default
+    #       the system will target on average 70 concurrent requests
+    #       per revision pod.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    container-concurrency-target-default: "100"
+
+    # The requests per second (RPS) target default is what the Autoscaler will
+    # try to maintain when RPS is used as the scaling metric for a Revision and
+    # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # the autoscaler will horizontally scale the application based on this
+    # target RPS.
+    # Must be greater than 1.0.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    requests-per-second-target-default: "200"
+
+    # The target burst capacity specifies the size of burst in concurrent
+    # requests that the system operator expects the system will receive.
+    # Autoscaler will try to protect the system from queueing by introducing
+    # Activator in the request path if the current spare capacity of the
+    # service is less than this setting.
+    # If this setting is 0, then Activator will be in the request path only
+    # when the revision is scaled to 0.
+    # If this setting is > 0 and container-concurrency-target-percentage is
+    # 100% or 1.0, then activator will always be in the request path.
+    # -1 denotes unlimited target-burst-capacity and activator will always
+    # be in the request path.
+    # Other negative values are invalid.
+    target-burst-capacity: "200"
+
+    # When operating in a stable mode, the autoscaler operates on the
+    # average concurrency over the stable window.
+    # Stable window must be in whole seconds.
+    stable-window: "60s"
+
+    # When observed average concurrency during the panic window reaches
+    # panic-threshold-percentage the target concurrency, the autoscaler
+    # enters panic mode. When operating in panic mode, the autoscaler
+    # scales on the average concurrency over the panic window which is
+    # panic-window-percentage of the stable-window.
+    # Must be in the [1, 100] range.
+    # When computing the panic window it will be rounded to the closest
+    # whole second, at least 1s.
+    panic-window-percentage: "10.0"
+
+    # The percentage of the container concurrency target at which to
+    # enter panic mode when reached within the panic window.
+    panic-threshold-percentage: "200.0"
+
+    # Max scale up rate limits the rate at which the autoscaler will
+    # increase pod count. It is the maximum ratio of desired pods versus
+    # observed pods.
+    # Cannot be less or equal to 1.
+    # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # over single Autoscaler period (2s), but at least N to
+    # N+1, if Autoscaler needs to scale up.
+    max-scale-up-rate: "1000.0"
+
+    # Max scale down rate limits the rate at which the autoscaler will
+    # decrease pod count. It is the maximum ratio of observed pods versus
+    # desired pods.
+    # Cannot be less or equal to 1.
+    # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # over single Autoscaler evaluation period (2s), but at
+    # least N to N-1, if Autoscaler needs to scale down.
+    max-scale-down-rate: "2.0"
+
+    # Scale to zero feature flag.
+    enable-scale-to-zero: "true"
+
+    # Scale to zero grace period is the time an inactive revision is left
+    # running before it is scaled to zero (min: 6s).
+    # This is the upper limit and is provided not to enforce timeout after
+    # the revision stopped receiving requests for stable window, but to
+    # ensure network reprogramming to put activator in the path has completed.
+    # If the system determines that a shorter period is satisfactory,
+    # then the system will only wait that amount of time before scaling to 0.
+    # NOTE: this period might actually be 0, if activator has been
+    # in the request path sufficiently long.
+    # If there is necessity for the last pod to linger longer use
+    # scale-to-zero-pod-retention-period flag.
+    scale-to-zero-grace-period: "30s"
+
+    # Scale to zero pod retention period defines the minimum amount
+    # of time the last pod will remain after Autoscaler has decided to
+    # scale to zero.
+    # This flag is for the situations where the pod starup is very expensive
+    # and the traffic is bursty (requiring smaller windows for fast action),
+    # but patchy.
+    # The larger of this flag and `scale-to-zero-grace-period` will effectively
+    # detemine how the last pod will hang around.
+    scale-to-zero-pod-retention-period: "0s"
+
+    # pod-autoscaler-class specifies the default pod autoscaler class
+    # that should be used if none is specified. If omitted, the Knative
+    # Horizontal Pod Autoscaler (KPA) is used by default.
+    pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+
+    # The capacity of a single activator task.
+    # The `unit` is one concurrent request proxied by the activator.
+    # activator-capacity must be at least 1.
+    # This value is used for computation of the Activator subset size.
+    # See the algorithm here: http://bit.ly/38XiCZ3.
+    # TODO(vagababov): tune after actual benchmarking.
+    activator-capacity: "100.0"
+
+    # initial-scale is the cluster-wide default value for the initial target
+    # scale of a revision after creation, unless overridden by the
+    # "autoscaling.knative.dev/initialScale" annotation.
+    # This value must be greater than 0 unless allow-zero-initial-scale is true.
+    initial-scale: "1"
+
+    # allow-zero-initial-scale controls whether either the cluster-wide initial-scale flag,
+    # or the "autoscaling.knative.dev/initialScale" annotation, can be set to 0.
+    allow-zero-initial-scale: "false"
+
+    # max-scale is the cluster-wide default value for the max scale of a revision,
+    # unless overridden by the "autoscaling.knative.dev/maxScale" annotation.
+    # If set to 0, the revision has no maximum scale.
+    max-scale: "0"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "b44360b5"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # revision-timeout-seconds contains the default number of
+    # seconds to use for the revision's per-request timeout, if
+    # none is specified.
+    revision-timeout-seconds: "300"  # 5 minutes
+
+    # max-revision-timeout-seconds contains the maximum number of
+    # seconds that can be used for revision-timeout-seconds.
+    # This value must be greater than or equal to revision-timeout-seconds.
+    # If omitted, the system default is used (600 seconds).
+    #
+    # If this value is increased, the activator's terminationGraceTimeSeconds
+    # should also be increased to prevent in-flight requests being disrupted.
+    max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-cpu-request contains the cpu allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+    # revision-memory-request contains the memory allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-request: "100M"  # 100 megabytes of memory
+
+    # revision-ephemeral-storage-request contains the ephemeral storage
+    # allocation to assign to revisions by default.  If omitted, no value is
+    # specified and the system default is used.
+    revision-ephemeral-storage-request: "500M"  # 500 megabytes of storage
+
+    # revision-cpu-limit contains the cpu allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+    # revision-memory-limit contains the memory allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # revision-ephemeral-storage-limit contains the ephemeral storage
+    # allocation to limit revisions to by default.  If omitted, no value is
+    # specified and the system default is used.
+    revision-ephemeral-storage-limit: "750M"  # 750 megabytes of storage
+
+    # container-name-template contains a template for the default
+    # container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    container-name-template: "user-container"
+
+    # container-concurrency specifies the maximum number
+    # of requests the Container can handle at once, and requests
+    # above this threshold are queued.  Setting a value of zero
+    # disables this throttling and lets through as many requests as
+    # the pod receives.
+    container-concurrency: "0"
+
+    # The container concurrency max limit is an operator setting ensuring that
+    # the individual revisions cannot have arbitrary large concurrency
+    # values, or autoscaling targets. `container-concurrency` default setting
+    # must be at or below this value.
+    #
+    # Must be greater than 1.
+    #
+    # Note: even with this set, a user can choose a containerConcurrency
+    # of 0 (i.e. unbounded) unless allow-container-concurrency-zero is
+    # set to "false".
+    container-concurrency-max-limit: "1000"
+
+    # allow-container-concurrency-zero controls whether users can
+    # specify 0 (i.e. unbounded) for containerConcurrency.
+    allow-container-concurrency-zero: "true"
+
+    # enable-service-links specifies the default value used for the
+    # enableServiceLinks field of the PodSpec, when it is omitted by the user.
+    # See: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service
+    #
+    # In environments with large number of services it is suggested
+    # to set this value to `false`.
+    # See https://github.com/knative/serving/issues/8498.
+    enable-service-links: "default"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-deployment
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "a409bec7"
+data:
+  # This is the Go import path for the binary that is containerized
+  # and substituted here.
+  queueSidecarImage: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:492eff7822d56ff86e29c35eb2fcc2c9edceb2a11ba129a783cec9a1bac806b3
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # List of repositories for which tag to digest resolving should be skipped
+    registriesSkippingTagResolving: "ko.local,dev.local"
+
+    # ProgressDeadline is the duration we wait for the deployment to
+    # be ready before considering it failed.
+    progressDeadline: "120s"
+
+    # queueSidecarCPURequest is the requests.cpu to set for the queue proxy sidecar container.
+    # If omitted, a default value (currently "25m"), is used.
+    queueSidecarCPURequest: "25m"
+
+    # queueSidecarCPULimit is the limits.cpu to set for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarCPULimit: "1000m"
+
+    # queueSidecarMemoryRequest is the requests.memory to set for the queue proxy container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarMemoryRequest: "400Mi"
+
+    # queueSidecarMemoryLimit is the limits.memory to set for the queue proxy container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarMemoryLimit: "800Mi"
+
+    # queueSidecarEphemeralStorageRequest is the requests.ephemeral-storage to
+    # set for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarEphemeralStorageRequest: "512Mi"
+
+    # queueSidecarEphemeralStorageLimit is the limits.ephemeral-storage to set
+    # for the queue proxy sidecar container.
+    # If omitted, no value is specified and the system default is used.
+    queueSidecarEphemeralStorageLimit: "1024Mi"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "f8e5beb4"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default value for domain.
+    # Although it will match all routes, it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # These are example settings of domain.
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+
+    # Routes having domain suffix of 'svc.cluster.local' will not be exposed
+    # through Ingress. You can define your own label selector to assign that
+    # domain suffix to your Route here, or you can set the label
+    #    "serving.knative.dev/visibility=cluster-local"
+    # to achieve the same effect.  This shows how to make routes having
+    # the label app=secret only exposed to the local cluster.
+    svc.cluster.local: |
+      selector:
+        app: secret
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "dd011edb"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Indicates whether multi container support is enabled
+    multi-container: "enabled"
+
+    # Indicates whether Kubernetes affinity support is enabled
+    kubernetes.podspec-affinity: "disabled"
+
+    # Indicates whether Kubernetes nodeSelector support is enabled
+    kubernetes.podspec-nodeselector: "disabled"
+
+    # Indicates whether Kubernetes tolerations support is enabled
+    kubernetes.podspec-tolerations: "disabled"
+
+    # Indicates whether Kubernetes FieldRef support is enabled
+    kubernetes.podspec-fieldref: "disabled"
+
+    # This feature validates PodSpecs from the validating webhook
+    # against the K8s API Server.
+    #
+    # When "enabled", the server will always run the extra validation.
+    # When "allowed", the server will not run the dry-run validation by default.
+    #   However, clients may enable the behavior on an individual Service by
+    #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
+    kubernetes.podspec-dryrun: "allowed"
+
+    # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
+    # in addition to expanding the allowable fields within a Container's SecurityContext.
+    #
+    # When set to "enabled" or "allowed" it allows the following
+    # PodSecurityContext properties:
+    # - FSGroup
+    # - RunAsGroup
+    # - RunAsNonRoot
+    # - SupplementalGroups
+    # - RunAsUser
+    #
+    # When set to "enabled" or "allowed" it allows the following
+    # Container SecurityContext properties:
+    # - RunAsNonRoot
+    # - RunAsGroup
+    # - RunAsUser (already allowed without this flag)
+    #
+    # This feature flag should be used with caution as the PodSecurityContext
+    # properties may have a side-effect on non-user sidecar containers that come
+    # from Knative or your service mesh
+    #
+    kubernetes.podspec-securitycontext: "disabled"
+
+    # Indicates whether new responsive garbage collection is enabled. This
+    # feature labels revisions in real-time as they become referenced and
+    # dereferenced by Routes. This allows us to reap revisions shortly after
+    # they are no longer active.
+    # ALPHA WARNING: This feature is not yet stable or complete. Enabling it
+    # should be used for testing purposes only.
+    responsive-revision-gc: "disabled"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gc
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "4b89cfa0"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Delay after revision creation before considering it for GC
+    stale-revision-create-delay: "48h"
+
+    # Duration since a route has pointed at the revision before it
+    # should be GC'd.
+    # This minus lastpinned-debounce must be longer than the controller
+    # resync period (10 hours).
+    stale-revision-timeout: "15h"
+
+    # Minimum number of generations of non-active revisions to keep before
+    # considering them for GC.
+    stale-revision-minimum-generations: "20"
+
+    # To avoid constant updates, we allow an existing annotation to be stale by this
+    # amount before we update the timestamp.
+    stale-revision-lastpinned-debounce: "5h"
+
+
+    # ---------------------------------------
+    # V2 Garbage Collector Settings
+    # ---------------------------------------
+    #
+    # These settings are enabled via the "responsive-revision-gc" feature flag.
+    # ALPHA NOTE: This feature is still experimental and under active development.
+    #
+    # Active
+    #   * Revisions which are referenced by a Route are considered active.
+    #   * Individual revisions may be marked with the annotation
+    #      "knative.dev/no-gc":"true" to be permanently considered active.
+    #   * Active revisions are not considered for GC.
+    # Retention
+    #   * Revisions are retained if they are any of the following:
+    #       1. Active
+    #       2. Were created within "retain-since-create-time"
+    #       3. Were last referenced by a route within
+    #           "retain-since-last-active-time"
+    #       4. There are fewer than "min-non-active-revisions"
+    #     If none of these conditions are met, or if the count of revisions exceed
+    #      "max-non-active-revisions", they will be deleted by GC.
+    #     The special value "disabled" may be used to turn off these limits.
+    #
+    # Example config to immediately collect any inactive revision:
+    #    min-non-active-revisions: "0"
+    #    retain-since-create-time: "disabled"
+    #    retain-since-last-active-time: "disabled"
+    #
+    # Example config to always keep around the last ten non-active revisions:
+    #     retain-since-create-time: "disabled"
+    #     retain-since-last-active-time: "disabled"
+    #     max-non-active-revisions: "10"
+    #
+    # Example config to disable all GC:
+    #     retain-since-create-time: "disabled"
+    #     retain-since-last-active-time: "disabled"
+    #     max-non-active-revisions: "disabled"
+    #
+    # Example config to keep recently deployed or active revisions,
+    # always maintain the last two in case of rollback, and prevent
+    # burst activity from exploding the count of old revisions:
+    #      retain-since-create-time: "48h"
+    #      retain-since-last-active-time: "15h"
+    #      min-non-active-revisions: "2"
+    #      max-non-active-revisions: "1000"
+
+    # Duration since creation before considering a revision for GC or "disabled".
+    retain-since-create-time: "48h"
+
+    # Duration since active before considering a revision for GC or "disabled".
+    retain-since-last-active-time: "15h"
+
+    # Minimum number of non-active revisions to retain.
+    min-non-active-revisions: "20"
+
+    # Maximum number of non-active revisions to retain
+    # or "disabled" to disable any maximum limit.
+    max-non-active-revisions: "1000"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "a255a6cc"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retryPeriod: "2s"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "23eed3d8"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "ts",
+          "levelKey": "level",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "msg",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the autoscaler and queue proxy,
+    # changes are be picked up immediately.
+    # For autoscaler and queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+    loglevel.hpaautoscaler: "info"
+    loglevel.certcontroller: "info"
+    loglevel.istiocontroller: "info"
+    loglevel.nscontroller: "info"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "b22469ec"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # DEPRECATED:
+    # istio.sidecar.includeOutboundIPRanges is obsolete.
+    # The current versions have outbound network access enabled by default.
+    # If you need this option for some reason, please use global.proxy.includeIPRanges in Istio.
+    #
+    # istio.sidecar.includeOutboundIPRanges: "*"
+
+    # ingress.class specifies the default ingress class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Istio ingress.
+    #
+    # Note that changing the Ingress class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    ingress.class: "istio.ingress.networking.knative.dev"
+
+    # certificate.class specifies the default Certificate class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Cert-Manager Certificate.
+    #
+    # Note that changing the Certificate class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    certificate.class: "cert-manager.certificate.networking.knative.dev"
+
+    # domainTemplate specifies the golang text template string to use
+    # when constructing the Knative service's DNS name. The default
+    # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}".
+    #
+    # Valid variables defined in the template include Name, Namespace, Domain,
+    # Labels, and Annotations. Name will be the result of the tagTemplate
+    # below, if a tag is specified for the route.
+    #
+    # Changing this value might be necessary when the extra levels in
+    # the domain name generated is problematic for wildcard certificates
+    # that only support a single level of domain name added to the
+    # certificate's domain. In those cases you might consider using a value
+    # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # entirely from the template. When choosing a new value be thoughtful
+    # of the potential for conflicts - for example, when users choose to use
+    # characters such as `-` in their service, or namespace, names.
+    # {{.Annotations}} or {{.Labels}} can be used for any customization in the
+    # go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid
+    # domain name clashes:
+    # eg. '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template
+    # would be {Name}-{Namespace}.foo.{Domain}
+    domainTemplate: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # tagTemplate specifies the golang text template string to use
+    # when constructing the DNS name for "tags" within the traffic blocks
+    # of Routes and Configuration.  This is used in conjunction with the
+    # domainTemplate above to determine the full URL for the tag.
+    tagTemplate: "{{.Tag}}-{{.Name}}"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate external TLS connection.
+    # 1. Enabled: enabling auto-TLS feature.
+    # 2. Disabled: disabling auto-TLS feature.
+    autoTLS: "Disabled"
+
+    # Controls the behavior of the HTTP endpoint for the Knative ingress.
+    # It requires autoTLS to be enabled.
+    # 1. Enabled: The Knative ingress will be able to serve HTTP connection.
+    # 2. Disabled: The Knative ingress will reject HTTP traffic.
+    # 3. Redirected: The Knative ingress will send a 302 redirect for all
+    # http connections, asking the clients to use HTTPS
+    httpProtocol: "Enabled"
+
+    # Controls whether tag header based routing feature are enabled or not.
+    # 1. Enabled: enabling tag header based routing
+    # 2. Disabled: disabling tag header based routing
+    tagHeaderBasedRouting: "Disabled"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "11674c15"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    # This value is what you might use the the Knative monitoring bundle, and provides
+    # access to Kibana after setting up kubectl proxy.
+    logging.revision-url-template: "http://localhost:8001/api/v1/namespaces/knative-monitoring/services/kibana-logging/proxy/app/kibana#/discover?_a=(query:(match:(kubernetes.labels.knative-dev%2FrevisionUID:(query:'${REVISION_UID}',type:phrase))))"
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # NB: after 0.18 release logging.enable-request-log must be explicitly set to true
+    # in order for request logging to be enabled.
+    #
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, the request logging will be enabled.
+    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # will be ignored.
+    logging.enable-request-log: "false"
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+  annotations:
+    knative.dev/example-checksum: "4002b4c2"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "stackdriver", the default is "none"
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # The GCP project into which stackdriver metrics will be written
+    # when backend is "stackdriver".  If unspecified, the project-id
+    # is read from GCP metadata when running on GCP.
+    stackdriver-project-id: "my-project"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  minReplicas: 1
+  maxReplicas: 20
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      # Percentage of the requested CPU
+      targetAverageUtilization: 100
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      role: activator
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: activator
+        role: activator
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: activator
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:e5009a07e0aeb256d9009c728f5da673d27137863725c0f562d25730d1d7fe1e
+        # The numbers are based on performance test results from
+        # https://github.com/knative/serving/issues/1625#issuecomment-511930023
+        resources:
+          requests:
+            cpu: 300m
+            memory: 60Mi
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+        env:
+        - # Run Activator with GC collection when newly generated memory is 500%.
+          name: GOGC
+          value: "500"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: http1
+          containerPort: 8012
+        - name: h2c
+          containerPort: 8013
+        readinessProbe: &probe
+          httpGet:
+            port: 8012
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "activator"
+          failureThreshold: 12
+        livenessProbe: *probe
+      # The activator (often) sits on the dataplane, and may proxy long (e.g.
+      # streaming, websockets) requests.  We give a long grace period for the
+      # activator to "lame duck" and drain outstanding requests before we
+      # forcibly terminate the pod (and outstanding connections).  This value
+      # should be at least as large as the upper bound on the Revision's
+      # timeoutSeconds property to avoid servicing events disrupting
+      # connections.
+      terminationGracePeriodSeconds: 600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: activator-service
+  namespace: knative-serving
+  labels:
+    app: activator
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  selector:
+    app: activator
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 80
+    targetPort: 8012
+  - name: http2
+    port: 81
+    targetPort: 8013
+  type: ClusterIP
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: autoscaler
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: autoscaler
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:2065a95375faa45bbe8be94583127b3137471544eea87ebc563a62e4da513f6e
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: websocket
+          containerPort: 8080
+        readinessProbe: &probe
+          httpGet:
+            port: 8080
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "autoscaler"
+        livenessProbe: *probe
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    serving.knative.dev/release: "v0.17.2"
+  name: autoscaler
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: autoscaler
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: controller
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: controller
+      containers:
+      - name: controller
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:ed69d2b7b02e3d0dab47d0dcb84a6032596de7e09c957eda5dbb31b5b17a6d83
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 1000m
+            memory: 1000Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/internal/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    serving.knative.dev/release: "v0.17.2"
+  name: controller
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: controller
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  selector:
+    matchLabels:
+      app: webhook
+      role: webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: webhook
+        role: webhook
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:69bccb89b0bf8995f214acb9341a651f264183dcb469185a821edf6b9f7f37a2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: WEBHOOK_PORT
+          value: "8443"
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+        readinessProbe: &probe
+          periodSeconds: 1
+          httpGet:
+            scheme: HTTPS
+            port: 8443
+            httpHeaders:
+            - name: k-kubelet-probe
+              value: "webhook"
+        livenessProbe: *probe
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+    serving.knative.dev/release: "v0.17.2"
+  name: webhook
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    role: webhook
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kcert
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: LatestCreated
+      type: string
+      jsonPath: .status.latestCreatedRevisionName
+    - name: LatestReady
+      type: string
+      jsonPath: .status.latestReadyRevisionName
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - config
+    - cfg
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - kingress
+    - king
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+    - knative-internal
+    - autoscaling
+  scope: Namespaced
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: DesiredScale
+      type: integer
+      jsonPath: ".status.desiredScale"
+    - name: ActualScale
+      type: integer
+      jsonPath: ".status.actualScale"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+    - knative-internal
+    - autoscaling
+    shortNames:
+    - kpa
+    - pa
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Config Name
+      type: string
+      jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+    - name: K8s Service Name
+      type: string
+      jsonPath: ".status.serviceName"
+    - name: Generation
+      type: string # int in string form :(
+      jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rev
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.url
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - rt
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Mode
+      type: string
+      jsonPath: ".spec.mode"
+    - name: Activators
+      type: integer
+      jsonPath: ".spec.numActivators"
+    - name: ServiceName
+      type: string
+      jsonPath: ".status.serviceName"
+    - name: PrivateServiceName
+      type: string
+      jsonPath: ".status.privateServiceName"
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+    - knative-internal
+    - networking
+    shortNames:
+    - sks
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+  - &version
+    name: v1alpha1
+    served: true
+    storage: false
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: URL
+      type: string
+      jsonPath: .status.url
+    - name: LatestCreated
+      type: string
+      jsonPath: .status.latestCreatedRevisionName
+    - name: LatestReady
+      type: string
+      jsonPath: .status.latestReadyRevisionName
+    - name: Ready
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - !!merge <<: *version
+    name: v1beta1
+  - !!merge <<: *version
+    name: v1
+    storage: true
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-addressable-resolver
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    # Labeled to facilitate aggregated cluster roles that act on Addressables.
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - routes
+  - routes/status
+  - services
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    serving.knative.dev/release: "v0.17.2"
+rules:
+- apiGroups: ["serving.knative.dev"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev",
+    "caching.internal.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    serving.knative.dev/release: "v0.17.2"
+rules:
+- apiGroups: ["serving.knative.dev"]
+  resources: ["*"]
+  verbs: ["create", "update", "patch", "delete"]
+- apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev",
+    "caching.internal.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    serving.knative.dev/release: "v0.17.2"
+rules:
+- apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev",
+    "caching.internal.knative.dev"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-core
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    serving.knative.dev/controller: "true"
+rules:
+- apiGroups: [""]
+  resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services",
+    "events", "serviceaccounts"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+  verbs: ["create"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+- apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
+  resources: ["*", "*/status", "*/finalizers"]
+  verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch",
+    "watch"]
+- apiGroups: ["caching.internal.knative.dev"]
+  resources: ["images"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-podspecable-binding
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
+    duck.knative.dev/podspecable: "true"
+# Do not use this role directly. These rules will be added to the "podspecable-binder" role.
+rules:
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - configurations
+  - services
+  verbs:
+  - list
+  - watch
+  - patch
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.serving.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists
+  timeoutSeconds: 10
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: webhook.serving.knative.dev
+  timeoutSeconds: 10
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+webhooks:
+- admissionReviewVersions: ["v1", "v1beta1"]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: validation.webhook.serving.knative.dev
+  timeoutSeconds: 10
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+# The data is populated at install time.
+
+---

--- a/cmd/operator/kodata/knative-serving/0.17.2/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/3-serving-hpa.yaml
@@ -1,0 +1,99 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler-hpa
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    autoscaling.knative.dev/autoscaler-provider: hpa
+spec:
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: autoscaler-hpa
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: autoscaler-hpa
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      serviceAccountName: controller
+      containers:
+      - name: autoscaler-hpa
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:50fe2cdccbadf4d4c5fcf513c330780ed66db920a1c0c02670aa8d8982948aa6
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/serving
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler-hpa
+    serving.knative.dev/release: "v0.17.2"
+    autoscaling.knative.dev/autoscaler-provider: hpa
+  name: autoscaler-hpa
+  namespace: knative-serving
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  selector:
+    app: autoscaler-hpa
+
+---

--- a/cmd/operator/kodata/knative-serving/0.17.2/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/4-net-istio.yaml
@@ -1,0 +1,456 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # These are the permissions needed by the Istio Ingress implementation.
+  name: knative-serving-istio
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    serving.knative.dev/controller: "true"
+    networking.knative.dev/ingress-provider: istio
+rules:
+- apiGroups: ["networking.istio.io"]
+  resources: ["virtualservices", "gateways"]
+  verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is the shared Gateway for all Knative routes to use.
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: knative-ingress-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A cluster local gateway to allow pods outside of the mesh to access
+# Services and Routes not exposing through an ingress.  If the users
+# do have a service mesh setup, this isn't required.
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: cluster-local-gateway
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    istio: cluster-local-gateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.istio.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - {key: "serving.knative.dev/configuration", operator: Exists}
+  name: webhook.istio.networking.internal.knative.dev
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.istio.networking.internal.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: istio-webhook
+      namespace: knative-serving
+  failurePolicy: Fail
+  sideEffects: None
+  name: config.webhook.istio.networking.internal.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: serving.knative.dev/release
+      operator: Exists
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: istio-webhook-certs
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-istio
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default Knative Gateway after v0.3. It points to the Istio
+    # standard istio-ingressgateway, instead of a custom one that we
+    # used pre-0.3. The configuration format should be `gateway.
+    # {{gateway_namespace}}.{{gateway_name}}: "{{ingress_name}}.
+    # {{ingress_namespace}}.svc.cluster.local"`. The {{gateway_namespace}}
+    # is optional; when it is omitted, the system will search for
+    # the gateway in the serving system namespace `knative-serving`
+    gateway.knative-serving.knative-ingress-gateway: "istio-ingressgateway.istio-system.svc.cluster.local"
+
+    # A cluster local gateway to allow pods outside of the mesh to access
+    # Services and Routes not exposing through an ingress.  If the users
+    # do have a service mesh setup, this isn't required and can be removed.
+    #
+    # An example use case is when users want to use Istio without any
+    # sidecar injection (like Knative's istio-ci-no-mesh.yaml).  Since every pod
+    # is outside of the service mesh in that case, a cluster-local  service
+    # will need to be exposed to a cluster-local gateway to be accessible.
+    # The configuration format should be `local-gateway.{{local_gateway_namespace}}.
+    # {{local_gateway_name}}: "{{cluster_local_gateway_name}}.
+    # {{cluster_local_gateway_namespace}}.svc.cluster.local"`. The
+    # {{local_gateway_namespace}} is optional; when it is omitted, the system
+    # will search for the local gateway in the serving system namespace
+    # `knative-serving`
+    local-gateway.knative-serving.cluster-local-gateway: "cluster-local-gateway.istio-system.svc.cluster.local"
+
+    # To use only Istio service mesh and no cluster-local-gateway, replace
+    # all local-gateway.* entries by the following entry.
+    local-gateway.mesh: "mesh"
+  # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: networking-istio
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    matchLabels:
+      app: networking-istio
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        # This must be outside of the mesh to probe the gateways.
+        # NOTE: this is allowed here and not elsewhere because
+        # this is the Istio controller, and so it may be Istio-aware.
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: networking-istio
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: networking-istio
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:d641b71dfc38afcbd30121b57f11cb3c489413b93166ae77d724da1b2a5f5759
+        resources:
+          requests:
+            cpu: 30m
+            memory: 40Mi
+          limits:
+            cpu: 300m
+            memory: 400Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+
+# Unlike other controllers, this doesn't need a Service defined for metrics and
+# profiling because it opts out of the mesh (see annotation above).
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-webhook
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  selector:
+    matchLabels:
+      app: istio-webhook
+      role: istio-webhook
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: istio-webhook
+        role: istio-webhook
+        serving.knative.dev/release: "v0.17.2"
+    spec:
+      serviceAccountName: controller
+      containers:
+      - name: webhook
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:23df9385de0f11ae3bfcdf03ed5e9935342a5433990ef2e515df5b418d978468
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+          limits:
+            cpu: 200m
+            memory: 200Mi
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: config-logging
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+          name: METRICS_DOMAIN
+          value: knative.dev/net-istio
+        - name: WEBHOOK_NAME
+          value: istio-webhook
+        securityContext:
+          allowPrivilegeEscalation: false
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: profiling
+          containerPort: 8008
+        - name: https-webhook
+          containerPort: 8443
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-webhook
+  namespace: knative-serving
+  labels:
+    role: istio-webhook
+    serving.knative.dev/release: "v0.17.2"
+    networking.knative.dev/ingress-provider: istio
+spec:
+  ports:
+  - # Define metrics and profiling for them to be accessible within service meshes.
+    name: http-metrics
+    port: 9090
+    targetPort: 9090
+  - name: http-profiling
+    port: 8008
+    targetPort: 8008
+  - name: https-webhook
+    port: 443
+    targetPort: 8443
+  selector:
+    app: istio-webhook
+
+---

--- a/cmd/operator/kodata/knative-serving/0.17.2/5-serving-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/5-serving-post-install-jobs.yaml
@@ -1,0 +1,49 @@
+
+---
+# /tmp/tmp.YyBK09Jk4l/serving-storage-version-migration.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: storage-version-migration-serving-
+  namespace: knative-serving
+  labels:
+    app: "storage-version-migration-serving"
+    serving.knative.dev/release: "v0.17.2"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: "storage-version-migration-serving"
+    spec:
+      serviceAccountName: controller
+      restartPolicy: OnFailure
+      containers:
+      - name: migrate
+        # This is the Go import path for the binary that is containerized
+        # and substituted here.
+        image: gcr.io/knative-releases/knative.dev/serving/vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:326d88e3c61e9f75e301b366b0561d1f2cb4773f674a13c5241a755f086ed530
+        args:
+        - "services.serving.knative.dev"
+        - "configurations.serving.knative.dev"
+        - "revisions.serving.knative.dev"
+        - "routes.serving.knative.dev"
+
+---


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* This PR grabs the latest 0.17 patch releases for serving and eventing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
