### PR TITLE
Verify the latest version against the previous version

### DIFF
--- a/test/downgrade/knative_postdowngrade_test.go
+++ b/test/downgrade/knative_postdowngrade_test.go
@@ -71,7 +71,7 @@ func TestKnativeEventingPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }
@@ -116,7 +116,7 @@ func TestKnativeServingPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,6 +263,7 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
+  sleep 5m
 }
 
 function if_version_exists() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,6 +263,11 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
+  # Operator has the issue making sure all deployments are ready before running the postupgrade
+	# tests, especially when spec.version is set to latest. Before figuring out the optimal approach,
+	# we add a timeout of 3 mins here to make sure all the deployments are up and running for the
+	# target version.
+	sleep 3m
 }
 
 function if_version_exists() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,7 +263,6 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
-  sleep 5m
 }
 
 function if_version_exists() {

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -91,31 +91,24 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 			// Currently, the network ingress resource is still specified together with the knative serving.
 			// It is possible that network ingress resource is not using the same version as knative serving.
 			// This is the reason why we skip the version checking for network ingress resource.
+			statusCheck := false
 			if val == fmt.Sprintf("v%s", version) && version != common.LATEST_VERSION {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if key == "networking.knative.dev/ingress-provider" {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if version == common.LATEST_VERSION && version == existingVersion {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if version == common.LATEST_VERSION && version != existingVersion && (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val != fmt.Sprintf("v%s", existingVersion) {
+				statusCheck = true
+			}
+
+			if statusCheck {
 				for _, c := range d.Status.Conditions {
 					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
 						return true

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -257,8 +257,8 @@ func AssertKnativeObsoleteResource(t *testing.T, clients *test.Clients, namespac
 }
 
 // AssertKnativeDeploymentStatus verifies if the Knative deployments reach the READY status.
-func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, version string, expectedDeployments []string) {
-	if err := WaitForKnativeDeploymentState(clients, namespace, version, expectedDeployments, t.Logf,
+func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, version string, existingVersion string, expectedDeployments []string) {
+	if err := WaitForKnativeDeploymentState(clients, namespace, version, existingVersion, expectedDeployments, t.Logf,
 		IsKnativeDeploymentReady); err != nil {
 		t.Fatalf("Knative Serving deployments failed to meet the expected deployments: %v", err)
 	}

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -92,7 +92,7 @@ func eventingCRPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }
@@ -136,7 +136,7 @@ func servingCRPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest.Filter(ingress.Filters(instance)))
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -80,7 +80,7 @@ func servingCRPostUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest.Filter(ingress.Filters(ks)))
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ks),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ks), test.OperatorFlags.PreviousServingVersion,
 			expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
 
@@ -130,7 +130,7 @@ func eventingCRPostUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ke),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ke), test.OperatorFlags.PreviousEventingVersion,
 			expectedDeployments)
 
 		instance := &v1alpha1.KnativeEventing{

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -73,7 +73,13 @@ func servingCRPostUpgrade(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		ks := &v1alpha1.KnativeServing{}
+		ks := &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: common.LATEST_VERSION,
+				},
+			},
+		}
 		targetManifest, err := common.TargetManifest(ks)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)
@@ -123,7 +129,13 @@ func eventingCRPostUpgrade(t *testing.T) {
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the latest release version, get the deployment resources.
-		ke := &v1alpha1.KnativeEventing{}
+		ke := &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: common.LATEST_VERSION,
+				},
+			},
+		}
 		targetManifest, err := common.TargetManifest(ke)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -90,7 +90,7 @@ func servingCRPreUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, kserving.GetStatus().GetVersion(),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, kserving.GetStatus().GetVersion(), "",
 			expectedDeployments)
 	})
 }
@@ -132,7 +132,7 @@ func eventingCRPreUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, keventing.GetStatus().GetVersion(),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, keventing.GetStatus().GetVersion(), "",
 			expectedDeployments)
 	})
 }


### PR DESCRIPTION
Fixes: #606 
Tests in preupgrade and postdowngrade do not necessarily need to verify with the previous existing version in the cluster, because their version is specific, and we can check the label based on that, but for postupgrade tests, we need to know what is in the cluster and compare it with the current target version to verify the correct deployment resource with the correct version label, especially spec.version is set to `latest`.