### PR TITLE
Allow the update of ingress resources with spec.additionalManifests

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -106,8 +106,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1alpha1.KnativeServ
 	}
 	stages := common.Stages{
 		common.AppendTarget,
-		common.AppendAdditionalManifests,
 		ingress.AppendTargetIngresses,
+		common.AppendAdditionalManifests,
 		r.filterDisabledIngresses,
 		r.appendExtensionManifests,
 		r.transform,


### PR DESCRIPTION


Fixes #505

## Proposed Changes

* This PR changed the order to append the additional manifests, which made it possible to update the ingress resources.
* The serving CR does not provide the option to configure the knative-ingress-gateway, but customized manifests can update any resource.