### PR TITLE
Adjust maxReplicas in HPA when high-availability has larger number

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -97,7 +97,8 @@ func HighAvailabilityTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) 
 				return nil
 			}
 
-			// Increase maxReplicas to the amount that we increased.
+			// Increase maxReplicas to the amount that we increased,
+			// because we need to avoid minReplicas > maxReplicas happenning.
 			if err := unstructured.SetNestedField(u.Object, max+(replicas-min), "spec", "maxReplicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -90,7 +90,7 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		name:     "HA; adjust hpa when replicas is lerger than maxReplicas",
 		config:   makeHa(6),
 		in:       makeUnstructuredHPA(t, "activator", 2, 5),
-		expected: makeUnstructuredHPA(t, "activator", 6, 9),
+		expected: makeUnstructuredHPA(t, "activator", 6, 9), // maxReplicas is increased by max+(replicas-min) to avoid minReplicas > maxReplicas happenning.
 	}, {
 		name:     "HA; adjust hpa when minReplica is equal to maxReplicas",
 		config:   makeHa(3),

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -91,6 +91,11 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		config:   makeHa(6),
 		in:       makeUnstructuredHPA(t, "activator", 2, 5),
 		expected: makeUnstructuredHPA(t, "activator", 6, 9),
+	}, {
+		name:     "HA; adjust hpa when minReplica is equal to maxReplicas",
+		config:   makeHa(3),
+		in:       makeUnstructuredHPA(t, "activator", 2, 2),
+		expected: makeUnstructuredHPA(t, "activator", 3, 3),
 	}}
 
 	for _, tc := range cases {

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -74,13 +74,23 @@ func TestHighAvailabilityTransform(t *testing.T) {
 	}, {
 		name:     "HA; adjust hpa",
 		config:   makeHa(2),
-		in:       makeUnstructuredHPA(t, "activator", 1),
-		expected: makeUnstructuredHPA(t, "activator", 2),
+		in:       makeUnstructuredHPA(t, "activator", 1, 4),
+		expected: makeUnstructuredHPA(t, "activator", 2, 5),
 	}, {
 		name:     "HA; keep higher hpa value",
 		config:   makeHa(2),
-		in:       makeUnstructuredHPA(t, "activator", 3),
-		expected: makeUnstructuredHPA(t, "activator", 3),
+		in:       makeUnstructuredHPA(t, "activator", 3, 5),
+		expected: makeUnstructuredHPA(t, "activator", 3, 5),
+	}, {
+		name:     "HA; do nothing when replicas is equal to minReplicas",
+		config:   makeHa(2),
+		in:       makeUnstructuredHPA(t, "activator", 2, 5),
+		expected: makeUnstructuredHPA(t, "activator", 2, 5),
+	}, {
+		name:     "HA; adjust hpa when replicas is lerger than maxReplicas",
+		config:   makeHa(6),
+		in:       makeUnstructuredHPA(t, "activator", 2, 5),
+		expected: makeUnstructuredHPA(t, "activator", 6, 9),
 	}}
 
 	for _, tc := range cases {
@@ -130,13 +140,14 @@ func makeUnstructuredDeploymentReplicas(t *testing.T, name string, replicas int3
 	return result
 }
 
-func makeUnstructuredHPA(t *testing.T, name string, minReplicas int32) *unstructured.Unstructured {
+func makeUnstructuredHPA(t *testing.T, name string, minReplicas, maxReplicas int32) *unstructured.Unstructured {
 	hpa := &autoscalingv2beta1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
 			MinReplicas: &minReplicas,
+			MaxReplicas: maxReplicas,
 		},
 	}
 


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/337

When we set `high-availability` more than maxReplicas in HPA,
scale up fails.

For example, webhook has [`maxReplicas: 5`](https://github.com/knative/operator/blob/main/cmd/operator/kodata/knative-serving/0.25.0/2-serving-core.yaml#L5446),
so the limit of high-availability is currently `5` for the webhook.

This patch changes to support adjustment of the maxReplicas in HPA.

**Release Note**

```release-note
operator now adjusts maxReplicas in HPA based on `high-availability` setting.
```

/cc @houshengbo 
