### PR TITLE
Fix the error issue with installing spec.manifests

### DIFF
--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -71,7 +71,7 @@ func TargetVersion(instance v1alpha1.KComponent) string {
 func TargetManifest(instance v1alpha1.KComponent) (mf.Manifest, error) {
 	manifestsPath := targetManifestPath(instance)
 	if len(instance.GetSpec().GetManifests()) == 0 {
-		getManifestWithVersionValidation(manifestsPath, instance, FetchManifest)
+		return getManifestWithVersionValidation(manifestsPath, instance, FetchManifest)
 	}
 	return getManifestWithVersionValidation(manifestsPath, instance, fetchManifestFromPath)
 }
@@ -185,10 +185,9 @@ func getManifestWithVersionValidation(manifestsPath string, instance v1alpha1.KC
 	version := TargetVersion(instance)
 	manifests, err := fn(manifestsPath)
 	if err != nil {
-		if len(instance.GetSpec().GetManifests()) == 0 && len(instance.GetSpec().GetAdditionalManifests()) == 0 {
+		if len(instance.GetSpec().GetManifests()) == 0 {
 			// If we cannot access the manifests, there is no need to check whether the versions match.
-			// If both spec.manifests and spec.additionalManifests are empty, there is no need to check whether the versions
-			// match.
+			// If spec.manifests is empty, there is no need to check whether the versions match.
 			return manifests, fmt.Errorf("The manifests of the target version %v are not available to this release.",
 				instance.GetSpec().GetVersion())
 		}

--- a/pkg/reconciler/knativeeventing/source/source.go
+++ b/pkg/reconciler/knativeeventing/source/source.go
@@ -104,7 +104,7 @@ func AppendTargetSources(ctx context.Context, manifest *mf.Manifest, instance v1
 	}
 	if len(instance.GetSpec().GetManifests()) != 0 {
 		// If spec.manifests is not empty, it is possible that the eventing source is not available with the
-		// specified version. The user can specify the ingress link in the spec.manifests.
+		// specified version. The user can specify the eventing source link in the spec.manifests.
 		return nil
 	}
 	return err
@@ -125,7 +125,7 @@ func AppendInstalledSources(ctx context.Context, manifest *mf.Manifest, instance
 	// It is possible that the eventing source is not available with the specified version.
 	// If the user specified a version with a minor version, which is not supported by the current operator, the operator
 	// can still work, as long as spec.manifests contains all the manifest links. This function can always return nil,
-	// even if the ingress is not available.
+	// even if the eventing source is not available.
 	return nil
 }
 

--- a/pkg/reconciler/knativeeventing/source/source.go
+++ b/pkg/reconciler/knativeeventing/source/source.go
@@ -28,16 +28,11 @@ import (
 	"knative.dev/operator/pkg/reconciler/common"
 )
 
-func getSource(manifest *mf.Manifest, path string) error {
+func getSource(manifest *mf.Manifest, path string) (mf.Manifest, error) {
 	if path == "" {
-		return nil
+		return mf.Manifest{}, nil
 	}
-	m, err := common.FetchManifest(path)
-	if err != nil {
-		return err
-	}
-	*manifest = manifest.Append(m)
-	return nil
+	return common.FetchManifest(path)
 }
 
 func getSourcePath(version string, ke *v1alpha1.KnativeEventing) string {
@@ -103,7 +98,16 @@ func getSourcePath(version string, ke *v1alpha1.KnativeEventing) string {
 func AppendTargetSources(ctx context.Context, manifest *mf.Manifest, instance v1alpha1.KComponent) error {
 	version := common.TargetVersion(instance)
 	sourcePath := getSourcePath(version, convertToKE(instance))
-	return getSource(manifest, sourcePath)
+	m, err := getSource(manifest, sourcePath)
+	if err == nil {
+		*manifest = manifest.Append(m)
+	}
+	if len(instance.GetSpec().GetManifests()) != 0 {
+		// If spec.manifests is not empty, it is possible that the eventing source is not available with the
+		// specified version. The user can specify the ingress link in the spec.manifests.
+		return nil
+	}
+	return err
 }
 
 // AppendInstalledSources appends the installed manifests of the eventing sources
@@ -113,7 +117,16 @@ func AppendInstalledSources(ctx context.Context, manifest *mf.Manifest, instance
 		version = common.TargetVersion(instance)
 	}
 	sourcePath := getSourcePath(version, convertToKE(instance))
-	return getSource(manifest, sourcePath)
+	m, err := getSource(manifest, sourcePath)
+	if err == nil {
+		*manifest = manifest.Append(m)
+	}
+
+	// It is possible that the eventing source is not available with the specified version.
+	// If the user specified a version with a minor version, which is not supported by the current operator, the operator
+	// can still work, as long as spec.manifests contains all the manifest links. This function can always return nil,
+	// even if the ingress is not available.
+	return nil
 }
 
 func convertToKE(instance v1alpha1.KComponent) *v1alpha1.KnativeEventing {

--- a/pkg/reconciler/knativeeventing/source/source_test.go
+++ b/pkg/reconciler/knativeeventing/source/source_test.go
@@ -111,6 +111,16 @@ func TestAppendInstalledSources(t *testing.T) {
 		},
 		expectedIngressPath: os.Getenv(common.KoEnvKey) + "/eventing-source/empty.yaml",
 		expectedErr:         nil,
+	}, {
+		name: "Unavailable eventing source",
+		instance: eventingv1alpha1.KnativeEventing{
+			Spec: eventingv1alpha1.KnativeEventingSpec{},
+			Status: eventingv1alpha1.KnativeEventingStatus{
+				Version: "0.21",
+			},
+		},
+		expectedIngressPath: os.Getenv(common.KoEnvKey) + "/eventing-source/empty.yaml",
+		expectedErr:         nil,
 	}}
 
 	for _, tt := range tests {
@@ -216,6 +226,24 @@ func TestAppendTargetSources(t *testing.T) {
 			},
 		},
 		expectedErr: fmt.Errorf("stat testdata/kodata/eventing-source/0.12/awssqs: no such file or directory"),
+	}, {
+		name: "Unavailable target source wih spec.manifests",
+		instance: eventingv1alpha1.KnativeEventing{
+			Spec: eventingv1alpha1.KnativeEventingSpec{
+				CommonSpec: eventingv1alpha1.CommonSpec{
+					Version: "0.12.1",
+					Manifests: []eventingv1alpha1.Manifest{{
+						Url: "testdata/kodata/eventing-source/empty.yaml",
+					}},
+				},
+				Source: &eventingv1alpha1.SourceConfigs{
+					Awssqs: eventingv1alpha1.AwssqsSourceConfiguration{
+						Enabled: true,
+					},
+				},
+			},
+		},
+		expectedErr: nil,
 	}, {
 		name: "Get the latest target source when the directory latest is unavailable",
 		instance: eventingv1alpha1.KnativeEventing{

--- a/pkg/reconciler/knativeserving/ingress/ingress_test.go
+++ b/pkg/reconciler/knativeserving/ingress/ingress_test.go
@@ -60,11 +60,12 @@ func TestGetIngress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manifest, _ := mf.ManifestFrom(mf.Slice{})
-			err := getIngress(tt.version, &manifest)
+			m, err := getIngress(tt.version)
 			if err != nil {
 				util.AssertEqual(t, err.Error(), tt.expectedErr.Error())
 				util.AssertEqual(t, len(manifest.Resources()), 0)
 			} else {
+				manifest = manifest.Append(m)
 				util.AssertEqual(t, err, tt.expectedErr)
 				util.AssertEqual(t, util.DeepMatchWithPath(manifest, tt.expectedIngressPath), true)
 			}
@@ -111,7 +112,8 @@ func TestAppendInstalledIngresses(t *testing.T) {
 				Version: "0.12.1",
 			},
 		},
-		expectedErr: fmt.Errorf("stat testdata/kodata/ingress/0.12: no such file or directory"),
+		// We still return nil, even if the ingress is not available.
+		expectedErr: nil,
 	}}
 
 	for _, tt := range tests {
@@ -333,8 +335,9 @@ func TestGetIngressWithFilters(t *testing.T) {
 			targetIngressManifests, err := common.FetchManifest(tt.expectedManifestPath)
 			util.AssertEqual(t, err, nil)
 			manifest, _ := mf.ManifestFrom(mf.Slice{})
-			err = getIngress(version, &manifest)
+			m, err := getIngress(version)
 			util.AssertEqual(t, err == nil, tt.expected)
+			manifest = manifest.Append(m)
 			manifest = manifest.Filter(Filters(&tt.instance))
 			// The resources loaded with the enabled istio ingress returns exactly the same resources as we
 			// expect from the ingress yaml file.


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #741

If the spec.manifests is specified with an older version, not supported by the operator, the operator can still work by merely installing what is available in spec.manifests.