### PR TITLE
Transform jobs first so images are overridable.

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -28,10 +28,10 @@ func transformers(ctx context.Context, obj v1alpha1.KComponent) []mf.Transformer
 	return []mf.Transformer{
 		mf.InjectOwner(obj),
 		mf.InjectNamespace(obj.GetNamespace()),
+		JobTransform(obj),
 		ImageTransform(obj.GetSpec().GetRegistry(), logger),
 		ConfigMapTransform(obj.GetSpec().GetConfig(), logger),
 		ResourceRequirementsTransform(obj.GetSpec().GetResources(), logger),
-		JobTransform(obj),
 	}
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The job transformer gives a job with a `generateName` an actual, predictable name. If we apply it before the image transform, that gives us the possibility to override the respective image via an image transformer.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @matzew @houshengbo 
