### PR TITLE
Clear OwnerReferences on knative-local-gateway Service

### DIFF
--- a/pkg/reconciler/knativeserving/common/ingress_service.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service.go
@@ -22,10 +22,13 @@ import (
 )
 
 // IngressServiceTransform pins the namespace to istio-system for the service named knative-local-gateway.
+// It also removes the OwnerReference to the operator, as they are in different namespaces, which is
+// invalid in Kubernetes 1.20+.
 func IngressServiceTransform() mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetAPIVersion() == "v1" && u.GetKind() == "Service" && u.GetName() == "knative-local-gateway" {
 			u.SetNamespace("istio-system")
+			u.SetOwnerReferences(nil)
 		}
 		return nil
 	}


### PR DESCRIPTION
Kubernetes v1.20+ does not allow cross-namespace owner references
and will cause the resource to be considered invalid and will
garbage collect it.

Because the knative-local-gateway service has its namespace
changed to istio-system, it's owner reference to the operator
is invalid, and it must be removed.

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #507 

## Proposed Changes

* Remove owner references on knative-local-gateway service after changing namespace to istio-system
