### PR TITLE
Use deployment namespace to determine gateway namespace for Kourier

### DIFF
--- a/pkg/reconciler/knativeserving/ingress/kourier.go
+++ b/pkg/reconciler/knativeserving/ingress/kourier.go
@@ -38,13 +38,14 @@ var kourierFilter = ingressFilter("kourier")
 
 func kourierTransformers(ctx context.Context, instance *v1alpha1.KnativeServing) []mf.Transformer {
 	return []mf.Transformer{
-		replaceGWNamespace(instance),
+		replaceGWNamespace(),
 		configureGWServiceType(instance),
 	}
 }
 
-// replaceGWNamespace replace the environment variable KOURIER_GATEWAY_NAMESPACE with the namespace of the Knative Serving CR
-func replaceGWNamespace(instance *v1alpha1.KnativeServing) mf.Transformer {
+// replaceGWNamespace replace the environment variable KOURIER_GATEWAY_NAMESPACE with the
+// namespace of the deployment its set on.
+func replaceGWNamespace() mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" && u.GetName() == kourierControllerDeploymentName && hasProviderLabel(u) {
 			deployment := &appsv1.Deployment{}
@@ -57,7 +58,7 @@ func replaceGWNamespace(instance *v1alpha1.KnativeServing) mf.Transformer {
 				for j := range c.Env {
 					envVar := &c.Env[j]
 					if envVar.Name == kourierGatewayNSEnvVarKey {
-						envVar.Value = instance.GetNamespace()
+						envVar.Value = deployment.GetNamespace()
 					}
 				}
 			}

--- a/pkg/reconciler/knativeserving/ingress/kourier_test.go
+++ b/pkg/reconciler/knativeserving/ingress/kourier_test.go
@@ -89,7 +89,7 @@ func TestTransformKourierManifest(t *testing.T) {
 				}
 			}
 
-			manifest, err = manifest.Transform(replaceGWNamespace(tt.instance))
+			manifest, err = manifest.Transform(replaceGWNamespace())
 			if err != nil {
 				t.Fatalf("Failed to transform manifest: %v", err)
 			}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

In principle, this transform is equal to the transform as on `main`. The slight difference this allows is, that an extension can throw the Kourier controller (and gateway) into a different namespace, allowing this transform to still work as intended (current code would rewrite to `knative-serving` and thus break).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @nak3 @houshengbo 
