### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,24 +1,8 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- houshengbo
-- jcrossley3
-- trshafer
-- evankanderson  # TOC member as backup
-- mattmoor       # TOC member as backup
-- Cynocracy
-- matzew
-- n3wscott
-- aliok
-- markusthoemmes
+- technical-oversight-committee
+- operations-writers
 
 reviewers:
-- Cynocracy
-- houshengbo
-- jcrossley3
-- trshafer
-- yu2003w
-- matzew
-- n3wscott
-- aliok
-- markusthoemmes
+- operations-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -6,21 +6,42 @@ aliases:
   autoscaling-wg-leads:
   - markusthoemmes
   - vagababov
+  autoscaling-writers:
+  - markusthoemmes
+  - vagababov
   channel-wg-leads:
   - matzew
   - slinkydeveloper
+  client-reviewers:
+  - itsmurugappan
   client-wg-leads:
   - navidshaikh
   - rhuss
   client-writers:
+  - dsimansk
+  - maximilien
   - navidshaikh
   - rhuss
   conformance-wg-leads:
   - tayarani
   conformance-writers:
   - tayarani
+  docs-reviewers:
+  - RichardJJG
+  - jonatasbaldin
+  - mpetason
+  - omerbensaadon
+  - snneji
   docs-wg-leads: []
-  docs-writers: []
+  docs-writers:
+  - abrennan89
+  - carieshmarie
+  - richieescarez
+  eventing-reviewers:
+  - aslom
+  - nlopezgi
+  - tayarani
+  - tommyreddad
   eventing-triage:
   - akashrv
   - antoineco
@@ -35,6 +56,7 @@ aliases:
   - vaikas
   eventing-writers:
   - akashrv
+  - aliok
   - antoineco
   - devguyio
   - grantr
@@ -42,6 +64,7 @@ aliases:
   - lionelvillard
   - matzew
   - n3wscott
+  - pierDipi
   - slinkydeveloper
   - vaikas
   - zhongduo
@@ -94,14 +117,53 @@ aliases:
   - knative-prow-releaser-robot
   - knative-prow-robot
   - knative-test-reporter-robot
+  networking-reviewers:
+  - JRBANCEL
+  - ZhiminXiang
+  - andrew-su
+  - arturenault
+  - markusthoemmes
+  - nak3
+  - shashwathi
+  - tcnghia
+  - vagababov
+  - yanweiguo
   networking-wg-leads:
   - ZhiminXiang
   - nak3
   - tcnghia
+  networking-writers:
+  - JRBANCEL
+  - ZhiminXiang
+  - nak3
+  - tcnghia
+  - vagababov
+  operations-reviewers:
+  - Cynocracy
+  - aliok
+  - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
+  - yu2003w
   operations-wg-leads:
   - houshengbo
   operations-writers:
+  - Cynocracy
+  - aliok
   - houshengbo
+  - jcrossley3
+  - markusthoemmes
+  - matzew
+  - n3wscott
+  - trshafer
+  productivity-reviewers:
+  - coryrc
+  - evankanderson
+  - steuhs
+  - yt3liu
   productivity-wg-leads:
   - chizhg
   - n3wscott
@@ -117,10 +179,8 @@ aliases:
   serving-writers:
   - ZhiminXiang
   - dprotaso
-  - markusthoemmes
   - nak3
   - tcnghia
-  - vagababov
   source-wg-leads:
   - lionelvillard
   - n3wscott

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -147,7 +147,6 @@ aliases:
   - matzew
   - n3wscott
   - trshafer
-  - yu2003w
   operations-wg-leads:
   - houshengbo
   operations-writers:


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
