### PR TITLE
Preserve the env variable KO_FLAGS

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,6 +25,7 @@ function build_release() {
   echo "call build release ....................."
   local YAML_LIST="${REPO_ROOT_DIR}/.operator-temp.yaml"
   export TAG
+  export KO_FLAGS
   $(dirname $0)/generate-yamls.sh "${REPO_ROOT_DIR}" "${YAML_LIST}"
   ARTIFACTS_TO_PUBLISH=$(cat "${YAML_LIST}" | tr '\n' ' ')
   if (( ! PUBLISH_RELEASE )); then


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->
## Proposed Change

* The environment variable `KO_FLAGS` is exported in `hack/release.sh` because the values for it disappear in `hack/generate-yamls.sh`.

## Expectations from the change

* The assigned values `"-P --platform=all"` will be preserved in `hack/generate-yamls.sh`.
* The docker image `operator` for the multiple platforms will be available. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support the multi-arch docker image 
```
