### PR TITLE
[release-0.19] Separate serving and eventing upgrade tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -201,3 +201,62 @@ function wait_for_file() {
   done
   return 0
 }
+
+function install_previous_operator_release() {
+  install_istio || fail_test "Istio installation failed"
+  install_operator
+  install_previous_knative
+}
+
+function install_previous_knative() {
+  header "Create the custom resources for Knative of the previous version"
+  create_knative_serving ${PREVIOUS_SERVING_RELEASE_VERSION}
+  create_knative_eventing ${PREVIOUS_EVENTING_RELEASE_VERSION}
+}
+
+function create_knative_serving() {
+  version=${1}
+  echo ">> Creating the custom resource of Knative Serving:"
+  cat <<EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${TEST_NAMESPACE}
+spec:
+  version: "${version}"
+EOF
+}
+
+function create_knative_eventing() {
+  version=${1}
+  echo ">> Creating the custom resource of Knative Eventing:"
+  cat <<-EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: ${TEST_EVENTING_NAMESPACE}
+spec:
+  version: "${version}"
+EOF
+}
+
+function create_latest_custom_resource() {
+  echo ">> Creating the custom resource of Knative Serving:"
+  cat <<EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: ${TEST_NAMESPACE}
+EOF
+  echo ">> Creating the custom resource of Knative Eventing:"
+  cat <<-EOF | kubectl apply -f -
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: ${TEST_EVENTING_NAMESPACE}
+EOF
+}

--- a/test/e2e-serving-upgrade-tests.sh
+++ b/test/e2e-serving-upgrade-tests.sh
@@ -38,73 +38,30 @@ source $(dirname $0)/e2e-common.sh
 # TODO: remove when components can coexist in same namespace
 export TEST_EVENTING_NAMESPACE=knative-eventing
 
