### PR TITLE
Install the webhooks after installing the deployments and services

### DIFF
--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -36,9 +36,13 @@ func TestInstall(t *testing.T) {
 	roleBinding := NamespacedResource("rbac.authorization.k8s.io/v1", "RoleBinding", "test", "test-role-binding")
 	clusterRole := ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRole", "test-cluster-role")
 	clusterRoleBinding := ClusterScopedResource("rbac.authorization.k8s.io/v1", "ClusterRoleBinding", "test-cluster-role-binding")
+	mutatingWebhookConfiguration := ClusterScopedResource("admissionregistration.k8s.io/v1", "MutatingWebhookConfiguration", "test-mutating-webhook-configuration")
+	validatingWebhookConfiguration := ClusterScopedResource("admissionregistration.k8s.io/v1", "ValidatingWebhookConfiguration", "test-validating-webhook-configuration")
 
 	// Deliberately mixing the order in the manifest.
 	in := []unstructured.Unstructured{
+		*mutatingWebhookConfiguration,
+		*validatingWebhookConfiguration,
 		*deployment,
 		*role,
 		*roleBinding,
@@ -52,6 +56,8 @@ func TestInstall(t *testing.T) {
 		*roleBinding.DeepCopy(),
 		*clusterRoleBinding.DeepCopy(),
 		*deployment.DeepCopy(),
+		*mutatingWebhookConfiguration.DeepCopy(),
+		*validatingWebhookConfiguration.DeepCopy(),
 	}
 
 	client := &fakeClient{}


### PR DESCRIPTION


## Proposed Changes

* The webhooks rely on the services. The webhooks can be triggered during the installation of the manifests, because CMs are installed as well. We need to make sure that the services webhooks rely on, are installed before the installation of the webhooks.
* It may lead to some issues during the upgrading, if the webhooks are installed before the services. There is a gap the webhook is updated, but the service is not available. During this time, a change on the CM can trigger the webhook, raising errors.