### PR TITLE
Adds support for extension custom manifests

### DIFF
--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -24,6 +24,7 @@ import (
 
 // Extension enables platform-specific features
 type Extension interface {
+	Manifests() []mf.Manifest
 	Transformers(v1alpha1.KComponent) []mf.Transformer
 	Reconcile(context.Context, v1alpha1.KComponent) error
 	Finalize(context.Context, v1alpha1.KComponent) error
@@ -39,6 +40,9 @@ func NoExtension(context.Context) Extension {
 
 type nilExtension struct{}
 
+func (nilExtension) Manifests() []mf.Manifest {
+	return nil
+}
 func (nilExtension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 	return nil
 }

--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -24,7 +24,7 @@ import (
 
 // Extension enables platform-specific features
 type Extension interface {
-	Manifests() []mf.Manifest
+	Manifests(v1alpha1.KComponent) ([]mf.Manifest, error)
 	Transformers(v1alpha1.KComponent) []mf.Transformer
 	Reconcile(context.Context, v1alpha1.KComponent) error
 	Finalize(context.Context, v1alpha1.KComponent) error
@@ -40,8 +40,8 @@ func NoExtension(context.Context) Extension {
 
 type nilExtension struct{}
 
-func (nilExtension) Manifests() []mf.Manifest {
-	return nil
+func (nilExtension) Manifests(v1alpha1.KComponent) ([]mf.Manifest, error) {
+	return nil, nil
 }
 func (nilExtension) Transformers(v1alpha1.KComponent) []mf.Transformer {
 	return nil

--- a/pkg/reconciler/common/extensions_test.go
+++ b/pkg/reconciler/common/extensions_test.go
@@ -31,7 +31,7 @@ func (t TestExtension) Manifests() []mf.Manifest {
 	if err != nil {
 		return nil
 	}
-	return []mf.Manifest {manifest}
+	return []mf.Manifest{manifest}
 }
 
 func (t TestExtension) Transformers(v1alpha1.KComponent) []mf.Transformer {

--- a/pkg/reconciler/common/extensions_test.go
+++ b/pkg/reconciler/common/extensions_test.go
@@ -26,12 +26,12 @@ import (
 
 type TestExtension string
 
-func (t TestExtension) Manifests() []mf.Manifest {
+func (t TestExtension) Manifests(v1alpha1.KComponent) ([]mf.Manifest, error) {
 	manifest, err := mf.NewManifest("testdata/kodata/additional-manifests/additional-sa.yaml")
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	return []mf.Manifest{manifest}
+	return []mf.Manifest{manifest}, nil
 }
 
 func (t TestExtension) Transformers(v1alpha1.KComponent) []mf.Transformer {
@@ -83,11 +83,14 @@ func TestExtensions(t *testing.T) {
 					t.Error("Unexpected result")
 				}
 				if test.length == 1 {
-					manifest := test.platform.Manifests()[0]
-					if err := Transform(context.TODO(), &manifest, &v1alpha1.KnativeServing{}, transformers...); err != nil {
+					manifests, err := test.platform.Manifests(nil)
+					if err != nil {
 						t.Error("Unexpected result")
 					}
-					for _, r := range manifest.Resources() {
+					if err := Transform(context.TODO(), &manifests[0], &v1alpha1.KnativeServing{}, transformers...); err != nil {
+						t.Error("Unexpected result")
+					}
+					for _, r := range manifests[0].Resources() {
 						if r.GetNamespace() != string(ext.(TestExtension)) {
 							t.Error("Unexpected result")
 						}

--- a/pkg/reconciler/common/testdata/kodata/additional-manifests/additional-sa.yaml
+++ b/pkg/reconciler/common/testdata/kodata/additional-manifests/additional-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eventing-controller
+  namespace: default

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -101,7 +101,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	}
 	stages := common.Stages{
 		common.AppendTarget,
-		r.appendExtension,
+		r.appendExtensionManifests,
 		r.transform,
 		common.Install,
 		common.CheckDeployments,
@@ -133,7 +133,7 @@ func (r *Reconciler) installed(ctx context.Context, instance v1alpha1.KComponent
 	return &installed, err
 }
 
-func (r *Reconciler) appendExtension(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+func (r *Reconciler) appendExtensionManifests(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	platformManifests, err := r.extension.Manifests(instance)
 	if err != nil {
 		return err

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -106,7 +106,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 		common.CheckDeployments,
 		common.DeleteObsoleteResources(ctx, ke, r.installed),
 	}
-	manifest := r.manifest.Append(r.extension.Manifests()...)
+	platformManifests, err := r.extension.Manifests(ke)
+	if err != nil {
+		return err
+	}
+	manifest := r.manifest.Append(platformManifests...)
 	return stages.Execute(ctx, &manifest, ke)
 }
 

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -107,11 +107,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 		common.CheckDeployments,
 		common.DeleteObsoleteResources(ctx, ke, r.installed),
 	}
-	platformManifests, err := r.extension.Manifests(ke)
-	if err != nil {
-		return err
-	}
-	manifest := r.manifest.Append(platformManifests...)
+	manifest := r.manifest.Append()
 	return stages.Execute(ctx, &manifest, ke)
 }
 

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -101,6 +101,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 	}
 	stages := common.Stages{
 		common.AppendTarget,
+		r.appendExtension,
 		r.transform,
 		common.Install,
 		common.CheckDeployments,
@@ -134,4 +135,13 @@ func (r *Reconciler) installed(ctx context.Context, instance v1alpha1.KComponent
 	stages := common.Stages{common.AppendInstalled, r.transform}
 	err := stages.Execute(ctx, &installed, instance)
 	return &installed, err
+}
+
+func (r *Reconciler) appendExtension(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+	platformManifests, err := r.extension.Manifests(instance)
+	if err != nil {
+		return err
+	}
+	*manifest = manifest.Append(platformManifests...)
+	return nil
 }

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -106,7 +106,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1alpha1.KnativeEven
 		common.CheckDeployments,
 		common.DeleteObsoleteResources(ctx, ke, r.installed),
 	}
-	manifest := r.manifest.Append()
+	manifest := r.manifest.Append(r.extension.Manifests()...)
 	return stages.Execute(ctx, &manifest, ke)
 }
 

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -108,7 +108,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 		common.AppendTarget,
 		ingress.AppendTargetIngresses,
 		r.filterDisabledIngresses,
-		r.appendExtension,
+		r.appendExtensionManifests,
 		r.transform,
 		common.Install,
 		common.CheckDeployments,
@@ -148,7 +148,7 @@ func (r *Reconciler) installed(ctx context.Context, instance v1alpha1.KComponent
 	return &installed, err
 }
 
-func (r *Reconciler) appendExtension(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
+func (r *Reconciler) appendExtensionManifests(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	platformManifests, err := r.extension.Manifests(instance)
 	if err != nil {
 		return err

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -113,7 +113,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 		common.CheckDeployments,
 		common.DeleteObsoleteResources(ctx, ks, r.installed),
 	}
-	manifest := r.manifest.Append()
+	manifest := r.manifest.Append(r.extension.Manifests()...)
 	return stages.Execute(ctx, &manifest, ks)
 }
 

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -113,7 +113,11 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 		common.CheckDeployments,
 		common.DeleteObsoleteResources(ctx, ks, r.installed),
 	}
-	manifest := r.manifest.Append(r.extension.Manifests()...)
+	platformManifests, err := r.extension.Manifests(ks)
+	if err != nil {
+		return err
+	}
+	manifest := r.manifest.Append(platformManifests...)
 	return stages.Execute(ctx, &manifest, ks)
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes

* Appends manifests defined in the controller extension into the main manifested loaded by the controller.
* Why? 
Currently downstream we have a scenario where a number of [custom monitoring resources](https://github.com/openshift-knative/serverless-operator/blob/400e76da629085e45f401b69dc3cbbf9900c376c/openshift-knative-operator/cmd/operator/kodata/knative-serving/0.19.0/0-rbac-proxy.yaml) are installed along with the 
core Serving ones. Although we can ship them together with the core ones, we would like to be able to create 
a number of manifests dynamically from a resource blueprint as there is a lot of repetition in the monitoring custom resources.
Another issue is that we need to filter core resources to apply specific transformations and this requires special transformation where we need to pick a resource based on some naming convention.
* Custom resources go through the validation process along with the rest of the manifests as usual assuming the appropriate label is defined. 
* Although there is support for custom manifests at the CRD level this does not really fit into our requirements for platform specific custom resources. Afaik, that functionality was meant for loading manifests from a Knative user perspective eg. ops persona. This patch serves the vendor persona.

/cc @markusthoemmes 
