### PR TITLE
Change container name of the sugar-controller to support separate resource requests

### DIFF
--- a/cmd/operator/kodata/knative-eventing/0.18.0/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.0/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-      - name: controller
+      - name: sugar-controller
         image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:c1836e244b4e31c130e72de785bf7ff0d2d481ba7bef08626a7d557cd6a8dfc1
         env:
         - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.1/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.1/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:1ea3dbb1dcf05f937ed84b19a272611adfed3c96a36813b7554973f19afff695
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.2/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.2/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:05b45cca98e9632b559c6e3b11932c29e2cc26a6ce737b759258456b2b9916e6
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.3/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.3/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:c39b97f252284f964f53f6be73ffdd46bb94e1ec44b5e980d255a4c2501af9f9
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.4/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.4/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:29b0d3eaeb1a37742e88afd85371f1175fcfba3cf8e7a9c6ff3c27cd96aef89a
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.5/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.5/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:c9d90bb552afb711cd61f52d2104164c3e4365513608a3d375a3b2670a4ce76c
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.18.6/6-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.18.6/6-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:2970ebdb4b2aa68212d88680fbdf9c47a4bb80f04d721120e97c242eee60300f
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.19.0/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.19.0/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:313eabba8abd3089e563082d3b6058996c6b43e6160bc27a91e2eabaacd27949
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.19.1/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.19.1/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:5f46c612715a33afe0c04c2edd3662fc8fb41713773d4e8e4379562eae67eda3
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.19.2/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.19.2/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:eb1f9a59ca91f53cf95ebadad681774aef47835fa9ea70ec7b8acedb11bccc86
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.19.3/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.19.3/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:6219a96093c084e3aa246db0744ed88ac7e50f4ebbfa3b0a38fd5cae419b6e7f
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.19.4/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.19.4/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:9604d8f8b7233d577c3e6545f84b9ad54e2adfa39cb3931ad3a4cd1053b7f5b8
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.20.0/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.20.0/5-eventing-sugar-controller.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/sugar_controller-21e338e9b1552831f2ed555cc5c359d6@sha256:6d76309808d7881c8cab88922c03e694b81af532bd20242bb57e2adb76989441
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.20.1/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.20.1/5-eventing-sugar-controller.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       serviceAccountName: eventing-controller
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:65ba42375cd3bf33179b6fe783661a5996555147af9ad079a79dbd7b4f646ed9
           env:
             - name: CONFIG_LOGGING_NAME

--- a/cmd/operator/kodata/knative-eventing/0.21.0/5-eventing-sugar-controller.yaml
+++ b/cmd/operator/kodata/knative-eventing/0.21.0/5-eventing-sugar-controller.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: eventing-controller
       enableServiceLinks: false
       containers:
-        - name: controller
+        - name: sugar-controller
           image: gcr.io/knative-releases/knative.dev/eventing/cmd/sugar_controller@sha256:d13785d2532cc6726aa89de04e185f1a1d40dae1de60e095ba07556825beab64
           env:
             - name: CONFIG_LOGGING_NAME


### PR DESCRIPTION

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->


## Proposed Changes
This PR changes the container name of the sugar-controller Deployment from `controller` to `sugar-controller`. This enables to set separate resource requests using https://github.com/knative/operator/blob/master/docs/configuration.md#specresources. Currently, the sugar-controller and the imc-controller both share the container name `controller`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The container name of the sugar-controller Deployment changes from `controller` to `sugar-controller`
```
