### PR TITLE
Add a 20-second timeout before running the post upgrade tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,10 @@ require (
 	k8s.io/apimachinery v0.19.7
 	k8s.io/client-go v0.19.7
 	k8s.io/code-generator v0.19.7
-	knative.dev/caching v0.0.0-20210602063230-bf644edb3acf
+	knative.dev/caching v0.0.0-20210602143630-65e546f333b1
 	knative.dev/eventing v0.23.1-0.20210602100130-608a7fea977d
 	knative.dev/hack v0.0.0-20210601210329-de04b70e00d0
 	knative.dev/pkg v0.0.0-20210602095030-0e61d6763dd6
-	knative.dev/serving v0.23.1-0.20210602140637-16a1f6f45be0
+	knative.dev/serving v0.23.1-0.20210602145637-966f01547a16
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1477,8 +1477,8 @@ k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 h1:0T5IaWHO3sJTEmCP6mUlBvMukxPKUQWqiI/YuiBNMiQ=
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/caching v0.0.0-20210601151938-0556e04ffb5e/go.mod h1:F+S9aum7EyVPSBUghmOh9dVg3hWNOdJYn5eZ2kh6m7I=
-knative.dev/caching v0.0.0-20210602063230-bf644edb3acf h1:uxxcMEmlXfgiyPM5gY7LI5hlD1JOp19orTQd0EDGbTU=
-knative.dev/caching v0.0.0-20210602063230-bf644edb3acf/go.mod h1:KgvB+X1PGibUXwAk6eCZeEXLlaDLuyrowobuVnuOycs=
+knative.dev/caching v0.0.0-20210602143630-65e546f333b1 h1:rdYe8oTsrLA+E+k0wjyibWw46NBsZRwo4JeQLnHb3K8=
+knative.dev/caching v0.0.0-20210602143630-65e546f333b1/go.mod h1:Bqj8FbF/a7IxYPwKjgu3ry1HDQaNTdO6q+tguYUiGaI=
 knative.dev/eventing v0.23.1-0.20210602100130-608a7fea977d h1:kFG3UkiWre/FLWFTNuAcFClPZpthP14y+1lfKuHckCs=
 knative.dev/eventing v0.23.1-0.20210602100130-608a7fea977d/go.mod h1:ufvymZ96D7UaJwwdZ+wcb5CGhgfqaRYFZc0lnOitcx4=
 knative.dev/hack v0.0.0-20210428122153-93ad9129c268/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
@@ -1494,8 +1494,8 @@ knative.dev/pkg v0.0.0-20210601151938-e6552a0303ff/go.mod h1:nOD9XjvR+UuO1fHZSaO
 knative.dev/pkg v0.0.0-20210602095030-0e61d6763dd6 h1:Z0cPPaa6ofJ4qKrMQ8XFE0z3NHuBrxK2szR1d1+7kqA=
 knative.dev/pkg v0.0.0-20210602095030-0e61d6763dd6/go.mod h1:/hT1IXHPs8ZwQ8yTJtfaYWpLmsLhC2s6/v/ydF7PoiE=
 knative.dev/reconciler-test v0.0.0-20210528174829-f667a8f5433e/go.mod h1:eT090ddGX9t191Vwt5sECwdV+jhD0vc4RPEOLrgqjoE=
-knative.dev/serving v0.23.1-0.20210602140637-16a1f6f45be0 h1:UmWriAClxDXbkeS/PKZiJXMvBJSrY9giWte6078yvdI=
-knative.dev/serving v0.23.1-0.20210602140637-16a1f6f45be0/go.mod h1:Se2tkoY60EcKvV6aOB5xpsm2Fwj53xas4saVe46tvHQ=
+knative.dev/serving v0.23.1-0.20210602145637-966f01547a16 h1:hvBwaC9n7U2Ig2iib6L3bhXUWcc+7PYLXlKzTc6QIQI=
+knative.dev/serving v0.23.1-0.20210602145637-966f01547a16/go.mod h1:Se2tkoY60EcKvV6aOB5xpsm2Fwj53xas4saVe46tvHQ=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/test/downgrade/knative_postdowngrade_test.go
+++ b/test/downgrade/knative_postdowngrade_test.go
@@ -71,7 +71,7 @@ func TestKnativeEventingPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }
@@ -116,7 +116,7 @@ func TestKnativeServingPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,6 +263,7 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
+  sleep 5m
 }
 
 function if_version_exists() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,11 +263,6 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
-  # Operator has the issue making sure all deployments are ready before running the postupgrade
-	# tests, especially when spec.version is set to latest. Before figuring out the optimal approach,
-	# we add a timeout of 20 seconds here to make sure all the deployments are up and running for the
-	# target version.
-	sleep 20s
 }
 
 function if_version_exists() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,7 +263,6 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
