### PR TITLE
Consolidate the used YAML dependencies to just one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/emicklei/go-restful v2.11.1+incompatible // indirect
-	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-logr/zapr v0.1.1
 	github.com/google/go-cmp v0.5.2
 	github.com/manifestival/client-go-client v0.4.0
@@ -12,7 +12,6 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/mod v0.3.0
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible

--- a/pkg/reconciler/common/resources_test.go
+++ b/pkg/reconciler/common/resources_test.go
@@ -273,6 +273,7 @@ func TestResourceRequirementsTransform(t *testing.T) {
 		Input    servingv1alpha1.KnativeServing
 		Expected map[string]v1.ResourceRequirements
 	}{}
+
 	if err := yaml.Unmarshal(testdata, &tests); err != nil {
 		t.Fatalf("Failed to unmarshal tests: %v", err)
 	}

--- a/pkg/reconciler/knativeeventing/common/defaultbroker.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker.go
@@ -19,7 +19,6 @@ package common
 import (
 	"encoding/json"
 
-	"github.com/ghodss/yaml"
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	eventingconfig "knative.dev/eventing/pkg/apis/config"
 	"knative.dev/eventing/pkg/apis/eventing"
+	"sigs.k8s.io/yaml"
 
 	eventingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )

--- a/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
+++ b/pkg/reconciler/knativeeventing/common/defaultbroker_test.go
@@ -20,11 +20,11 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
 
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 	util "knative.dev/operator/pkg/reconciler/common/testing"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -415,7 +415,6 @@ gopkg.in/alecthomas/kingpin.v2
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/yaml.v2 v2.3.0
-## explicit
 gopkg.in/yaml.v2
 # k8s.io/api v0.18.8 => k8s.io/api v0.18.8
 ## explicit


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

I opted to go with `sigs.k8s.io/yaml` because... it's from K8s and we're mangling K8s stuff so :man_shrugging: 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo 
