### PR TITLE
Set the namespace of the service knative-local-gateway to the istio namespace

### DIFF
--- a/pkg/reconciler/knativeserving/common/ingress_service.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service.go
@@ -25,11 +25,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-const (
-	IstioName       = "istio"
-	ConfigIstioName = "config-istio"
-)
-
 // IngressServiceTransform pins the namespace to istio-system for the service named knative-local-gateway.
 // It also removes the OwnerReference to the operator, as they are in different namespaces, which is
 // invalid in Kubernetes 1.20+.
@@ -39,12 +34,12 @@ func IngressServiceTransform(ks *v1alpha1.KnativeServing) mf.Transformer {
 			u.SetNamespace("istio-system")
 			u.SetOwnerReferences(nil)
 			config := ks.GetSpec().GetConfig()
-			if data, ok := config[IstioName]; ok {
+			if data, ok := config["istio"]; ok {
 				UpdateNamespace(u, data, ks.GetNamespace())
 			}
 
 			// The "config-" prefix is optional
-			if data, ok := config[ConfigIstioName]; ok {
+			if data, ok := config["config-istio"]; ok {
 				UpdateNamespace(u, data, ks.GetNamespace())
 			}
 		}

--- a/pkg/reconciler/knativeserving/common/ingress_service_test.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service_test.go
@@ -65,7 +65,7 @@ func TestIngressServiceTransform(t *testing.T) {
 			},
 			Spec: servingv1alpha1.KnativeServingSpec{
 				CommonSpec: servingv1alpha1.CommonSpec{
-					Config: map[string]map[string]string{"istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
+					Config: map[string]map[string]string{"istio": {"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
 				},
 			},
 		},
@@ -82,7 +82,7 @@ func TestIngressServiceTransform(t *testing.T) {
 			},
 			Spec: servingv1alpha1.KnativeServingSpec{
 				CommonSpec: servingv1alpha1.CommonSpec{
-					Config: map[string]map[string]string{"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
+					Config: map[string]map[string]string{"config-istio": {"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
 				},
 			},
 		},
@@ -99,8 +99,8 @@ func TestIngressServiceTransform(t *testing.T) {
 			},
 			Spec: servingv1alpha1.KnativeServingSpec{
 				CommonSpec: servingv1alpha1.CommonSpec{
-					Config: map[string]map[string]string{"istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-2.svc.cluster.local"},
-						"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-3.svc.cluster.local"}},
+					Config: map[string]map[string]string{"istio": {"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-2.svc.cluster.local"},
+						"config-istio": {"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-3.svc.cluster.local"}},
 				},
 			},
 		},
@@ -117,7 +117,7 @@ func TestIngressServiceTransform(t *testing.T) {
 			},
 			Spec: servingv1alpha1.KnativeServingSpec{
 				CommonSpec: servingv1alpha1.CommonSpec{
-					Config: map[string]map[string]string{"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway"}},
+					Config: map[string]map[string]string{"config-istio": {"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway"}},
 				},
 			},
 		},

--- a/pkg/reconciler/knativeserving/common/ingress_service_test.go
+++ b/pkg/reconciler/knativeserving/common/ingress_service_test.go
@@ -21,9 +21,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	servingv1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 	util "knative.dev/operator/pkg/reconciler/common/testing"
 )
 
@@ -33,26 +33,103 @@ func TestIngressServiceTransform(t *testing.T) {
 		namespace         string
 		serviceName       string
 		expectedNamespace string
+		instance          *servingv1alpha1.KnativeServing
 		expected          bool
 	}{{
 		name:              "KeepKnativeIngressServiceNamespace",
 		namespace:         "test-namespace",
 		serviceName:       "knative-local-gateway",
 		expectedNamespace: "istio-system",
-		expected:          true,
+		instance: &servingv1alpha1.KnativeServing{
+			Spec: servingv1alpha1.KnativeServingSpec{},
+		},
+		expected: true,
 	}, {
 		name:              "DoNotKeepKnativeIngressServiceNamespace",
 		namespace:         "test-namespace",
 		serviceName:       "knative-local-gateway-other",
 		expectedNamespace: "istio-system",
-		expected:          false,
+		instance: &servingv1alpha1.KnativeServing{
+			Spec: servingv1alpha1.KnativeServingSpec{},
+		},
+		expected: false,
+	}, {
+		name:              "IstioNotUnderDefaultNS with istio",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway",
+		expectedNamespace: "istio-system-1",
+		instance: &servingv1alpha1.KnativeServing{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-instance",
+				Namespace: "test-namespace",
+			},
+			Spec: servingv1alpha1.KnativeServingSpec{
+				CommonSpec: servingv1alpha1.CommonSpec{
+					Config: map[string]map[string]string{"istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name:              "IstioNotUnderDefaultNS with config-istio",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway",
+		expectedNamespace: "istio-system-1",
+		instance: &servingv1alpha1.KnativeServing{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-instance",
+				Namespace: "test-namespace",
+			},
+			Spec: servingv1alpha1.KnativeServingSpec{
+				CommonSpec: servingv1alpha1.CommonSpec{
+					Config: map[string]map[string]string{"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-1.svc.cluster.local"}},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name:              "IstioNotUnderDefaultNS with both istio and config-istio",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway",
+		expectedNamespace: "istio-system-3",
+		instance: &servingv1alpha1.KnativeServing{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-instance",
+				Namespace: "test-namespace",
+			},
+			Spec: servingv1alpha1.KnativeServingSpec{
+				CommonSpec: servingv1alpha1.CommonSpec{
+					Config: map[string]map[string]string{"istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-2.svc.cluster.local"},
+						"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway.istio-system-3.svc.cluster.local"}},
+				},
+			},
+		},
+		expected: true,
+	}, {
+		name:              "IstioNotUnderDefaultNS with invalid config-istio data",
+		namespace:         "test-namespace",
+		serviceName:       "knative-local-gateway",
+		expectedNamespace: "istio-system",
+		instance: &servingv1alpha1.KnativeServing{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-instance",
+				Namespace: "test-namespace",
+			},
+			Spec: servingv1alpha1.KnativeServingSpec{
+				CommonSpec: servingv1alpha1.CommonSpec{
+					Config: map[string]map[string]string{"config-istio": map[string]string{"local-gateway.test-namespace.knative-local-gateway": "knative-local-gateway"}},
+				},
+			},
+		},
+		expected: true,
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service := makeIngressService(t, tt.serviceName, tt.namespace)
-			IngressServiceTransform()(service)
+			IngressServiceTransform(tt.instance)(service)
 			util.AssertEqual(t, service.GetNamespace() == tt.expectedNamespace, tt.expected)
+			util.AssertEqual(t, service.GetOwnerReferences() == nil, true)
 		})
 	}
 }

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -139,7 +139,7 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 		ksc.AggregationRuleTransform(manifest.Client),
 	}
 	extra = append(extra, r.extension.Transformers(instance)...)
-	extra = append(extra, ksc.IngressServiceTransform())
+	extra = append(extra, ksc.IngressServiceTransform(instance))
 	extra = append(extra, ingress.Transformers(ctx, instance)...)
 	return common.Transform(ctx, manifest, instance, extra...)
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #565 #586

## Proposed Changes

* Set the namespace of istio to the service knative-local-gateway based on the serving CR.