### PR TITLE
Report non-ready deployments to give a sense of progression

### DIFF
--- a/pkg/apis/operator/v1alpha1/common.go
+++ b/pkg/apis/operator/v1alpha1/common.go
@@ -83,7 +83,7 @@ type KComponentStatus interface {
 	MarkDeploymentsAvailable()
 	// MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 	// it's waiting for deployments.
-	MarkDeploymentsNotReady()
+	MarkDeploymentsNotReady([]string)
 
 	// MarkVersionMigrationEligible marks the VersionMigrationEligible status as true.
 	MarkVersionMigrationEligible()

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 )
@@ -91,11 +93,11 @@ func (es *KnativeEventingStatus) MarkVersionMigrationNotEligible(msg string) {
 
 // MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 // it's waiting for deployments.
-func (es *KnativeEventingStatus) MarkDeploymentsNotReady() {
+func (es *KnativeEventingStatus) MarkDeploymentsNotReady(deployments []string) {
 	eventingCondSet.Manage(es).MarkFalse(
 		DeploymentsAvailable,
 		"NotReady",
-		"Waiting on deployments")
+		"Waiting on deployments: %s", strings.Join(deployments, ", "))
 }
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.

--- a/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_lifecycle_test.go
@@ -53,7 +53,7 @@ func TestKnativeEventingHappyPath(t *testing.T) {
 	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)
 
 	// Deployments are not available at first.
-	ke.MarkDeploymentsNotReady()
+	ke.MarkDeploymentsNotReady([]string{"test"})
 	apistest.CheckConditionSucceeded(ke, DependenciesInstalled, t)
 	apistest.CheckConditionFailed(ke, DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ke, InstallSucceeded, t)

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"strings"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 )
@@ -90,11 +92,11 @@ func (is *KnativeServingStatus) MarkDeploymentsAvailable() {
 
 // MarkDeploymentsNotReady marks the DeploymentsAvailable status as false and calls out
 // it's waiting for deployments.
-func (is *KnativeServingStatus) MarkDeploymentsNotReady() {
+func (is *KnativeServingStatus) MarkDeploymentsNotReady(deployments []string) {
 	servingCondSet.Manage(is).MarkFalse(
 		DeploymentsAvailable,
 		"NotReady",
-		"Waiting on deployments")
+		"Waiting on deployments: %s", strings.Join(deployments, ", "))
 }
 
 // MarkDependenciesInstalled marks the DependenciesInstalled status as true.

--- a/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_lifecycle_test.go
@@ -53,7 +53,7 @@ func TestKnativeServingHappyPath(t *testing.T) {
 	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)
 
 	// Deployments are not available at first.
-	ks.MarkDeploymentsNotReady()
+	ks.MarkDeploymentsNotReady([]string{"test"})
 	apistest.CheckConditionSucceeded(ks, DependenciesInstalled, t)
 	apistest.CheckConditionFailed(ks, DeploymentsAvailable, t)
 	apistest.CheckConditionSucceeded(ks, InstallSucceeded, t)


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

We currently don't tell the user which deployments we're still waiting on, which makes debugging tough and gives no sense of progression. This reports the list of deployments we're waiting on

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The list of unready deployments are now reported in the status of either KnativeServing or KnativeEventing.
```

/assign @houshengbo 
