### PR TITLE
Allow to set NodeSelector via `spec.deployments.nodeSelector`

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -99,6 +99,11 @@ spec:
                       description: The number of replicas that HA parts of the control plane will be scaled to
                       type: integer
                       minimum: 1
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector overrides nodeSelector for the deployment.
+                      type: object
               source:
                 description: The source configuration for Knative Eventing
                 properties:

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -120,6 +120,11 @@ spec:
                       description: The number of replicas that HA parts of the control plane will be scaled to
                       type: integer
                       minimum: 1
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector overrides nodeSelector for the deployment.
+                      type: object
               ingress:
                 description: The ingress configuration for Knative Serving
                 properties:

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -233,6 +233,10 @@ type DeploymentOverride struct {
 	// will be scaled to.
 	// +optional
 	Replicas int32 `json:"replicas,omitempty"`
+
+	// NodeSelector overrides nodeSelector for the deployment.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // ResourceRequirementsOverride enables the user to override any container's

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -217,6 +217,13 @@ func (in *DeploymentOverride) DeepCopyInto(out *DeploymentOverride) {
 			(*out)[key] = val
 		}
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/common/deployments_override.go
+++ b/pkg/reconciler/common/deployments_override.go
@@ -43,6 +43,7 @@ func DeploymentsTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) mf.Tr
 				replaceLabels(&override, deployment)
 				replaceAnnotations(&override, deployment)
 				replaceReplicas(&override, deployment)
+				replaceNodeSelector(&override, deployment)
 				if err := scheme.Scheme.Convert(deployment, u, nil); err != nil {
 					return err
 				}
@@ -84,5 +85,11 @@ func replaceLabels(override *v1alpha1.DeploymentOverride, deployment *appsv1.Dep
 func replaceReplicas(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
 	if override.Replicas > 0 {
 		deployment.Spec.Replicas = &override.Replicas
+	}
+}
+
+func replaceNodeSelector(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
+	if len(override.NodeSelector) > 0 {
+		deployment.Spec.Template.Spec.NodeSelector = override.NodeSelector
 	}
 }


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/5

This patch adds `spec.deployments.nodeSelector` to set nodeSelector on
each deployment.

For example, when the following CR is created,
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: ks
  namespace: knative-serving
spec:
  high-availability:
    replicas: 1
  deployments:
  - name: webhook
    nodeSelector:
      foo: ba
```

The webhook deployment has `spec.template.spec.nodeSelector`.

```
$ kubectl get deploy -n knative-serving  webhook -o jsonpath={.spec.template.spec.nodeSelector}
{"foo":"bar"}
```

/cc @houshengbo @markusthoemmes @matzew 