### PR TITLE
Make e2e test run over other networks

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,7 +29,9 @@
 source $(dirname $0)/e2e-common.sh
 
 function knative_setup() {
-  install_istio || fail_test "Istio installation failed"
+  if is_ingress_class istio; then
+    install_istio || fail_test "Istio installation failed"
+  fi
   create_namespace
   install_operator
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #629 

## Proposed Changes

* Introduce an environment `$INGRESS_CLASS`
* Toggle off the `istio` installation when the `$INGRESS_CLASS` is set to a value other than `istio.ingress.networking.knative.dev` (e.g. `kourier` or `contour`)
* Reflect the configuration on a creation of the crd `KnativeServing` in the e2e test
* Assume that the corresponding network should be installed in advance  

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
