### PR TITLE
Spelling (with checksums)

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.0/1-eventing.yaml
@@ -371,7 +371,7 @@ data:
     # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:

--- a/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.1/1-eventing.yaml
@@ -371,7 +371,7 @@ data:
     # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:

--- a/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.2/1-eventing.yaml
@@ -371,7 +371,7 @@ data:
     # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:

--- a/cmd/operator/kodata/knative-eventing/0.15.3/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.3/1-eventing.yaml
@@ -371,7 +371,7 @@ data:
     # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:

--- a/cmd/operator/kodata/knative-eventing/0.15.4/1-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.15.4/1-eventing.yaml
@@ -371,7 +371,7 @@ data:
     # giving up; 10 seconds is the value used by core kubernetes controllers.
     renewDeadline: "10s"
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:

--- a/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
@@ -341,7 +341,7 @@ metadata:
     eventing.knative.dev/release: "v0.16.0"
     knative.dev/example-checksum: "43edfe90"
   annotations:
-    knative.dev/example-checksum: f7320456
+    knative.dev/example-checksum: 71a0eb3b
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.0/2-eventing.yaml
@@ -368,7 +368,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
     # enabledComponents is a comma-delimited list of component names for which

--- a/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
@@ -341,7 +341,7 @@ metadata:
     eventing.knative.dev/release: "v0.16.1"
     knative.dev/example-checksum: "43edfe90"
   annotations:
-    knative.dev/example-checksum: f7320456
+    knative.dev/example-checksum: 71a0eb3b
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.16.1/2-eventing.yaml
@@ -368,7 +368,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
     # enabledComponents is a comma-delimited list of component names for which

--- a/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.0"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.0/3-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.1"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.1/2-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.2/2-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.2"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.3/2-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.3"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.17.4/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.4/2-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.4/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.4/2-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.4"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.17.5/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.5/2-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.17.5/2-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.17.5/2-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.17.5"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-eventing/0.18.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.0/3-eventing-core.yaml
@@ -364,7 +364,7 @@ data:
     renewDeadline: "10s"
 
     # retryPeriod is how long the leader election client waits between tries of
-    # actions; 2 seconds is the value used by core kuberntes controllers.
+    # actions; 2 seconds is the value used by core kubernetes controllers.
     retryPeriod: "2s"
 
 ---

--- a/cmd/operator/kodata/knative-eventing/0.18.0/3-eventing-core.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.0/3-eventing-core.yaml
@@ -337,7 +337,7 @@ metadata:
   labels:
     eventing.knative.dev/release: "v0.18.0"
   annotations:
-    knative.dev/example-checksum: "6cf53e10"
+    knative.dev/example-checksum: "a255a6cc"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.0/2-serving-core.yaml
@@ -297,7 +297,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # Enable graceful scaledown feature flag.

--- a/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.1/2-serving-core.yaml
@@ -297,7 +297,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # Enable graceful scaledown feature flag.

--- a/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.15.2/2-serving-core.yaml
@@ -297,7 +297,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # Enable graceful scaledown feature flag.

--- a/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
@@ -289,7 +289,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.16.0/2-serving-core.yaml
@@ -156,7 +156,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.16.0"
   annotations:
-    knative.dev/example-checksum: "088ba8b3"
+    knative.dev/example-checksum: "544cba62"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
@@ -289,7 +289,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
@@ -1138,7 +1138,7 @@ data:
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
     # If true, the request logging will be enabled.
-    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
     # will be ignored.
     logging.enable-request-log: "false"
 

--- a/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.0/2-serving-core.yaml
@@ -156,7 +156,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.0"
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "84771098"
 data:
   _example: |
     ################################
@@ -1075,7 +1075,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.0"
   annotations:
-    knative.dev/example-checksum: "11674c15"
+    knative.dev/example-checksum: "67e5d2ff"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
@@ -289,7 +289,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
@@ -156,7 +156,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.1"
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "84771098"
 data:
   _example: |
     ################################
@@ -1075,7 +1075,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.1"
   annotations:
-    knative.dev/example-checksum: "11674c15"
+    knative.dev/example-checksum: "67e5d2ff"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.1/2-serving-core.yaml
@@ -1138,7 +1138,7 @@ data:
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
     # If true, the request logging will be enabled.
-    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
     # will be ignored.
     logging.enable-request-log: "false"
 

--- a/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
@@ -289,7 +289,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
@@ -156,7 +156,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.2"
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "84771098"
 data:
   _example: |
     ################################
@@ -1075,7 +1075,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.2"
   annotations:
-    knative.dev/example-checksum: "11674c15"
+    knative.dev/example-checksum: "67e5d2ff"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.2/2-serving-core.yaml
@@ -1138,7 +1138,7 @@ data:
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
     # If true, the request logging will be enabled.
-    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
     # will be ignored.
     logging.enable-request-log: "false"
 

