### PR TITLE
[release-0.25] Remove pingsource from HA scaling (#740)

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -51,7 +51,6 @@ func haSupport(obj v1alpha1.KComponent) sets.String {
 		"imc-controller",
 		"imc-dispatcher",
 		"mt-broker-controller",
-		"pingsource-mt-adapter",
 	)
 
 	// HA for autoscaler is supported since v0.19+.

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -101,11 +101,6 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 3),
 		expected: makeUnstructuredHPA(t, "activator", 3),
-	}, {
-		name:     "HA; pingsource-mt-adapter",
-		config:   makeHa(2),
-		in:       makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
-		expected: makeUnstructuredDeploymentReplicas(t, "pingsource-mt-adapter", 2),
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

backport of #740 to 0.25