### PR TITLE
Make network layer consistent throughout e2e-test

### DIFF
--- a/test/resources/verify.go
+++ b/test/resources/verify.go
@@ -65,14 +65,14 @@ func KSOperatorCRVerifyConfiguration(t *testing.T, clients *test.Clients, names 
 	// Delete a single key/value pair
 	verifySingleKeyDeletion(t, LoggingConfigKey, loggingConfigMapName, clients, names)
 
+	// Verify HA config
+	VerifyHADeployments(t, clients, names)
+
 	// Use an empty map as the value
 	verifyEmptyKey(t, DefaultsConfigKey, defaultsConfigMapName, clients, names)
 
 	// Now remove the config from the spec and update
 	verifyEmptySpec(t, loggingConfigMapName, clients, names)
-
-	// Verify HA config
-	VerifyHADeployments(t, clients, names)
 }
 
 func verifyDefaultConfig(t *testing.T, ks *v1alpha1.KnativeServing, defaultsConfigMapName string, clients *test.Clients, names test.ResourceNames) {


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #794 

## Proposed Changes

* Make a network layer consistent throughout the e2e test in a case where one other than `istio` is installed
* Configure `IngressConfigs` and `ConfigMapData` on creating or updating `KnativeServing` according to a value of the env `INGRESS_CLASS`
* Do nothing for istio

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
