### PR TITLE
Pass controller to extensions to be able to setup new handlers

### DIFF
--- a/pkg/reconciler/common/extensions.go
+++ b/pkg/reconciler/common/extensions.go
@@ -20,6 +20,7 @@ import (
 
 	mf "github.com/manifestival/manifestival"
 	"knative.dev/operator/pkg/apis/operator/v1alpha1"
+	"knative.dev/pkg/controller"
 )
 
 // Extension enables platform-specific features
@@ -31,10 +32,10 @@ type Extension interface {
 }
 
 // ExtensionGenerator creates an Extension from a Context
-type ExtensionGenerator func(context.Context) Extension
+type ExtensionGenerator func(context.Context, *controller.Impl) Extension
 
 // NoPlatform "generates" a NilExtension
-func NoExtension(context.Context) Extension {
+func NoExtension(context.Context, *controller.Impl) Extension {
 	return nilExtension{}
 }
 

--- a/pkg/reconciler/common/extensions_test.go
+++ b/pkg/reconciler/common/extensions_test.go
@@ -67,7 +67,7 @@ func TestExtensions(t *testing.T) {
 		length:   0,
 	}, {
 		name:     "no path",
-		platform: NoExtension(context.TODO()),
+		platform: NoExtension(context.TODO(), nil),
 		length:   0,
 	}}
 

--- a/pkg/reconciler/knativeeventing/controller.go
+++ b/pkg/reconciler/knativeeventing/controller.go
@@ -59,10 +59,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),
-			extension:         generator(ctx),
 			manifest:          manifest,
 		}
 		impl := knereconciler.NewImpl(ctx, c)
+		c.extension = generator(ctx, impl)
 
 		logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/knativeserving/controller.go
+++ b/pkg/reconciler/knativeserving/controller.go
@@ -59,10 +59,10 @@ func NewExtendedController(generator common.ExtensionGenerator) injection.Contro
 		c := &Reconciler{
 			kubeClientSet:     kubeClient,
 			operatorClientSet: operatorclient.Get(ctx),
-			extension:         generator(ctx),
 			manifest:          manifest,
 		}
 		impl := knsreconciler.NewImpl(ctx, c)
+		c.extension = generator(ctx, impl)
 
 		logger.Info("Setting up event handlers")
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

As per title, by passing controllers to the extensions we allow each extension to setup new informers for resources they may be creating during their reconcilation.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Extensions can now setup handlers.
```
