### PR TITLE
Apply high availability settings to kourier as well

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -39,6 +39,8 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
 		"networking-certmanager",
 		"networking-ns-cert",
 		"networking-istio",
+		"3scale-kourier-control",
+		"3scale-kourier-gateway",
 		"eventing-controller",
 		"sugar-controller",
 		"imc-controller",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The Kourier deployments have the ability for high-availability too, so let's apply the respective settings there too.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Kourier deployments now respect the global high-availability setting.
```

/assign @nak3 @houshengbo 
