### PR TITLE
[release-0.19] Create the service of knative-local-gateway under the ns istio-system

### DIFF
--- a/cmd/operator/kodata/knative-serving/0.19.0/4-net-istio.yaml
+++ b/cmd/operator/kodata/knative-serving/0.19.0/4-net-istio.yaml
@@ -123,7 +123,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: knative-local-gateway
-  namespace: knative-serving
+  namespace: istio-system
   labels:
     serving.knative.dev/release: "v0.19.0"
     networking.knative.dev/ingress-provider: istio

--- a/hack/boilerplate/boilerplate.yaml.txt
+++ b/hack/boilerplate/boilerplate.yaml.txt
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/pkg/reconciler/knativeserving/common/ingress_service.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service.go
@@ -13,3 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// IngressServiceTransform pins the namespace to istio-system for the service named knative-local-gateway.
+func IngressServiceTransform() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetAPIVersion() == "v1" && u.GetKind() == "Service" && u.GetName() == "knative-local-gateway" {
+			u.SetNamespace("istio-system")
+		}
+		return nil
+	}
+}

--- a/pkg/reconciler/knativeserving/common/ingress_service_test.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestIngressServiceTransform(t *testing.T) {
+	tests := []struct {
+		name              string
+		namespace         string
+		serviceName       string
+		expectedNamespace string
+		expected          bool
+	}{{
+		name:              "KeepKnativeIngressServiceNamespace",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway",
+		expectedNamespace: "istio-system",
+		expected:          true,
+	}, {
+		name:              "DoNotKeepKnativeIngressServiceNamespace",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway-other",
+		expectedNamespace: "istio-system",
+		expected:          false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := makeIngressService(t, tt.serviceName, tt.namespace)
+			IngressServiceTransform()(service)
+			util.AssertEqual(t, service.GetNamespace() == tt.expectedNamespace, tt.expected)
+		})
+	}
+}
+
+func makeIngressService(t *testing.T, name, ns string) *unstructured.Unstructured {
+	service := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+	}
+	result := &unstructured.Unstructured{}
+	err := scheme.Scheme.Convert(service, result, nil)
+	if err != nil {
+		t.Fatalf("Could not create unstructured Service: %v, err: %v", service, err)
+	}
+
+	return result
+}

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -125,6 +125,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		ksc.AggregationRuleTransform(manifest.Client),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
+	extra = append(extra, ksc.IngressServiceTransform())
 	return common.Transform(ctx, manifest, instance, extra...)
 }
 


### PR DESCRIPTION

* Create the service of knative-local-gateway under the ns istio-system

* Update the template

Cherry-pick of 2d4f44ad2a7ad58fe550daa953c71db4b267854b