### PR TITLE
Add unsupported service type validation for Kourier

### DIFF
--- a/pkg/reconciler/knativeserving/ingress/kourier.go
+++ b/pkg/reconciler/knativeserving/ingress/kourier.go
@@ -90,6 +90,8 @@ func configureGWServiceType(instance *v1alpha1.KnativeServing) mf.Transformer {
 			switch serviceType {
 			case v1.ServiceTypeClusterIP, v1.ServiceTypeNodePort, v1.ServiceTypeLoadBalancer:
 				svc.Spec.Type = serviceType
+			case v1.ServiceTypeExternalName:
+				return fmt.Errorf("unsupported service type %q", serviceType)
 			default:
 				return fmt.Errorf("unknown service type %q", serviceType)
 			}


### PR DESCRIPTION
Add `ExternalName` to unsupported service type for Kourier Gateway service type

`LoadBalancer` (default service type) to `ExternalName` service type is not supported
as ExternalName needs the additional setting `spec.externalName`.

This patch adds more clear validation.

/cc @houshengbo @markusthoemmes 