### PR TITLE
[release-0.18] Add the transformer for pingsource to keep the env vars and replicas

### DIFF
--- a/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
+++ b/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	mf "github.com/manifestival/manifestival"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+type unstructuredGetter interface {
+	Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+}
+
+// ReplicasEnvVarsTransform keeps the number of replicas and the env vars, if the deployment
+// pingsource-mt-adapter exists in the cluster.
+func ReplicasEnvVarsTransform(client unstructuredGetter) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() == "Deployment" && u.GetName() == "pingsource-mt-adapter" {
+			currentU, err := client.Get(u)
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			apply := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(u, apply, nil); err != nil {
+				return err
+			}
+			current := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(currentU, current, nil); err != nil {
+				return err
+			}
+
+			// Keep the existing number of replicas in the cluster for the deployment
+			apply.Spec.Replicas = current.Spec.Replicas
+
+			for index := range current.Spec.Template.Spec.Containers {
+				currentContainer := current.Spec.Template.Spec.Containers[index]
+				for j := range apply.Spec.Template.Spec.Containers {
+					applyContainer := &apply.Spec.Template.Spec.Containers[j]
+					if currentContainer.Name == applyContainer.Name {
+						applyContainer.Env = currentContainer.Env
+					}
+				}
+			}
+
+			if err := scheme.Scheme.Convert(apply, u, nil); err != nil {
+				return err
+			}
+			// The zero-value timestamp defaulted by the conversion causes
+			// superfluous updates
+			u.SetCreationTimestamp(metav1.Time{})
+		}
+		return nil
+	}
+}

--- a/pkg/reconciler/knativeeventing/common/replicasenvvarstransform_test.go
+++ b/pkg/reconciler/knativeeventing/common/replicasenvvarstransform_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+)
+
+func TestPingsourceMTAadapterTransform(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Input    *unstructured.Unstructured
+		Existing *unstructured.Unstructured
+		Expected *unstructured.Unstructured
+	}{}
+	var testData = []byte(`
+- name: "existing pingsource-mt-adapter has the same number of containers, but different env vars and replicas"
+  input:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 0
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: ''
+                - name: K_LOGGING_CONFIG
+                  value: ''
+  existing:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+  expected:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+- name: "existing pingsource-mt-adapter has less containers"
+  input:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 0
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: ''
+                - name: K_LOGGING_CONFIG
+                  value: ''
+            - name: dispatcher1
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: ''
+                - name: K_LOGGING_CONFIG
+                  value: ''
+  existing:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v2
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+  expected:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v2
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+            - name: dispatcher1
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: ''
+                - name: K_LOGGING_CONFIG
+                  value: ''
+- name: "existing pingsource-mt-adapter has more containers"
+  input:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 0
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: ''
+                - name: K_LOGGING_CONFIG
+                  value: ''
+  existing:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v2
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+            - name: dispatcher1
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v2
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+  expected:
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: pingsource-mt-adapter
+      namespace: knative-eventing
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+            - name: dispatcher
+              image: gcr.io/knative-releases/knative.dev/eventing/cmd/mtping@sha256:d6b4bd0d75a67c486f36eb34534178154db81b2ee85c0b18d7ca5269b36df037
+              env:
+                - name: SYSTEM_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v2
+                      fieldPath: metadata.namespace
+                - name: K_METRICS_CONFIG
+                  value: 'test1'
+                - name: K_LOGGING_CONFIG
+                  value: 'test2'
+`)
+	err := yaml.Unmarshal(testData, &tests)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			mock := mockGetter{test.Existing}
+			transformer := ReplicasEnvVarsTransform(&mock)
+			if err := transformer(test.Input); err != nil {
+				t.Error(err)
+			}
+			got := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(test.Input, got, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			want := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(test.Expected, want, nil); err != nil {
+				t.Fatal(err)
+			}
+
+			if !cmp.Equal(got, want) {
+				t.Errorf("Not equal: (+got, -want):\n%s", cmp.Diff(got, want))
+			}
+		})
+	}
+}
+
+type mockGetter struct {
+	u *unstructured.Unstructured
+}
+
+func (m *mockGetter) Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if m.u == nil {
+		return nil, errors.NewNotFound(schema.GroupResource{}, "")
+	}
+	return m.u, nil
+}

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -121,6 +121,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 	extra := []mf.Transformer{
 		kec.DefaultBrokerConfigMapTransform(instance, logger),
 		kec.SinkBindingSelectionModeTransform(instance, logger),
+		kec.ReplicasEnvVarsTransform(manifest.Client),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Cherry-pick: eaf60c26acaa42995ff456116a274e382c5d886c

## Proposed Changes


* Add the transformer for pingsource to keep the env vars and replicas

* Add the deployment kafka-ch-dispatcher and imc-dispatcher into the transformer

* Covert into the deployment

* Refactor the transformer for the pingsource only

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

