### PR TITLE
Set E2E_UPGRADE_TESTS_SERVING_USE to test kservice in eventing tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -101,15 +101,20 @@ function istio_yaml() {
 
 # Download the repository of Knative. The purpose of this function is to download the source code of
 # knative component for further use, based on component name and branch name.
-# Parameter: $1 - component name, either serving or eventing, $2 - branch of the repository.
-function donwload_knative() {
-  local component=$1
+# Parameters:
+#  $1 - component repo name, either knative/serving or knative/eventing,
+#  $2 - component name,
+#  $3 - branch of the repository.
+function download_knative() {
+  local component_repo component_name
+  component_repo=$1
+  component_name=$2
   # Go the directory to download the source code of knative
   cd ${KNATIVE_DIR}
   # Download the source code of knative
-  git clone https://github.com/knative/${component}.git
-  cd ${component}
-  local branch=$2
+  git clone "https://github.com/${component_repo}.git" "${component_name}"
+  cd "${component_name}"
+  local branch=$3
   if [ -n "${branch}" ] ; then
     git fetch origin ${branch}:${branch}
     git checkout ${branch}

--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -40,6 +40,7 @@ readonly EVENTING_PROBER_FILE="/tmp/prober-signal-eventing"
 
 # TODO: remove when components can coexist in same namespace
 export TEST_EVENTING_NAMESPACE=knative-eventing
+export E2E_UPGRADE_TESTS_SERVING_USE=true
 
 function install_previous_operator_release() {
   install_istio || fail_test "Istio installation failed"
@@ -105,8 +106,8 @@ EOF
 function knative_setup() {
   create_namespace
   install_previous_operator_release
-  donwload_knative "serving" ${KNATIVE_REPO_BRANCH}
-  donwload_knative "eventing" ${KNATIVE_REPO_BRANCH}
+  download_knative "${KNATIVE_SERVING_REPO:-knative/serving}" serving "${KNATIVE_REPO_BRANCH}"
+  download_knative "${KNATIVE_EVENTING_REPO:-knative/eventing}" eventing "${KNATIVE_REPO_BRANCH}"
 }
 
 # Create test resources and images


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #252 

## Proposed Changes

* Upgrade tests for Eventing utilize Knative Serving forwarder component while running in Operator tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
