### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.14.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.14.0/1-eventing.yaml
@@ -697,9 +697,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.14.1/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.14.1/1-eventing.yaml
@@ -697,9 +697,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.14.2/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.14.2/1-eventing.yaml
@@ -697,9 +697,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
@@ -692,9 +692,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
@@ -692,9 +692,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
@@ -692,9 +692,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.15.3/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.3/1-eventing.yaml
@@ -692,9 +692,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.15.4/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.4/1-eventing.yaml
@@ -692,9 +692,9 @@ spec:
           value: eventing-webhook
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
@@ -700,9 +700,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
@@ -700,9 +700,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
@@ -708,9 +708,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
@@ -708,9 +708,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
@@ -708,9 +708,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
@@ -708,9 +708,9 @@ spec:
           value: "8443"
           # SINK_BINDING_SELECTION_MODE specifies the NamespaceSelector and ObjectSelector
           # for the sinkbinding webhook.
-          # If `inclusion` is selected, namespaces/objects labled as `bindings.knative.dev/include:true`
+          # If `inclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/include:true`
           # will be considered by the sinkbinding webhook;
-          # If `exclusion` is selected, namespaces/objects labled as `bindings.knative.dev/exclude:true`
+          # If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
           # will NOT be considered by the sinkbinding webhook.
           # The default is `exclusion`.
         - name: SINK_BINDING_SELECTION_MODE

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -183,7 +183,7 @@ function wait_for_file() {
   waits=300
   timeout=$waits
 
-  echo "Waiting for existance of file: ${file}"
+  echo "Waiting for existence of file: ${file}"
 
   while [ ! -f "${file}" ]; do
     # When the timeout is equal to zero, show an error and leave the loop.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -37,7 +37,7 @@ function install_eventing_operator() {
 }
 
 function knative_setup() {
-  donwload_knative_serving
+  download_knative_serving
   install_istio || fail_test "Istio installation failed"
   create_namespace
   install_operator

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -16,7 +16,7 @@
 
 set -o errexit
 
-# This fucntion is used to build and publish the test images.
+# This function is used to build and publish the test images.
 # $1 - the first parameter is a string, specifying a path of the root directory of the project to run the ko command.
 # $2 - the second parameter is a string, speficying a sub-directory, where the images are built, under the root directory.
 # $3 - the third parameter is a string, speficying the tag of the images.


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc houshengbo
/assign houshengbo