### PR TITLE
Allow to set Tolerations via `spec.deployments.tolerations`

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -104,6 +104,46 @@ spec:
                         type: string
                       description: NodeSelector overrides nodeSelector for the deployment.
                       type: object
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any
+                          taint that matches the triple <key,value,effect> using the matching
+                          operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty
+                              means match all taint effects. When specified, allowed values
+                              are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty, operator
+                              must be Exists; this combination means to match all values and
+                              all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal. Exists
+                              is equivalent to wildcard for value, so that a pod can tolerate
+                              all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the
+                              toleration (which must be of effect NoExecute, otherwise this
+                              field is ignored) tolerates the taint. By default, it is not
+                              set, which means tolerate the taint forever (do not evict).
+                              Zero and negative values will be treated as 0 (evict immediately)
+                              by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise
+                              just a regular string.
+                            type: string
+                        type: object
+                      type: array
               source:
                 description: The source configuration for Knative Eventing
                 properties:

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -125,6 +125,46 @@ spec:
                         type: string
                       description: NodeSelector overrides nodeSelector for the deployment.
                       type: object
+                    tolerations:
+                      description: If specified, the pod's tolerations.
+                      items:
+                        description: The pod this Toleration is attached to tolerates any
+                          taint that matches the triple <key,value,effect> using the matching
+                          operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match. Empty
+                              means match all taint effects. When specified, allowed values
+                              are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty, operator
+                              must be Exists; this combination means to match all values and
+                              all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal. Exists
+                              is equivalent to wildcard for value, so that a pod can tolerate
+                              all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of time the
+                              toleration (which must be of effect NoExecute, otherwise this
+                              field is ignored) tolerates the taint. By default, it is not
+                              set, which means tolerate the taint forever (do not evict).
+                              Zero and negative values will be treated as 0 (evict immediately)
+                              by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise
+                              just a regular string.
+                            type: string
+                        type: object
+                      type: array
               ingress:
                 description: The ingress configuration for Knative Serving
                 properties:

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -237,6 +237,10 @@ type DeploymentOverride struct {
 	// NodeSelector overrides nodeSelector for the deployment.
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// Tolerations overrides tolerations for the deployment.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 
 // ResourceRequirementsOverride enables the user to override any container's

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -224,6 +224,13 @@ func (in *DeploymentOverride) DeepCopyInto(out *DeploymentOverride) {
 			(*out)[key] = val
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/common/deployments_override.go
+++ b/pkg/reconciler/common/deployments_override.go
@@ -44,6 +44,7 @@ func DeploymentsTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) mf.Tr
 				replaceAnnotations(&override, deployment)
 				replaceReplicas(&override, deployment)
 				replaceNodeSelector(&override, deployment)
+				replaceTolerations(&override, deployment)
 				if err := scheme.Scheme.Convert(deployment, u, nil); err != nil {
 					return err
 				}
@@ -91,5 +92,11 @@ func replaceReplicas(override *v1alpha1.DeploymentOverride, deployment *appsv1.D
 func replaceNodeSelector(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
 	if len(override.NodeSelector) > 0 {
 		deployment.Spec.Template.Spec.NodeSelector = override.NodeSelector
+	}
+}
+
+func replaceTolerations(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
+	if len(override.Tolerations) > 0 {
+		deployment.Spec.Template.Spec.Tolerations = override.Tolerations
 	}
 }


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/5

This patch adds `spec.deployments.tolerations` to set tolerations on
each deployment.

For example, when the following CR is created,
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: ks
  namespace: knative-serving
spec:
  high-availability:
    replicas: 1

  deployments:
  - name: webhook
    tolerations:
    - effect: NoSchedule
      key: node-type
      operator: Equal
      value: production
```

The webhook deployment has `spec.template.spec.tolerations`.

```
$ kubectl get deploy webhook -o jsonpath={.spec.template.spec.tolerations}
[{"effect":"NoSchedule","key":"node-type","operator":"Equal","value":"production"}]
```

/cc @houshengbo 