### PR TITLE
Allow to specify build platform for test images

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -39,9 +39,17 @@ function upload_test_images() {
     tag_option="--tags $docker_tag,latest"
   fi
 
+  # If PLATFORM environment variable is specified, then images will be built for
+  # specific hardware architecture.
+  # Example of the variable values - "linux/arm64", "linux/s390x".
+  local platform=""
+  if [ -n "${PLATFORM}" ]; then
+    platform="--platform ${PLATFORM}"
+  fi
+
   # ko resolve is being used for the side-effect of publishing images,
   # so the resulting yaml produced is ignored.
-  ko resolve ${tag_option} -RBf "${image_dir}" > /dev/null
+  ko resolve ${platform} ${tag_option} -RBf "${image_dir}" > /dev/null
 }
 
 : ${KO_DOCKER_REPO:?"You must set 'KO_DOCKER_REPO', see DEVELOPMENT.md"}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This is an echo of the https://github.com/knative/eventing/pull/4763 for operator. The test images are built and uploaded without a break on other architectures by specifying a `PLATFORM` env variable.

## Proposed Changes

* Add a local variable `platform` (empty by default) which can be set by an environment variable `PLATFORM` at test/upload-test-images.sh

