### PR TITLE
Drop version check for autoscaler HA

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -19,7 +19,6 @@ package common
 import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
-	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
@@ -33,8 +32,9 @@ const (
 )
 
 func haSupport(obj v1alpha1.KComponent) sets.String {
-	deploymentNames := sets.NewString(
+	return sets.NewString(
 		"controller",
+		"autoscaler",
 		"autoscaler-hpa",
 		"networking-certmanager",
 		"networking-ns-cert",
@@ -53,14 +53,6 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
 		"mt-broker-controller",
 		"pingsource-mt-adapter",
 	)
-
-	// HA for autoscaler is supported since v0.19+.
-	version := obj.GetStatus().GetVersion()
-	if semver.Compare(SanitizeSemver(version), "v0.19") >= 0 {
-		deploymentNames.Insert("autoscaler")
-	}
-
-	return deploymentNames
 }
 
 // HighAvailabilityTransform mutates configmaps and replicacounts of certain

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -34,7 +34,6 @@ func TestHighAvailabilityTransform(t *testing.T) {
 	cases := []struct {
 		name     string
 		config   *v1alpha1.HighAvailability
-		version  string
 		in       *unstructured.Unstructured
 		expected *unstructured.Unstructured
 		err      error
@@ -55,17 +54,10 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredDeployment(t, "controller"),
 		expected: makeUnstructuredDeploymentReplicas(t, "controller", 2),
 	}, {
-		name:     "HA; autoscaler after v0.19",
+		name:     "HA; autoscaler",
 		config:   makeHa(2),
-		version:  "0.19.0",
 		in:       makeUnstructuredDeployment(t, "autoscaler"),
 		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler", 2),
-	}, {
-		name:     "HA; autoscaler before v0.19",
-		config:   makeHa(2),
-		version:  "0.18.2",
-		in:       makeUnstructuredDeployment(t, "autoscaler"),
-		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler", 1), // autoscaler HA is not supported before serving v0.19.
 	}, {
 		name:     "HA; autoscaler-hpa",
 		config:   makeHa(2),
@@ -118,8 +110,6 @@ func TestHighAvailabilityTransform(t *testing.T) {
 					},
 				},
 			}
-			instance.Status.SetVersion(tc.version)
-
 			haTransform := HighAvailabilityTransform(instance, log)
 			err := haTransform(tc.in)
 


### PR DESCRIPTION
As 0.19 is before than -3 minor versions, this patch drops version check for autoscaler HA.

For the background, autoscaler HA was supported since 0.19+ and operator verifies the version.
But v0.18 or before the versions are no longer supported, this patch drops the code.