-function install_previous_operator_release() {
-  install_istio || fail_test "Istio installation failed"
-  install_operator
-  install_previous_knative
-}
-
-function install_previous_knative() {
-  header "Create the custom resources for Knative of the previous version"
-  create_knative_serving ${PREVIOUS_SERVING_RELEASE_VERSION}
-  create_knative_eventing ${PREVIOUS_EVENTING_RELEASE_VERSION}
-}
-
-function create_knative_serving() {
-  version=${1}
-  echo ">> Creating the custom resource of Knative Serving:"
-  cat <<EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: ${TEST_NAMESPACE}
-spec:
-  version: "${version}"
-EOF
-}
-
-function create_knative_eventing() {
-  version=${1}
-  echo ">> Creating the custom resource of Knative Eventing:"
-  cat <<-EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: ${TEST_EVENTING_NAMESPACE}
-spec:
-  version: "${version}"
-EOF
-}
-
-function create_latest_custom_resource() {
-  echo ">> Creating the custom resource of Knative Serving:"
-  cat <<EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-  namespace: ${TEST_NAMESPACE}
-EOF
-  echo ">> Creating the custom resource of Knative Eventing:"
-  cat <<-EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeEventing
-metadata:
-  name: knative-eventing
-  namespace: ${TEST_EVENTING_NAMESPACE}
-EOF
-}
-
 function knative_setup() {
   create_namespace
   install_previous_operator_release
+  download_knative "${KNATIVE_SERVING_REPO:-knative/serving}" serving "${KNATIVE_REPO_BRANCH}"
 }
 
 # Create test resources and images
 function test_setup() {
+  echo ">> Creating test resources (test/config/) in Knative Serving repository"
+  cd ${KNATIVE_DIR}/serving
+  for i in $(ls test/config/*.yaml); do
+    sed s/knative-serving/${TEST_NAMESPACE}/ $i | ko apply ${KO_FLAGS} -f -
+  done || return 1
+  # Disable the chaosduck deployment as in Serving upgrade prow
+  kubectl -n "${TEST_NAMESPACE}" scale deployment "chaosduck" --replicas=0 || fail_test
+
+  echo ">> Uploading test images..."
+  # We only need to build and publish two images among all the test images
+  ${OPERATOR_DIR}/test/upload-test-images.sh ${KNATIVE_DIR}/serving "test/test_images/pizzaplanetv1"
+  ${OPERATOR_DIR}/test/upload-test-images.sh ${KNATIVE_DIR}/serving "test/test_images/pizzaplanetv2"
+  ${OPERATOR_DIR}/test/upload-test-images.sh ${KNATIVE_DIR}/serving "test/test_images/autoscale"
+
   test_setup_logging
+
   echo ">> Waiting for Ingress provider to be running..."
   if [[ -n "${ISTIO_VERSION}" ]]; then
     wait_until_pods_running istio-system || return 1
@@ -121,7 +78,12 @@ function test_setup() {
   local kail_pid=$!
   # Clean up kail so it doesn't interfere with job shutting down
   add_trap "kill $kail_pid || true" EXIT
+
+  cd ${OPERATOR_DIR}
 }
+
+# This function either generate the manifest based on a branch or download the latest manifest for Knative Serving.
+# Parameter: $1 - branch name. If it is empty, download the manifest from nightly build.
 
 # Skip installing istio as an add-on
 initialize $@ --skip-istio-addon
@@ -130,20 +92,34 @@ TIMEOUT=10m
 PROBE_TIMEOUT=20m
 failed=0
 
-header "Running preupgrade tests for Knative Operator"
-go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade || fail_test=1
-
 header "Listing all the pods of the previous release"
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
+header "Running preupgrade tests for Knative Serving"
+# Go to the knative serving repo
+cd ${KNATIVE_DIR}/serving
+go_test_e2e -tags=preupgrade -timeout=${TIMEOUT} ./test/upgrade \
+  --resolvabledomain="false" "--https" || fail_test=1
+
+header "Starting prober test for serving"
+# Remove this in case we failed to clean it up in an earlier test.
+rm -f /tmp/prober-signal
+rm -f /tmp/autoscaling-signal
+rm -f /tmp/autoscaling-tbc-signal
+go_test_e2e -tags=probe -timeout=${PROBE_TIMEOUT} ./test/upgrade \
+  --resolvabledomain="false" "--https" &
+PROBER_PID_SERVING=$!
+echo "Prober PID Serving is ${PROBER_PID_SERVING}"
+
 create_latest_custom_resource
 
+# If we got this far, the operator installed Knative of the latest source code.
 header "Running tests for Knative Operator"
-
 # Run the postupgrade tests under operator
 # Operator tests here will make sure that all the Knative deployments reach the desired states and operator CR is
 # in ready state.
+cd ${OPERATOR_DIR}
 go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade \
   --preservingversion="${PREVIOUS_SERVING_RELEASE_VERSION}" --preeventingversion="${PREVIOUS_EVENTING_RELEASE_VERSION}" || failed=1
 
@@ -151,15 +127,32 @@ header "Listing all the pods of the current release"
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
 
+header "Running postupgrade tests for Knative Serving"
+# Run the postupgrade tests under serving
+cd ${KNATIVE_DIR}/serving
+go_test_e2e -tags=postupgrade -timeout=${TIMEOUT} ./test/upgrade || failed=1
+
 install_previous_knative
 
 header "Running postdowngrade tests for Knative Operator"
+cd ${OPERATOR_DIR}
 go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/downgrade \
   --preservingversion="${PREVIOUS_SERVING_RELEASE_VERSION}" --preeventingversion="${PREVIOUS_EVENTING_RELEASE_VERSION}" || failed=1
 
 header "Listing all the pods of the previous release"
 wait_until_pods_running ${TEST_NAMESPACE}
 wait_until_pods_running ${TEST_EVENTING_NAMESPACE}
+
+header "Running postdowngrade tests for Knative Serving"
+cd ${KNATIVE_DIR}/serving
+go_test_e2e -tags=postdowngrade -timeout=${TIMEOUT} ./test/upgrade \
+  --resolvabledomain="false" || fail_test
+
+echo "done" > /tmp/prober-signal
+echo "done" > /tmp/autoscaling-signal
+echo "done" > /tmp/autoscaling-tbc-signal
+header "Waiting for prober test for Knative Serving"
+wait ${PROBER_PID_SERVING} || fail_test "Prober failed"
 
 # Require that tests succeeded.
 (( failed )) && fail_test


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Cherry-pick: f1490fdcf2ebb1b77610a1034368cdc135a62851

## Proposed Changes

* Separate the upgrade tests into different build prows.