### PR TITLE
Allow for all Ingresses to be disabled

### DIFF
--- a/pkg/reconciler/knativeserving/ingress/ingress_test.go
+++ b/pkg/reconciler/knativeserving/ingress/ingress_test.go
@@ -449,6 +449,25 @@ func TestFilters(t *testing.T) {
 		},
 		labels:   []string{"istio", "contour", "kourier", ""},
 		expected: []bool{true, true, true, true},
+	}, {
+		name: "Disabled All ingress",
+		instance: servingv1alpha1.KnativeServing{
+			Spec: servingv1alpha1.KnativeServingSpec{
+				Ingress: &servingv1alpha1.IngressConfigs{
+					Istio: servingv1alpha1.IstioIngressConfiguration{
+						Enabled: false,
+					},
+					Kourier: servingv1alpha1.KourierIngressConfiguration{
+						Enabled: false,
+					},
+					Contour: servingv1alpha1.ContourIngressConfiguration{
+						Enabled: false,
+					},
+				},
+			},
+		},
+		labels:   []string{"istio", "contour", "kourier", ""},
+		expected: []bool{false, false, false, true},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #568

## Proposed Changes

As per title (and as described in the issue) this allow for all ingresses to be disabled while still being able to deploy Knative Serving successfully.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed a bug where disabling all Ingresses would break the installation of Knative Serving.
```

/assign @houshengbo 
