### PR TITLE
Add the support of `spec.deployments.affinity`

### DIFF
--- a/config/300-eventing.yaml
+++ b/config/300-eventing.yaml
@@ -146,6 +146,578 @@ spec:
                             type: string
                         type: object
                       type: array
+                    affinity:
+                      description: If specified, the pod's scheduling constraints.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches all
+                                  objects with implicit weight 0 (i.e. it's a no-op). A null
+                                  preferred scheduling term matches no objects (i.e. is also
+                                  a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the
+                                      corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the corresponding
+                                      nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to an update), the system may or may not try to
+                                eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The
+                                    terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term matches
+                                      no objects. The requirements of them are ANDed. The
+                                      TopologySelectorTerm type implements a subset of the
+                                      NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate
+                            this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to a pod label update), the system may or may not
+                                try to eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding to
+                                each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g.
+                            avoid putting this pod in the same node, zone, etc. as some other
+                            pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the anti-affinity expressions specified by this
+                                field, but it may choose a node that violates one or more
+                                of the expressions. The node that is most preferred is the
+                                one with the greatest sum of weights, i.e. for each node that
+                                meets all of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field
+                                and adding "weight" to the sum if the node has pods which
+                                matches the corresponding podAffinityTerm; the node(s) with
+                                the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified by
+                                this field are not met at scheduling time, the pod will not
+                                be scheduled onto the node. If the anti-affinity requirements
+                                specified by this field cease to be met at some point during
+                                pod execution (e.g. due to a pod label update), the system
+                                may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
               source:
                 description: The source configuration for Knative Eventing
                 properties:

--- a/config/300-serving.yaml
+++ b/config/300-serving.yaml
@@ -167,6 +167,578 @@ spec:
                             type: string
                         type: object
                       type: array
