### PR TITLE
Refactor the function getLatestRelease and add the correct error message

### DIFF
--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -82,6 +82,12 @@ func InstalledManifest(instance v1alpha1.KComponent) (mf.Manifest, error) {
 func IsVersionValidMigrationEligible(instance v1alpha1.KComponent) error {
 	var err error
 	target := sanitizeSemver(TargetVersion(instance))
+	if target == "v" {
+		// If the function TargetVersion returns empty string, if means the specified target version is not available
+		// in this release to install.
+		return fmt.Errorf("target version %v is not available in this release.", instance.GetSpec().GetVersion())
+	}
+
 	if !semver.IsValid(target) {
 		return fmt.Errorf("target version %v is not in a valid semantic versioning format.", target)
 	}

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -138,10 +138,15 @@ func getVersionKey(instance v1alpha1.KComponent) string {
 func getManifestWithVersionValidation(version string, instance v1alpha1.KComponent) (mf.Manifest, error) {
 	manifestsPath := targetManifestPath(version, instance)
 	manifests, err := fetch(manifestsPath)
-	if err != nil || (len(instance.GetSpec().GetManifests()) == 0 && len(instance.GetSpec().GetAdditionalManifests()) == 0) {
+	if err != nil && (len(instance.GetSpec().GetManifests()) == 0 && len(instance.GetSpec().GetAdditionalManifests()) == 0) {
 		// If we cannot access the manifests, there is no need to check whether the versions match.
 		// If both spec.manifests and spec.additionalManifests are empty, there is no need to check whether the versions
 		// match.
+		return manifests, fmt.Errorf("The manifests of the target version %v are not available to this release.",
+			instance.GetSpec().GetVersion())
+	}
+
+	if err != nil {
 		return manifests, err
 	}
 

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -138,15 +138,14 @@ func getVersionKey(instance v1alpha1.KComponent) string {
 func getManifestWithVersionValidation(version string, instance v1alpha1.KComponent) (mf.Manifest, error) {
 	manifestsPath := targetManifestPath(version, instance)
 	manifests, err := fetch(manifestsPath)
-	if err != nil && (len(instance.GetSpec().GetManifests()) == 0 && len(instance.GetSpec().GetAdditionalManifests()) == 0) {
-		// If we cannot access the manifests, there is no need to check whether the versions match.
-		// If both spec.manifests and spec.additionalManifests are empty, there is no need to check whether the versions
-		// match.
-		return manifests, fmt.Errorf("The manifests of the target version %v are not available to this release.",
-			instance.GetSpec().GetVersion())
-	}
-
 	if err != nil {
+		if len(instance.GetSpec().GetManifests()) == 0 && len(instance.GetSpec().GetAdditionalManifests()) == 0 {
+			// If we cannot access the manifests, there is no need to check whether the versions match.
+			// If both spec.manifests and spec.additionalManifests are empty, there is no need to check whether the versions
+			// match.
+			return manifests, fmt.Errorf("The manifests of the target version %v are not available to this release.",
+				instance.GetSpec().GetVersion())
+		}
 		return manifests, err
 	}
 

--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -82,12 +82,6 @@ func InstalledManifest(instance v1alpha1.KComponent) (mf.Manifest, error) {
 func IsVersionValidMigrationEligible(instance v1alpha1.KComponent) error {
 	var err error
 	target := sanitizeSemver(TargetVersion(instance))
-	if target == "v" {
-		// If the function TargetVersion returns empty string, if means the specified target version is not available
-		// in this release to install.
-		return fmt.Errorf("target version %v is not available in this release.", instance.GetSpec().GetVersion())
-	}
-
 	if !semver.IsValid(target) {
 		return fmt.Errorf("target version %v is not in a valid semantic versioning format.", target)
 	}
@@ -325,5 +319,5 @@ func getLatestRelease(instance v1alpha1.KComponent, version string) string {
 			return val
 		}
 	}
-	return ""
+	return version
 }

--- a/pkg/reconciler/common/releases_test.go
+++ b/pkg/reconciler/common/releases_test.go
@@ -196,6 +196,46 @@ func TestTargetVersion(t *testing.T) {
 			},
 		},
 		expected: "",
+	}, {
+		name: "serving CR with major.minor version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12",
+				},
+			},
+		},
+		expected: "0.12",
+	}, {
+		name: "eventing CR with major.minor version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12",
+				},
+			},
+		},
+		expected: "0.12",
+	}, {
+		name: "serving CR with major.minor.patch version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12.0",
+				},
+			},
+		},
+		expected: "0.12.0",
+	}, {
+		name: "eventing CR with major.minor.patch version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12.1",
+				},
+			},
+		},
+		expected: "0.12.1",
 	}}
 
 	os.Setenv(KoEnvKey, koPath)
@@ -235,6 +275,46 @@ func TestGetLatestRelease(t *testing.T) {
 			},
 		},
 		expected: "0.15.0",
+	}, {
+		name: "eventing CR with the major.minor version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.13",
+				},
+			},
+		},
+		expected: "0.13",
+	}, {
+		name: "serving CR with the major.minor version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.13",
+				},
+			},
+		},
+		expected: "0.13",
+	}, {
+		name: "eventing CR with the major.minor.patch version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.13.1",
+				},
+			},
+		},
+		expected: "0.13.1",
+	}, {
+		name: "serving CR with the major.minor.patch version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.13.1",
+				},
+			},
+		},
+		expected: "0.13.1",
 	}}
 
 	os.Setenv(KoEnvKey, koPath)
@@ -551,6 +631,65 @@ func TestTargetManifest(t *testing.T) {
 		},
 		expectedNumResources: 2,
 		expectedError:        nil,
+	}, {
+		name: "knative-serving with spec.version available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.16.0",
+				},
+			},
+		},
+		expectedNumResources: 2,
+		expectedError:        nil,
+	}, {
+		name: "knative-serving with major.minor spec.version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12",
+				},
+			},
+		},
+		expectedNumResources: 0,
+		expectedError: fmt.Errorf("The manifests of the target version %v are not available to this release.",
+			"0.12"),
+	}, {
+		name: "knative-serving with major.minor.patch spec.version not available",
+		component: &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12.1",
+				},
+			},
+		},
+		expectedNumResources: 0,
+		expectedError: fmt.Errorf("The manifests of the target version %v are not available to this release.",
+			"0.12.1"),
+	}, {
+		name: "knative-eventing with major.minor spec.version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12",
+				},
+			},
+		},
+		expectedNumResources: 0,
+		expectedError: fmt.Errorf("The manifests of the target version %v are not available to this release.",
+			"0.12"),
+	}, {
+		name: "knative-eventing with major.minor.patch spec.version not available",
+		component: &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: "0.12.1",
+				},
+			},
+		},
+		expectedNumResources: 0,
+		expectedError: fmt.Errorf("The manifests of the target version %v are not available to this release.",
+			"0.12.1"),
 	}}
 
 	koPath := "testdata/kodata"

--- a/pkg/reconciler/common/stages.go
+++ b/pkg/reconciler/common/stages.go
@@ -50,6 +50,7 @@ func NoOp(context.Context, *mf.Manifest, v1alpha1.KComponent) error {
 func AppendTarget(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	m, err := TargetManifest(instance)
 	if err != nil {
+		instance.GetStatus().MarkInstallFailed(err.Error())
 		return err
 	}
 	*manifest = manifest.Append(m)


### PR DESCRIPTION
## Proposed Changes

* The func getLatestRelease returns spec.version, if spec.version is not available.
* Add error message into the CR, if the manifest is not available.
