### PR TITLE
Don't wait for Ksvc to scale to zero

### DIFF
--- a/test/e2e-upgrade-tests.sh
+++ b/test/e2e-upgrade-tests.sh
@@ -41,6 +41,8 @@ readonly EVENTING_PROBER_FILE="/tmp/prober-signal-eventing"
 # TODO: remove when components can coexist in same namespace
 export TEST_EVENTING_NAMESPACE=knative-eventing
 export E2E_UPGRADE_TESTS_SERVING_USE=true
+# FIXME(ksuszyns): remove when knative/operator#297 is fixed
+export E2E_UPGRADE_TESTS_SERVING_SCALETOZERO=false
 
 function install_previous_operator_release() {
   install_istio || fail_test "Istio installation failed"


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Relates to #297

## Proposed Changes

* Skips waiting for forwarder ksvc component to scale to zero before routing traffic.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```