### PR TITLE
Apply `high-availability` to  all deployments managed by operator

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -24,7 +24,7 @@ import (
 	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
 
-func unSupported(obj v1alpha1.KComponent) sets.String {
+func haUnSupported(obj v1alpha1.KComponent) sets.String {
 	return sets.NewString(
 		"pingsource-mt-adapter",
 	)
@@ -50,7 +50,7 @@ func HighAvailabilityTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) 
 		replicas := int64(ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" && !unSupported(obj).Has(u.GetName()) {
+		if u.GetKind() == "Deployment" && !haUnSupported(obj).Has(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -20,32 +20,8 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/sets"
 	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
-
-func haSupport(obj v1alpha1.KComponent) sets.String {
-	return sets.NewString(
-		"controller",
-		"autoscaler",
-		"autoscaler-hpa",
-		"networking-certmanager",
-		"networking-ns-cert",
-		"networking-istio",
-		"3scale-kourier-control",
-		"3scale-kourier-gateway",
-		"net-nscert-controller",
-		"net-certmanager-controller",
-		"net-istio-controller",
-		"net-kourier-controller",
-		"net-kourier-gateway",
-		"eventing-controller",
-		"sugar-controller",
-		"imc-controller",
-		"imc-dispatcher",
-		"mt-broker-controller",
-	)
-}
 
 // HighAvailabilityTransform mutates configmaps and replicacounts of certain
 // controllers when HA control plane is specified.
@@ -67,7 +43,7 @@ func HighAvailabilityTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) 
 		replicas := int64(ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" && haSupport(obj).Has(u.GetName()) {
+		if u.GetKind() == "Deployment" {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -20,8 +20,15 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
+
+func unSupported(obj v1alpha1.KComponent) sets.String {
+	return sets.NewString(
+		"pingsource-mt-adapter",
+	)
+}
 
 // HighAvailabilityTransform mutates configmaps and replicacounts of certain
 // controllers when HA control plane is specified.
@@ -43,7 +50,7 @@ func HighAvailabilityTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) 
 		replicas := int64(ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" {
+		if u.GetKind() == "Deployment" && !unSupported(obj).Has(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -47,31 +47,6 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredDeployment(t, "autoscaler"),
 		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler", 2),
 	}, {
-		name:     "HA; autoscaler-hpa",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "autoscaler-hpa"),
-		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler-hpa", 2),
-	}, {
-		name:     "HA; networking-certmanager",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "networking-certmanager"),
-		expected: makeUnstructuredDeploymentReplicas(t, "networking-certmanager", 2),
-	}, {
-		name:     "HA; networking-ns-cert",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "networking-ns-cert"),
-		expected: makeUnstructuredDeploymentReplicas(t, "networking-ns-cert", 2),
-	}, {
-		name:     "HA; networking-istio",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "networking-istio"),
-		expected: makeUnstructuredDeploymentReplicas(t, "networking-istio", 2),
-	}, {
-		name:     "HA; some-unsupported-controller",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "some-unsupported-controller"),
-		expected: makeUnstructuredDeployment(t, "some-unsupported-controller"),
-	}, {
 		name:     "HA; adjust hpa",
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 1),

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -47,6 +47,11 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredDeployment(t, "autoscaler"),
 		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler", 2),
 	}, {
+		name:     "HA; unsupported deployment",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
+		expected: makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
+	}, {
 		name:     "HA; adjust hpa",
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 1),

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -282,7 +282,7 @@ func VerifyHADeployments(t *testing.T, clients *test.Clients, names test.Resourc
 		t.Fatalf("KnativeServing %q failed to get: %v", names.KnativeServing, err)
 	}
 	ks.Spec.HighAvailability = &v1alpha1.HighAvailability{Replicas: 2}
-	ks, err = clients.KnativeServing().Update(context.TODO(), ks, metav1.UpdateOptions{})
+	_, err = clients.KnativeServing().Update(context.TODO(), ks, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
 	}
@@ -308,6 +308,11 @@ func VerifyHADeployments(t *testing.T, clients *test.Clients, names test.Resourc
 		t.Fatal("Timed out waiting on KnativeServing to delete", err)
 	}
 
+	// Get KnativeServing CR again to avoid "the object has been modified" error.
+	ks, err = clients.KnativeServing().Get(context.TODO(), names.KnativeServing, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("KnativeServing %q failed to get: %v", names.KnativeServing, err)
+	}
 	ks.Spec.HighAvailability = nil
 	_, err = clients.KnativeServing().Update(context.TODO(), ks, metav1.UpdateOptions{})
 	if err != nil {

--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -282,7 +282,7 @@ func VerifyHADeployments(t *testing.T, clients *test.Clients, names test.Resourc
 		t.Fatalf("KnativeServing %q failed to get: %v", names.KnativeServing, err)
 	}
 	ks.Spec.HighAvailability = &v1alpha1.HighAvailability{Replicas: 2}
-	_, err = clients.KnativeServing().Update(context.TODO(), ks, metav1.UpdateOptions{})
+	ks, err = clients.KnativeServing().Update(context.TODO(), ks, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("KnativeServing %q failed to update: %v", names.KnativeServing, err)
 	}
@@ -298,6 +298,7 @@ func VerifyHADeployments(t *testing.T, clients *test.Clients, names test.Resourc
 		for _, deploy := range deployments.Items {
 			if got, want := deploy.Status.Replicas, int32(2); got != want {
 				t.Logf("deployment %q: Status.Replicas = %d, want: %d", deploy.Name, got, want)
+				t.Logf("Retrying...")
 				return false, nil
 			}
 		}
@@ -323,6 +324,7 @@ func VerifyHADeployments(t *testing.T, clients *test.Clients, names test.Resourc
 		for _, deploy := range deployments.Items {
 			if got, want := deploy.Status.Replicas, int32(2); got != want {
 				t.Logf("deployment %q: Status.Replicas = %d, want: %d", deploy.Name, got, want)
+				t.Logf("Retrying...")
 				return false, nil
 			}
 		}


### PR DESCRIPTION
Fix https://github.com/knative/operator/issues/337

Currently `high-availability` does not apply to all Deployments but
deployments listed in `haSupport()` only.

All components in Knative project should support HA (please correct me
if I was wrong) and so `high-availability` should also support
all deployment's HA.

__if__  there are some components which do not support HA, we should
create `haUnSupport()` fund and add it there.

**Release Note**

```release-note
`high-availability` applies all deployments managed by operator
```

/cc @houshengbo 