### PR TITLE
Revert "Remove pingsource-mt-adapter from the list of unsupported HA 

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -20,8 +20,15 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	v1alpha1 "knative.dev/operator/pkg/apis/operator/v1alpha1"
 )
+
+func haUnSupported(obj v1alpha1.KComponent) sets.String {
+	return sets.NewString(
+		"pingsource-mt-adapter",
+	)
+}
 
 // HighAvailabilityTransform mutates configmaps and replicacounts of certain
 // controllers when HA control plane is specified.
@@ -43,7 +50,7 @@ func HighAvailabilityTransform(obj v1alpha1.KComponent, log *zap.SugaredLogger) 
 		replicas := int64(ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" {
+		if u.GetKind() == "Deployment" && !haUnSupported(obj).Has(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -47,6 +47,11 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredDeployment(t, "autoscaler"),
 		expected: makeUnstructuredDeploymentReplicas(t, "autoscaler", 2),
 	}, {
+		name:     "HA; unsupported deployment",
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
+		expected: makeUnstructuredDeployment(t, "pingsource-mt-adapter"),
+	}, {
 		name:     "HA; adjust hpa",
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 1, 4),


### PR DESCRIPTION
Reverting #788


Reverting because

* When installed via the operator, the PingSource MT deployment's `replica` is set to what ever the `KnativeEventing.Spec.HA.replica` is. However this conflicts with MT-adapter being started "on demand"...
(either eventing-controller should control its replicas, or the operator should, **NOT** both  (or, at least one of them needs to be cool about the other one... ))

* Metrics issues: With no PingSource created (like, after a fresh installation), the pingsource-mt-adapter is running with invalid metrics configuration. The problem with the evns was then when the operator scaled the deployments up before there ever was any PingSource, there was nothing that would configure stuff like K_METRICS_CONFIG  ... (as the eventing-controller only configured those when it reconciled PingSources... so if there are none, the pingsource adapter will be running with empty K_METRICS_CONFIG...


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
MT-Pingsource adapter is not affected by setting from KnativeEventing.Spec.HA.replica
```
