### PR TITLE
Drop dependency on pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/manifestival/client-go-client v0.4.0
 	github.com/manifestival/manifestival v0.6.1
-	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/mod v0.3.0

--- a/test/resources/knativeeventing.go
+++ b/test/resources/knativeeventing.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -49,7 +48,7 @@ func WaitForKnativeEventingState(clients eventingv1alpha1.KnativeEventingInterfa
 	})
 
 	if waitErr != nil {
-		return lastState, errors.Wrapf(waitErr, "KnativeEventing %s is not in desired state, got: %+v", name, lastState)
+		return lastState, fmt.Errorf("KnativeEventing %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
 	}
 	return lastState, nil
 }

--- a/test/resources/knativeserving.go
+++ b/test/resources/knativeserving.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -52,7 +51,7 @@ func WaitForKnativeServingState(clients servingv1alpha1.KnativeServingInterface,
 	})
 
 	if waitErr != nil {
-		return lastState, errors.Wrapf(waitErr, "knativeserving %s is not in desired state, got: %+v", name, lastState)
+		return lastState, fmt.Errorf("knativeserving %s is not in desired state, got: %+v: %w", name, lastState, waitErr)
 	}
 	return lastState, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -174,7 +174,6 @@ github.com/modern-go/reflect2
 # github.com/openzipkin/zipkin-go v0.2.2
 github.com/openzipkin/zipkin-go/model
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.6.0
 github.com/prometheus/client_golang/prometheus


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The functionality has made its way into the stdlib. No need to vendor a lib for it anymore.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @houshengbo 