+                    affinity:
+                      description: If specified, the pod's scheduling constraints.
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: An empty preferred scheduling term matches all
+                                  objects with implicit weight 0 (i.e. it's a no-op). A null
+                                  preferred scheduling term matches no objects (i.e. is also
+                                  a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with the
+                                      corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    description: Weight associated with matching the corresponding
+                                      nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to an update), the system may or may not try to
+                                eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms. The
+                                    terms are ORed.
+                                  items:
+                                    description: A null or empty node selector term matches
+                                      no objects. The requirements of them are ANDed. The
+                                      TopologySelectorTerm type implements a subset of the
+                                      NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: A node selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: An array of string values. If the
+                                                operator is In or NotIn, the values array
+                                                must be non-empty. If the operator is Exists
+                                                or DoesNotExist, the values array must be
+                                                empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will
+                                                be interpreted as an integer. This array is
+                                                replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g. co-locate
+                            this pod in the same node, zone, etc. as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the affinity expressions specified by this field,
+                                but it may choose a node that violates one or more of the
+                                expressions. The node that is most preferred is the one with
+                                the greatest sum of weights, i.e. for each node that meets
+                                all of the scheduling requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating through
+                                the elements of this field and adding "weight" to the sum
+                                if the node has pods which matches the corresponding podAffinityTerm;
+                                the node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by this
+                                field are not met at scheduling time, the pod will not be
+                                scheduled onto the node. If the affinity requirements specified
+                                by this field cease to be met at some point during pod execution
+                                (e.g. due to a pod label update), the system may or may not
+                                try to eventually evict the pod from its node. When there
+                                are multiple elements, the lists of nodes corresponding to
+                                each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules (e.g.
+                            avoid putting this pod in the same node, zone, etc. as some other
+                            pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods to nodes
+                                that satisfy the anti-affinity expressions specified by this
+                                field, but it may choose a node that violates one or more
+                                of the expressions. The node that is most preferred is the
+                                one with the greatest sum of weights, i.e. for each node that
+                                meets all of the scheduling requirements (resource request,
+                                requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field
+                                and adding "weight" to the sum if the node has pods which
+                                matches the corresponding podAffinityTerm; the node(s) with
+                                the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label
+                                              selector requirements. The requirements are
+                                              ANDed.
+                                            items:
+                                              description: A label selector requirement is
+                                                a selector that contains values, a key, and
+                                                an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the
+                                                    selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's
+                                                    relationship to a set of values. Valid
+                                                    operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string
+                                                    values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If
+                                                    the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array
+                                                    is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator is "In",
+                                              and the values array contains only "value".
+                                              The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the pods
+                                          matching the labelSelector in the specified namespaces,
+                                          where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches
+                                          that of any node on which any of the selected pods
+                                          is running. Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    description: weight associated with matching the corresponding
+                                      podAffinityTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified by
+                                this field are not met at scheduling time, the pod will not
+                                be scheduled onto the node. If the anti-affinity requirements
+                                specified by this field cease to be met at some point during
+                                pod execution (e.g. due to a pod label update), the system
+                                may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding
+                                to each podAffinityTerm are intersected, i.e. all terms must
+                                be satisfied.
+                              items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s)) that
+                                  this pod should be co-located (affinity) or not co-located
+                                  (anti-affinity) with, where co-located is defined as running
+                                  on a node whose value of the label with key <topologyKey>
+                                  matches that of any node on which a pod of the set of pods
+                                  is running
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources, in
+                                      this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector
+                                          requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector
+                                            that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship
+                                                to a set of values. Valid operators are In,
+                                                NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values.
+                                                If the operator is In or NotIn, the values
+                                                array must be non-empty. If the operator is
+                                                Exists or DoesNotExist, the values array must
+                                                be empty. This array is replaced during a
+                                                strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs.
+                                          A single {key,value} in the matchLabels map is equivalent
+                                          to an element of matchExpressions, whose key field
+                                          is "key", the operator is "In", and the values array
+                                          contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces the
+                                      labelSelector applies to (matches against); null or
+                                      empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where
+                                      co-located is defined as running on a node whose value
+                                      of the label with key topologyKey matches that of any
+                                      node on which any of the selected pods is running. Empty
+                                      topologyKey is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
               ingress:
                 description: The ingress configuration for Knative Serving
                 properties:

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	k8s.io/client-go v0.21.4
 	k8s.io/code-generator v0.21.4
 	knative.dev/caching v0.0.0-20210914230307-0184eb914a42
-	knative.dev/eventing v0.25.1-0.20210915130608-20ec9f72595d
+	knative.dev/eventing v0.25.1-0.20210915174008-cf630edf519b
 	knative.dev/hack v0.0.0-20210806075220-815cd312d65c
 	knative.dev/pkg v0.0.0-20210914164111-4857ab6939e3
-	knative.dev/serving v0.25.1-0.20210915101108-8f8b7015b254
+	knative.dev/serving v0.25.1-0.20210915204539-583b182f1dfb
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1887,8 +1887,8 @@ k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 h1:0T5IaWHO3sJTEmCP6mUlBvMukxPKU
 k8s.io/utils v0.0.0-20210111153108-fddb29f9d009/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/caching v0.0.0-20210914230307-0184eb914a42 h1:F6EdQ4iawrOVlp7QSgzcIbxa4kH7B3VouKXbiWFyNzk=
 knative.dev/caching v0.0.0-20210914230307-0184eb914a42/go.mod h1:bGtv+kY2eDR7VJMUEKMzSeLhsVyoeiXrxv4RvOTb7Jw=
-knative.dev/eventing v0.25.1-0.20210915130608-20ec9f72595d h1:HA7CMKzw2gHNbszsNlIty1cH6t61rMYDS/UktZ3pyKI=
-knative.dev/eventing v0.25.1-0.20210915130608-20ec9f72595d/go.mod h1:A1IFWue5ck8v7fyolboKS/f2ijo8o/qiewmX/anQXNo=
+knative.dev/eventing v0.25.1-0.20210915174008-cf630edf519b h1:ZCYIOek0npEZhz1nGQYk5frC+ujjnypnbEXNd5NuRj8=
+knative.dev/eventing v0.25.1-0.20210915174008-cf630edf519b/go.mod h1:E2J5BSHDbTKfd6LccJ4bS9sLDD/ZY81npEStJ8RSPdM=
 knative.dev/hack v0.0.0-20210622141627-e28525d8d260/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/hack v0.0.0-20210806075220-815cd312d65c h1:nOXoDWAAItwr4o0dp3nHr6skgpVD4IvME/UX84YNl5k=
 knative.dev/hack v0.0.0-20210806075220-815cd312d65c/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
@@ -1896,12 +1896,11 @@ knative.dev/hack/schema v0.0.0-20210806075220-815cd312d65c/go.mod h1:ffjwmdcrH5v
 knative.dev/networking v0.0.0-20210914225408-69ad45454096 h1:Zo8WfetGtm4YPtex9Wo5FQbMNvTAMVuvnlZtWcZZFm0=
 knative.dev/networking v0.0.0-20210914225408-69ad45454096/go.mod h1:nQnVhVss/mFwL6E52vS01Qo0j9/mHTi9UUoETx8BRF0=
 knative.dev/pkg v0.0.0-20210803160015-21eb4c167cc5/go.mod h1:RPk5txNA3apR9X40D4MpUOP9/VqOG8CrtABWfOwGVS4=
-knative.dev/pkg v0.0.0-20210909165259-d4505c660535/go.mod h1:jMSqkNMsrzuy+XR4Yr/BMy7SDVbUOl3KKB6+5MR+ZU8=
 knative.dev/pkg v0.0.0-20210914164111-4857ab6939e3 h1:45c2VIOBQP6jpRj+pEyciuzTmBwbZpv8jBfBEf/B5oM=
 knative.dev/pkg v0.0.0-20210914164111-4857ab6939e3/go.mod h1:jMSqkNMsrzuy+XR4Yr/BMy7SDVbUOl3KKB6+5MR+ZU8=
 knative.dev/reconciler-test v0.0.0-20210820180205-a25de6a08087/go.mod h1:+Kovy+G5zXZNcuO/uB+zfo37vFKZzsLIlWezt/nKMz0=
-knative.dev/serving v0.25.1-0.20210915101108-8f8b7015b254 h1:15vPoDidAq2arMzEArIwqlNcaVDvQo4a/3x6VU1Sq6A=
-knative.dev/serving v0.25.1-0.20210915101108-8f8b7015b254/go.mod h1:eF/IloQeeYbP9+Zp33F/K9Vmy1Qjika8un91sQ1YMPE=
+knative.dev/serving v0.25.1-0.20210915204539-583b182f1dfb h1:LCePN8jib2s6fObs7Unsyeeg0GKwcVd3SICmmvhwvMc=
+knative.dev/serving v0.25.1-0.20210915204539-583b182f1dfb/go.mod h1:eF/IloQeeYbP9+Zp33F/K9Vmy1Qjika8un91sQ1YMPE=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 pgregory.net/rapid v0.3.3 h1:jCjBsY4ln4Atz78QoBWxUEvAHaFyNDQg9+WU62aCn1U=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=

--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -129,7 +129,7 @@ type CommonSpec struct {
 	// +optional
 	Resources []ResourceRequirementsOverride `json:"resources,omitempty"`
 
-	// DeploymentOverride overrides Deploymeet configurations such as resources and replicas.
+	// DeploymentOverride overrides Deployment configurations such as resources and replicas.
 	// +optional
 	DeploymentOverride []DeploymentOverride `json:"deployments,omitempty"`
 
@@ -241,6 +241,10 @@ type DeploymentOverride struct {
 	// Tolerations overrides tolerations for the deployment.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Affinities overrides affinity for the deployment.
+	// +optional
+	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 }
 
 // ResourceRequirementsOverride enables the user to override any container's

--- a/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.deepcopy.go
@@ -231,6 +231,11 @@ func (in *DeploymentOverride) DeepCopyInto(out *DeploymentOverride) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(v1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/common/deployments_override.go
+++ b/pkg/reconciler/common/deployments_override.go
@@ -45,6 +45,7 @@ func DeploymentsTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) mf.Tr
 				replaceReplicas(&override, deployment)
 				replaceNodeSelector(&override, deployment)
 				replaceTolerations(&override, deployment)
+				replaceAffinities(&override, deployment)
 				if err := scheme.Scheme.Convert(deployment, u, nil); err != nil {
 					return err
 				}
@@ -98,5 +99,11 @@ func replaceNodeSelector(override *v1alpha1.DeploymentOverride, deployment *apps
 func replaceTolerations(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
 	if len(override.Tolerations) > 0 {
 		deployment.Spec.Template.Spec.Tolerations = override.Tolerations
+	}
+}
+
+func replaceAffinities(override *v1alpha1.DeploymentOverride, deployment *appsv1.Deployment) {
+	if override.Affinity != nil {
+		deployment.Spec.Template.Spec.Affinity = override.Affinity
 	}
 }

--- a/vendor/knative.dev/serving/pkg/apis/serving/k8s_validation.go
+++ b/vendor/knative.dev/serving/pkg/apis/serving/k8s_validation.go
@@ -331,8 +331,8 @@ func ValidatePodSpec(ctx context.Context, ps corev1.PodSpec) *apis.FieldError {
 		errs = errs.Also(validateContainers(ctx, ps.Containers, volumes))
 	}
 	if ps.ServiceAccountName != "" {
-		for range validation.IsDNS1123Subdomain(ps.ServiceAccountName) {
-			errs = errs.Also(apis.ErrInvalidValue(ps.ServiceAccountName, "serviceAccountName"))
+		for _, err := range validation.IsDNS1123Subdomain(ps.ServiceAccountName) {
+			errs = errs.Also(apis.ErrInvalidValue(ps.ServiceAccountName, "serviceAccountName", err))
 		}
 	}
 	return errs

--- a/vendor/knative.dev/serving/test/v1/route.go
+++ b/vendor/knative.dev/serving/test/v1/route.go
@@ -54,6 +54,22 @@ func Route(names test.ResourceNames, fopt ...rtesting.RouteOption) *v1.Route {
 	return route
 }
 
+// GetRoute gets a route by name
+func GetRoute(clients *test.Clients, routeName string) (route *v1.Route, err error) {
+	return route, reconciler.RetryTestErrors(func(int) (err error) {
+		route, err = clients.ServingClient.Routes.Get(context.Background(), routeName, metav1.GetOptions{})
+		return err
+	})
+}
+
+// GetRoutes returns all the available routes
+func GetRoutes(clients *test.Clients) (list *v1.RouteList, err error) {
+	return list, reconciler.RetryTestErrors(func(int) (err error) {
+		list, err = clients.ServingClient.Routes.List(context.Background(), metav1.ListOptions{})
+		return err
+	})
+}
+
 // CreateRoute creates a route in the given namespace using the route name in names
 func CreateRoute(t testing.TB, clients *test.Clients, names test.ResourceNames, fopt ...rtesting.RouteOption) (rt *v1.Route, err error) {
 	route := Route(names, fopt...)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1039,7 +1039,7 @@ k8s.io/utils/trace
 ## explicit
 knative.dev/caching/pkg/apis/caching
 knative.dev/caching/pkg/apis/caching/v1alpha1
-# knative.dev/eventing v0.25.1-0.20210915130608-20ec9f72595d
+# knative.dev/eventing v0.25.1-0.20210915174008-cf630edf519b
 ## explicit
 knative.dev/eventing/pkg/apis/config
 knative.dev/eventing/pkg/apis/duck
@@ -1205,7 +1205,7 @@ knative.dev/pkg/unstructured
 knative.dev/pkg/version
 knative.dev/pkg/webhook
 knative.dev/pkg/webhook/certificates/resources
-# knative.dev/serving v0.25.1-0.20210915101108-8f8b7015b254
+# knative.dev/serving v0.25.1-0.20210915204539-583b182f1dfb
 ## explicit
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/5

This patch adds `spec.deployments.affinity` to set affinity on each deployment.