-  sleep 5m
 }
 
 function if_version_exists() {

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -263,6 +263,11 @@ metadata:
 spec:
   version: "${TARGET_RELEASE_VERSION}"
 EOF
+  # Operator has the issue making sure all deployments are ready before running the postupgrade
+	# tests, especially when spec.version is set to latest. Before figuring out the optimal approach,
+	# we add a timeout of 20 seconds here to make sure all the deployments are up and running for the
+	# target version.
+	sleep 20s
 }
 
 function if_version_exists() {

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -91,23 +91,53 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 			// Currently, the network ingress resource is still specified together with the knative serving.
 			// It is possible that network ingress resource is not using the same version as knative serving.
 			// This is the reason why we skip the version checking for network ingress resource.
+
+			// The parameter version means the target version of Knative component to be installed.
+			// The parameter existingVersion means the installed version of Knative component. It is set to empty, if
+			// there is no Knative installation.
 			statusCheck := false
-			if val == fmt.Sprintf("v%s", version) && version != common.LATEST_VERSION {
+
+			// When on of the following conditions is met:
+			// * spec.version is set to latest, but operator returns an actual semantic version
+			// * spec.version is set to a valid semantic version
+			// we need to verify the value of the key serving.knative.dev/release or eventing.knative.dev/release
+			// matches the version.
+			if version != common.LATEST_VERSION {
+				if (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val == fmt.Sprintf("v%s", existingVersion) {
+					statusCheck = true
+				}
 				statusCheck = true
 			}
 
+			// If the deployment resource is for ingress, we will check the status of the deployment.
 			if key == "networking.knative.dev/ingress-provider" {
 				statusCheck = true
 			}
 
+			// If spec.version is set to latest and operator bundles a directory called latest, it is possible that both
+			// the version and the existing version are latest. In this case, the knative component to be installed is the
+			// same as the existing one, and we will check the status of the deployment.
 			if version == common.LATEST_VERSION && version == existingVersion {
 				statusCheck = true
 			}
 
-			if version == common.LATEST_VERSION && version != existingVersion && (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val != fmt.Sprintf("v%s", existingVersion) {
-				statusCheck = true
+			// If spec.version is set to latest and operator bundles a directory called latest, it is possible that the
+			// version is the NOT same as the existing version. In this case, we need to look up
+			// the key serving.knative.dev/release or eventing.knative.dev/release and locate the its value, but we cannot
+			// verify by checking whether version equals to latest, because the nightly built manifests set some random
+			// commit number as the value. We can only check if the value is not equal to the existing the version, to
+			// determine the deployment has the correct version.
+			if version == common.LATEST_VERSION && version != existingVersion {
+				if (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val != fmt.Sprintf("v%s", existingVersion) {
+					statusCheck = true
+				}
 			}
 
+			// There is an exceptional case, we cannot cover.
+			// If spec.version is set to latest and operator bundles a directory called latest, it is possible that the
+			// version is the NOT same as the existing version, but the manifests contain the resources with the same semantic version.
+			// It only happens when users intentionally customize a directory called latest with the same manifests in
+			// one of the prior version. So far, the test cases do not include this scenario.
 			if statusCheck {
 				for _, c := range d.Status.Conditions {
 					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -91,31 +91,24 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 			// Currently, the network ingress resource is still specified together with the knative serving.
 			// It is possible that network ingress resource is not using the same version as knative serving.
 			// This is the reason why we skip the version checking for network ingress resource.
+			statusCheck := false
 			if val == fmt.Sprintf("v%s", version) && version != common.LATEST_VERSION {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if key == "networking.knative.dev/ingress-provider" {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if version == common.LATEST_VERSION && version == existingVersion {
-				for _, c := range d.Status.Conditions {
-					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
-						return true
-					}
-				}
+				statusCheck = true
 			}
 
 			if version == common.LATEST_VERSION && version != existingVersion && (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val != fmt.Sprintf("v%s", existingVersion) {
+				statusCheck = true
+			}
+
+			if statusCheck {
 				for _, c := range d.Status.Conditions {
 					if c.Type == v1.DeploymentAvailable && c.Status == corev1.ConditionTrue {
 						return true

--- a/test/resources/knativeresources.go
+++ b/test/resources/knativeresources.go
@@ -103,10 +103,9 @@ func IsKnativeDeploymentReady(dpList *v1.DeploymentList, expectedDeployments []s
 			// we need to verify the value of the key serving.knative.dev/release or eventing.knative.dev/release
 			// matches the version.
 			if version != common.LATEST_VERSION {
-				if (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val == fmt.Sprintf("v%s", existingVersion) {
+				if (key == "serving.knative.dev/release" || key == "eventing.knative.dev/release") && val == fmt.Sprintf("v%s", version) {
 					statusCheck = true
 				}
-				statusCheck = true
 			}
 
 			// If the deployment resource is for ingress, we will check the status of the deployment.

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -257,8 +257,8 @@ func AssertKnativeObsoleteResource(t *testing.T, clients *test.Clients, namespac
 }
 
 // AssertKnativeDeploymentStatus verifies if the Knative deployments reach the READY status.
-func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, version string, expectedDeployments []string) {
-	if err := WaitForKnativeDeploymentState(clients, namespace, version, expectedDeployments, t.Logf,
+func AssertKnativeDeploymentStatus(t *testing.T, clients *test.Clients, namespace string, version string, existingVersion string, expectedDeployments []string) {
+	if err := WaitForKnativeDeploymentState(clients, namespace, version, existingVersion, expectedDeployments, t.Logf,
 		IsKnativeDeploymentReady); err != nil {
 		t.Fatalf("Knative Serving deployments failed to meet the expected deployments: %v", err)
 	}

--- a/test/upgrade/postdowngrade.go
+++ b/test/upgrade/postdowngrade.go
@@ -92,7 +92,7 @@ func eventingCRPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }
@@ -136,7 +136,7 @@ func servingCRPostDowngrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(preManifest.Filter(ingress.Filters(instance)))
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(instance), "",
 			expectedDeployments)
 	})
 }

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	// TIMEOUT_UPGRADE specifies the timeout for Knative eventing upgrade.
-	TIMEOUT_UPGRADE = 180 * time.Second
+	// TimeoutUpgrade specifies the timeout for Knative eventing upgrade.
+	TimeoutUpgrade = 20 * time.Second
 )
 
 // OperatorPostUpgradeTests verifies the KnativeServing and KnativeEventing creation, deployment recreation, and
@@ -68,7 +68,7 @@ func EventingTimeoutForUpgrade() pkgupgrade.Operation {
 		// tests, especially when spec.version is set to latest. Before figuring out the optimal approach,
 		// we add a timeout of 20 seconds here to make sure all the deployments are up and running for the
 		// target version.
-		time.Sleep(TIMEOUT_UPGRADE)
+		time.Sleep(TimeoutUpgrade)
 	})
 }
 

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -19,6 +19,7 @@ package upgrade
 import (
 	"os"
 	"testing"
+	"time"
 
 	"knative.dev/operator/pkg/reconciler/knativeserving/ingress"
 
@@ -30,6 +31,11 @@ import (
 	"knative.dev/operator/test/client"
 	"knative.dev/operator/test/resources"
 	pkgupgrade "knative.dev/pkg/test/upgrade"
+)
+
+const (
+	// TIMEOUT_UPGRADE specifies the timeout for Knative eventing upgrade.
+	TIMEOUT_UPGRADE = 180 * time.Second
 )
 
 // OperatorPostUpgradeTests verifies the KnativeServing and KnativeEventing creation, deployment recreation, and
@@ -52,6 +58,17 @@ func ServingCRPostUpgradeTests() pkgupgrade.Operation {
 func EventingCRPostUpgradeTests() pkgupgrade.Operation {
 	return pkgupgrade.NewOperation("EventingCRPostUpgradeTests", func(c pkgupgrade.Context) {
 		eventingCRPostUpgrade(c.T)
+	})
+}
+
+// EventingTimeoutForUpgrade adds a timeout for Knative Eventing to complete the upgrade for readiness.
+func EventingTimeoutForUpgrade() pkgupgrade.Operation {
+	return pkgupgrade.NewOperation("EventingTimeoutForUpgrade", func(c pkgupgrade.Context) {
+		// Operator has the issue making sure all deployments are ready before running the postupgrade
+		// tests, especially when spec.version is set to latest. Before figuring out the optimal approach,
+		// we add a timeout of 20 seconds here to make sure all the deployments are up and running for the
+		// target version.
+		time.Sleep(TIMEOUT_UPGRADE)
 	})
 }
 

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -80,7 +80,7 @@ func servingCRPostUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest.Filter(ingress.Filters(ks)))
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ks),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ks), test.OperatorFlags.PreviousServingVersion,
 			expectedDeployments)
 		resources.AssertKSOperatorCRReadyStatus(t, clients, names)
 
@@ -130,7 +130,7 @@ func eventingCRPostUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(targetManifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ke),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, common.TargetVersion(ke), test.OperatorFlags.PreviousEventingVersion,
 			expectedDeployments)
 
 		instance := &v1alpha1.KnativeEventing{

--- a/test/upgrade/postupgrade.go
+++ b/test/upgrade/postupgrade.go
@@ -73,7 +73,13 @@ func servingCRPostUpgrade(t *testing.T) {
 		// TODO: We only verify the deployment, but we need to add other resources as well, like ServiceAccount, ClusterRoleBinding, etc.
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
-		ks := &v1alpha1.KnativeServing{}
+		ks := &v1alpha1.KnativeServing{
+			Spec: v1alpha1.KnativeServingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: common.LATEST_VERSION,
+				},
+			},
+		}
 		targetManifest, err := common.TargetManifest(ks)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)
@@ -123,7 +129,13 @@ func eventingCRPostUpgrade(t *testing.T) {
 		resources.SetKodataDir()
 		defer os.Unsetenv(common.KoEnvKey)
 		// Based on the latest release version, get the deployment resources.
-		ke := &v1alpha1.KnativeEventing{}
+		ke := &v1alpha1.KnativeEventing{
+			Spec: v1alpha1.KnativeEventingSpec{
+				CommonSpec: v1alpha1.CommonSpec{
+					Version: common.LATEST_VERSION,
+				},
+			},
+		}
 		targetManifest, err := common.TargetManifest(ke)
 		if err != nil {
 			t.Fatalf("Failed to get the manifest for Knative: %v", err)

--- a/test/upgrade/preupgrade.go
+++ b/test/upgrade/preupgrade.go
@@ -90,7 +90,7 @@ func servingCRPreUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, kserving.GetStatus().GetVersion(),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, kserving.GetStatus().GetVersion(), "",
 			expectedDeployments)
 	})
 }
@@ -132,7 +132,7 @@ func eventingCRPreUpgrade(t *testing.T) {
 		}
 		expectedDeployments := resources.GetExpectedDeployments(manifest)
 		util.AssertEqual(t, len(expectedDeployments) > 0, true)
-		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, keventing.GetStatus().GetVersion(),
+		resources.AssertKnativeDeploymentStatus(t, clients, names.Namespace, keventing.GetStatus().GetVersion(), "",
 			expectedDeployments)
 	})
 }

--- a/test/upgrade/upgradeeventing_test.go
+++ b/test/upgrade/upgradeeventing_test.go
@@ -35,6 +35,7 @@ func TestEventingUpgrades(t *testing.T) {
 				eventingupgrade.PreUpgradeTest(),
 			},
 			PostUpgrade: []pkgupgrade.Operation{
+				EventingTimeoutForUpgrade(),
 				EventingCRPostUpgradeTests(),
 				eventingupgrade.PostUpgradeTest(),
 			},

--- a/vendor/knative.dev/serving/test/e2e/e2e.go
+++ b/vendor/knative.dev/serving/test/e2e/e2e.go
@@ -36,7 +36,6 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/system"
 	pkgTest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/logstream"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -49,31 +48,13 @@ import (
 
 // Setup creates the client objects needed in the e2e tests.
 func Setup(t *testing.T) *test.Clients {
-	return SetupWithNamespace(t, test.ServingNamespace)
+	return test.Setup(t)
 }
 
 // SetupAlternativeNamespace creates the client objects needed in e2e tests
 // under the alternative namespace.
 func SetupAlternativeNamespace(t *testing.T) *test.Clients {
-	return SetupWithNamespace(t, test.AlternativeServingNamespace)
-}
-
-// SetupWithNamespace creates the client objects needed in the e2e tests under the specified namespace.
-func SetupWithNamespace(t *testing.T, namespace string) *test.Clients {
-	t.Helper()
-	pkgTest.SetupLoggingFlags()
-
-	cancel := logstream.Start(t)
-	t.Cleanup(cancel)
-
-	clients, err := test.NewClients(
-		pkgTest.Flags.Kubeconfig,
-		pkgTest.Flags.Cluster,
-		namespace)
-	if err != nil {
-		t.Fatal("Couldn't initialize clients:", err)
-	}
-	return clients
+	return test.Setup(t, test.AlternativeServingNamespace)
 }
 
 // autoscalerCM returns the current autoscaler config map deployed to the

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -982,7 +982,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/caching v0.0.0-20210602063230-bf644edb3acf
+# knative.dev/caching v0.0.0-20210602143630-65e546f333b1
 ## explicit
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
@@ -1149,7 +1149,7 @@ knative.dev/pkg/tracker
 knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
-# knative.dev/serving v0.23.1-0.20210602140637-16a1f6f45be0
+# knative.dev/serving v0.23.1-0.20210602145637-966f01547a16
 ## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1


### PR DESCRIPTION
Fixes: #606 

Also refactors some of the wait-for-ready logic in the tests in hopes to provide clearer error signals.

Picked up a new version of pkg.