### PR TITLE
Add $KO_FLAGS to e2e test

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -35,6 +35,7 @@ export SYSTEM_NAMESPACE=${TEST_NAMESPACE}
 # We will use only one namespace, when Knative supports both components can coexist under one namespace.
 export TEST_EVENTING_NAMESPACE="knative-eventing"
 export TEST_RESOURCE="knative"
+export KO_FLAGS="${KO_FLAGS:-}"
 
 # Boolean used to indicate whether to generate serving YAML based on the latest code in the branch KNATIVE_SERVING_REPO_BRANCH.
 GENERATE_SERVING_YAML=0
@@ -158,7 +159,7 @@ function install_operator() {
   download_latest_release
   header "Installing Knative operator"
   # Deploy the operator
-  ko apply -f config/
+  ko apply ${KO_FLAGS} -f config/
   wait_until_pods_running default || fail_test "Operator did not come up"
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #628 

## Proposed Changes

* Make an environment variable `$KO_FLAGS` configurable and use it for `ko apply` in `test/e2e-common.sh`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
