### PR TITLE
[release-0.22] Delete the installed ingress resources only

### DIFF
--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -147,7 +147,8 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 func (r *Reconciler) installed(ctx context.Context, instance v1alpha1.KComponent) (*mf.Manifest, error) {
 	// Create new, empty manifest with valid client and logger
 	installed := r.manifest.Append()
-	stages := common.Stages{common.AppendInstalled, ingress.AppendInstalledIngresses, r.transform}
+	stages := common.Stages{common.AppendInstalled, ingress.AppendInstalledIngresses, r.filterDisabledIngresses,
+		r.transform}
 	err := stages.Execute(ctx, &installed, instance)
 	return &installed, err
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #408

## Proposed Changes
* We only need to delete the ingress resources specified by the CR. If the reconcile loop tries to delete all the ingress resources, it could run into the error that certain resources do not have the matching kind.

