### PR TITLE
Remove pingsource from HA scaling

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -44,7 +44,6 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
 		"imc-controller",
 		"imc-dispatcher",
 		"mt-broker-controller",
-		"pingsource-mt-adapter",
 	)
 }
 

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -81,11 +81,6 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 3),
 		expected: makeUnstructuredHPA(t, "activator", 3),
-	}, {
-		name:     "HA; pingsource-mt-adapter",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
-		expected: makeUnstructuredDeploymentReplicas(t, "pingsource-mt-adapter", 2),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

* the pingsource is scaled, based on demand, via Knative Eventing itself - Instead of hard-wired via HA config. Therefore removing form the HA apply section

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
PingSource no langer is having a replica as default. It is scaled on demand
```