--- a/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
@@ -289,7 +289,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
@@ -156,7 +156,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.3"
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "84771098"
 data:
   _example: |
     ################################
@@ -1075,7 +1075,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.17.3"
   annotations:
-    knative.dev/example-checksum: "11674c15"
+    knative.dev/example-checksum: "67e5d2ff"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
@@ -293,7 +293,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.17.3/2-serving-core.yaml
@@ -1138,7 +1138,7 @@ data:
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
     # If true, the request logging will be enabled.
-    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
     # will be ignored.
     logging.enable-request-log: "false"
 

--- a/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
@@ -1968,7 +1968,7 @@ data:
     logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
 
     # If true, the request logging will be enabled.
-    # NB: up to and including Knative version 0.18 if logging.requst-log-template is non-empty, this value
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
     # will be ignored.
     logging.enable-request-log: "false"
 

--- a/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
@@ -1104,7 +1104,7 @@ data:
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively
-    # detemine how the last pod will hang around.
+    # determine how the last pod will hang around.
     scale-to-zero-pod-retention-period: "0s"
 
     # pod-autoscaler-class specifies the default pod autoscaler class

--- a/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
@@ -967,7 +967,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.18.0"
   annotations:
-    knative.dev/example-checksum: "7b6520ae"
+    knative.dev/example-checksum: "84771098"
 data:
   _example: |
     ################################
@@ -1905,7 +1905,7 @@ metadata:
   labels:
     serving.knative.dev/release: "v0.18.0"
   annotations:
-    knative.dev/example-checksum: "11674c15"
+    knative.dev/example-checksum: "67e5d2ff"
 data:
   _example: |
     ################################

--- a/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/0.18.0/2-serving-core.yaml
@@ -1100,7 +1100,7 @@ data:
     # Scale to zero pod retention period defines the minimum amount
     # of time the last pod will remain after Autoscaler has decided to
     # scale to zero.
-    # This flag is for the situations where the pod starup is very expensive
+    # This flag is for the situations where the pod startup is very expensive
     # and the traffic is bursty (requiring smaller windows for fast action),
     # but patchy.
     # The larger of this flag and `scale-to-zero-grace-period` will effectively

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,7 @@ container specs via three optional sub-fields: `override`, `default`, and
 The optional `override` field is a mapping of container names to docker image
 names.
 
-If the container name is not unique across all of the deployments, damemonsets
+If the container name is not unique across all of the deployments, daemonsets
 and jobs, you can prefix the container name with the "parent's" name and a
 slash, e.g. `deployment/container`.
 

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -27,7 +27,7 @@ const (
 	// DependenciesInstalled is a Condition indicating that potential dependencies have
 	// been installed correctly.
 	DependenciesInstalled apis.ConditionType = "DependenciesInstalled"
-	// InstallSucceeded is a Condition indiciating that the installation of the component
+	// InstallSucceeded is a Condition indicating that the installation of the component
 	// itself has been successful.
 	InstallSucceeded apis.ConditionType = "InstallSucceeded"
 	// DeploymentsAvailable is a Condition indicating whether or not the Deployments of

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
@@ -71,7 +71,7 @@ func (es *KnativeEventingStatus) MarkInstallFailed(msg string) {
 		"Install failed with message: %s", msg)
 }
 
-// MarkDeploymentsAvailable marks the VersionMigrationEligble status as true.
+// MarkDeploymentsAvailable marks the VersionMigrationEligible status as true.
 func (es *KnativeEventingStatus) MarkDeploymentsAvailable() {
 	eventingCondSet.Manage(es).MarkTrue(DeploymentsAvailable)
 }

--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -18,8 +18,8 @@ set -o errexit
 
 # This function is used to build and publish the test images.
 # $1 - the first parameter is a string, specifying a path of the root directory of the project to run the ko command.
-# $2 - the second parameter is a string, speficying a sub-directory, where the images are built, under the root directory.
-# $3 - the third parameter is a string, speficying the tag of the images.
+# $2 - the second parameter is a string, specifying a sub-directory, where the images are built, under the root directory.
+# $3 - the third parameter is a string, specifying the tag of the images.
 function upload_test_images() {
   echo ">> Publishing test images"
   # Script needs to be executed from the root directory


### PR DESCRIPTION
@jsoref I'm only opening this PR to show you what's missing in #301 for the tests to pass (see last 2 commits).

![image](https://user-images.githubusercontent.com/3299086/96323637-40f82680-101e-11eb-8013-8098e767e78c.png)

There is a tool in https://github.com/knative/pkg/tree/master/configmap/hash-gen which generates a hash from the content of ConfigMaps to prevent people from accidentally modifying `_example` values. Whenever a change is performed to `_example` data, the hash has to be re-generated.

Because those modifications happened in the past, I would refrain from touching the historical manifests saved in the operator repo (therefore marking as "do not merge"), and instead fix the typos directly inside the serving and eventing repos so we don't carry them here in the future.

cc @houshengbo

/hold