### PR TITLE
WIP: Refactor the upgrade tests and scripts for better reuse

### DIFF
--- a/test/e2e-eventing-upgrade-tests.sh
+++ b/test/e2e-eventing-upgrade-tests.sh
@@ -41,26 +41,6 @@ export E2E_UPGRADE_TESTS_SERVING_USE=false
 # FIXME(ksuszyns): remove when knative/operator#297 is fixed
 export E2E_UPGRADE_TESTS_SERVING_SCALETOZERO=false
 
-# Create test resources and images
-function test_setup() {
-  download_knative "knative/eventing" eventing "${KNATIVE_REPO_BRANCH}"
-  # Install kail if needed.
-  if ! which kail >/dev/null; then
-    bash <(curl -sfL https://raw.githubusercontent.com/boz/kail/master/godownloader.sh) -b "$GOPATH/bin"
-  fi
-
-  # Capture all logs.
-  kail >${ARTIFACTS}/k8s.log.txt &
-  local kail_pid=$!
-  # Clean up kail so it doesn't interfere with job shutting down
-  add_trap "kill $kail_pid || true" EXIT
-
-  echo ">> Publish test images for eventing"
-  ${OPERATOR_DIR}/test/upload-test-images.sh ${KNATIVE_DIR}/eventing "test/test_images"
-
-  cd ${OPERATOR_DIR}
-}
-
 # Skip installing istio as an add-on.
 initialize "$@" --skip-istio-addon
 

--- a/test/upgrade/installation/shell.go
+++ b/test/upgrade/installation/shell.go
@@ -26,6 +26,16 @@ func Base() pkgupgrade.Operation {
 	return install("OperatorWithServingEventingPreviousRelease", "install_previous_operator_release")
 }
 
+// ServingTestSetup sets up the test images for Knative Serving.
+func ServingTestSetup() pkgupgrade.Operation {
+	return install("ServingTestSetup", "serving_test_setup")
+}
+
+// EventingTestSetup sets up the test images for Knative Eventing.
+func EventingTestSetup() pkgupgrade.Operation {
+	return install("EventingTestSetup", "eventing_test_setup")
+}
+
 // LatestRelease installs Knative Serving and Eventing from the latest stable release.
 func LatestRelease() pkgupgrade.Operation {
 	return install("ServingEventingLatestRelease", "create_latest_custom_resource")

--- a/test/upgrade/upgradeeventing_test.go
+++ b/test/upgrade/upgradeeventing_test.go
@@ -49,6 +49,7 @@ func TestEventingUpgrades(t *testing.T) {
 		Installations: pkgupgrade.Installations{
 			Base: []pkgupgrade.Operation{
 				installation.Base(),
+				installation.EventingTestSetup(),
 			},
 			UpgradeWith: []pkgupgrade.Operation{
 				installation.LatestRelease(),

--- a/test/upgrade/upgradeserving_test.go
+++ b/test/upgrade/upgradeserving_test.go
@@ -44,6 +44,7 @@ func TestServingUpgrades(t *testing.T) {
 		Installations: pkgupgrade.Installations{
 			Base: []pkgupgrade.Operation{
 				installation.Base(),
+				installation.ServingTestSetup(),
 			},
 			UpgradeWith: []pkgupgrade.Operation{
 				installation.LatestRelease(),


### PR DESCRIPTION


## Proposed Changes

* The upgrade tests should have an easier way to run locally. This PR refactors the upgrade tests, so that we can run the upgrade tests locally with one one command without too many prerequisites to setup.