### PR TITLE
Refactor image transformer to deduplicate and simplify it

### DIFF
--- a/pkg/reconciler/common/images.go
+++ b/pkg/reconciler/common/images.go
@@ -79,6 +79,9 @@ func ImageTransform(registry *v1alpha1.Registry, log *zap.SugaredLogger) mf.Tran
 
 			obj = job
 			podSpec = &job.Spec.Template.Spec
+		default:
+			// No matches, exit early
+			return nil
 		}
 
 		log.Debugw("Updating", "name", obj.GetName(), "registry", registry)

--- a/pkg/reconciler/common/images.go
+++ b/pkg/reconciler/common/images.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"fmt"
 	"strings"
 
 	mf "github.com/manifestival/manifestival"
@@ -41,188 +42,111 @@ var (
 	delimiter             = "/"
 )
 
-// ImageTransformer is an interface for transforming images passed to the ResourceImageTransformer
-type ImageTransformer interface {
-	ImageForContainer(container *corev1.Container, parentName string) (string, bool)
-	ImageForEnvVar(env *corev1.EnvVar, parentName string) (string, bool)
-	ImageForImage(image *caching.Image, parentName string) (string, bool)
-	HandleImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference, log *zap.SugaredLogger) []corev1.LocalObjectReference
-}
-
-// registryImageTransformer is a v1alpha1.Registry specific transformer
-type registryImageTransformer struct {
-	registry *v1alpha1.Registry
-}
-
-var _ ImageTransformer = (*registryImageTransformer)(nil)
-
-func (rit *registryImageTransformer) ImageForContainer(container *corev1.Container, parentName string) (string, bool) {
-	return rit.handleImage(container.Name, parentName, true)
-}
-
-func (rit *registryImageTransformer) ImageForEnvVar(env *corev1.EnvVar, parentName string) (string, bool) {
-	return rit.handleImage(env.Name, "", false)
-}
-
-func (rit *registryImageTransformer) ImageForImage(image *caching.Image, parentName string) (string, bool) {
-	return rit.handleImage(image.Name, "", true)
-}
-
-func (rit *registryImageTransformer) handleImage(resourceName, parentName string, useDefault bool) (string, bool) {
-	if image, ok := rit.registry.Override[parentName+delimiter+resourceName]; ok {
-		return image, true
-	}
-	if image, ok := rit.registry.Override[resourceName]; ok {
-		return image, true
-	}
-	if !useDefault {
-		return "", false
-	}
-	return replaceName(rit.registry.Default, resourceName), true
-}
-
-func replaceName(imageTemplate string, name string) string {
-	return strings.ReplaceAll(imageTemplate, containerNameVariable, name)
-}
-
-func (rit *registryImageTransformer) HandleImagePullSecrets(imagePullSecrets []corev1.LocalObjectReference, log *zap.SugaredLogger) []corev1.LocalObjectReference {
-	if len(rit.registry.ImagePullSecrets) > 0 {
-		log.Debugf("Adding ImagePullSecrets: %v", rit.registry.ImagePullSecrets)
-		imagePullSecrets = append(imagePullSecrets, rit.registry.ImagePullSecrets...)
-	}
-	return imagePullSecrets
-}
-
 // ImageTransform updates image with a new registry and tag
 func ImageTransform(registry *v1alpha1.Registry, log *zap.SugaredLogger) mf.Transformer {
-	rit := &registryImageTransformer{
-		registry: registry,
-	}
-	return ResourceImageTransformer(rit, log)
-}
-
-// ResourceImageTransformer takes an ImageTransformer and transform images across resources
-func ResourceImageTransformer(imageTransformer ImageTransformer, log *zap.SugaredLogger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
+		// Image resources are handled quite differently, so branch them out early
+		if u.GetKind() == "Image" && u.GetAPIVersion() == "caching.internal.knative.dev/v1alpha1" {
+			return updateCachingImage(registry, u, log)
+		}
+
+		// Handle all resources that contain a PodSpec.
+		var podSpec *corev1.PodSpec
+		var obj metav1.Object
+
 		switch u.GetKind() {
-		// TODO need to use PodSpecable duck type in order to remove duplicates of deployment, daemonSet
 		case "Deployment":
-			return updateDeployment(imageTransformer, u, log)
+			deployment := &appsv1.Deployment{}
+			if err := scheme.Scheme.Convert(u, deployment, nil); err != nil {
+				return fmt.Errorf("failed to convert Unstructured to Deployment: %w", err)
+			}
+
+			obj = deployment
+			podSpec = &deployment.Spec.Template.Spec
 		case "DaemonSet":
-			return updateDaemonSet(imageTransformer, u, log)
+			ds := &appsv1.DaemonSet{}
+			if err := scheme.Scheme.Convert(u, ds, nil); err != nil {
+				return fmt.Errorf("failed to convert Unstructured to DaemonSet: %w", err)
+			}
+
+			obj = ds
+			podSpec = &ds.Spec.Template.Spec
 		case "Job":
-			return updateJob(imageTransformer, u, log)
-		case "Image":
-			if u.GetAPIVersion() == "caching.internal.knative.dev/v1alpha1" {
-				return updateCachingImage(imageTransformer, u, log)
+			job := &batchv1.Job{}
+			if err := scheme.Scheme.Convert(u, job, nil); err != nil {
+				return fmt.Errorf("failed to convert Unstructured to Job: %w", err)
+			}
+
+			obj = job
+			podSpec = &job.Spec.Template.Spec
+		}
+
+		log.Debugw("Updating", "name", obj.GetName(), "registry", registry)
+
+		containers := podSpec.Containers
+		for i := range containers {
+			container := &containers[i]
+
+			// Replace direct image YAML references.
+			if image, ok := registry.Override[obj.GetName()+delimiter+container.Name]; ok {
+				container.Image = image
+			} else if image, ok := registry.Override[container.Name]; ok {
+				container.Image = image
+			} else if registry.Default != "" {
+				// No matches found. Use default setting and replace potential container name placeholder.
+				container.Image = strings.ReplaceAll(registry.Default, containerNameVariable, container.Name)
+			}
+
+			for j := range container.Env {
+				env := &container.Env[j]
+				if image, ok := registry.Override[env.Name]; ok {
+					env.Value = image
+				}
 			}
 		}
+
+		// Add potential ImagePullSecrets
+		if len(registry.ImagePullSecrets) > 0 {
+			log.Debugf("Adding ImagePullSecrets: %v", registry.ImagePullSecrets)
+			podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, registry.ImagePullSecrets...)
+		}
+
+		if err := scheme.Scheme.Convert(obj, u, nil); err != nil {
+			return err
+		}
+
+		// The zero-value timestamp defaulted by the conversion causes
+		// superfluous updates
+		u.SetCreationTimestamp(metav1.Time{})
+
+		log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
 		return nil
 	}
 }
 
-func updateDeployment(imageTransformer ImageTransformer, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
-	var deployment = &appsv1.Deployment{}
-	if err := scheme.Scheme.Convert(u, deployment, nil); err != nil {
-		log.Error(err, "Error converting Unstructured to Deployment", "unstructured", u, "deployment", deployment)
-		return err
+func updateCachingImage(registry *v1alpha1.Registry, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
+	var img = &caching.Image{}
+	if err := scheme.Scheme.Convert(u, img, nil); err != nil {
+		return fmt.Errorf("failed to convert Unstructured to Image: %w", err)
 	}
 
-	updateRegistry(&deployment.Spec.Template.Spec, imageTransformer, log, deployment.GetName())
-	if err := scheme.Scheme.Convert(deployment, u, nil); err != nil {
-		return err
-	}
-	// The zero-value timestamp defaulted by the conversion causes
-	// superfluous updates
-	u.SetCreationTimestamp(metav1.Time{})
+	log.Debugw("Updating Image", "name", u.GetName(), "registry", registry)
 
-	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
-	return nil
-}
-
-func updateDaemonSet(imageTransformer ImageTransformer, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
-	var daemonSet = &appsv1.DaemonSet{}
-	if err := scheme.Scheme.Convert(u, daemonSet, nil); err != nil {
-		log.Error(err, "Error converting Unstructured to daemonSet", "unstructured", u, "daemonSet", daemonSet)
-		return err
-	}
-	updateRegistry(&daemonSet.Spec.Template.Spec, imageTransformer, log, daemonSet.GetName())
-	if err := scheme.Scheme.Convert(daemonSet, u, nil); err != nil {
-		return err
-	}
-	// The zero-value timestamp defaulted by the conversion causes
-	// superfluous updates
-	u.SetCreationTimestamp(metav1.Time{})
-
-	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
-	return nil
-}
-
-func updateJob(imageTransformer ImageTransformer, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
-	var job = &batchv1.Job{}
-	if err := scheme.Scheme.Convert(u, job, nil); err != nil {
-		log.Error(err, "Error converting Unstructured to job", "unstructured", u, "job", job)
-		return err
-	}
-	updateRegistry(&job.Spec.Template.Spec, imageTransformer, log, job.GetName())
-	if err := scheme.Scheme.Convert(job, u, nil); err != nil {
-		return err
-	}
-	// The zero-value timestamp defaulted by the conversion causes
-	// superfluous updates
-	u.SetCreationTimestamp(metav1.Time{})
-
-	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
-	return nil
-}
-
-func updateRegistry(spec *corev1.PodSpec, imageTransformer ImageTransformer, log *zap.SugaredLogger, name string) {
-	log.Debugw("Updating", "name", name, "imageTransformer", imageTransformer)
-
-	updateImage(spec, imageTransformer, log, name)
-	updateEnvVarImages(spec, imageTransformer, log, name)
-
-	spec.ImagePullSecrets = imageTransformer.HandleImagePullSecrets(
-		spec.ImagePullSecrets, log)
-}
-
-// updateImage updates the image with a new registry and tag
-func updateImage(spec *corev1.PodSpec, imageTransformer ImageTransformer, log *zap.SugaredLogger, name string) {
-	containers := spec.Containers
-	for index := range containers {
-		container := &containers[index]
-		newImage, _ := imageTransformer.ImageForContainer(container, name)
-		if newImage != "" {
-			updateContainer(container, newImage, log)
-		}
-	}
-	log.Debugw("Finished updating images", "name", name, "containers", spec.Containers)
-}
-
-func updateEnvVarImages(spec *corev1.PodSpec, imageTransformer ImageTransformer, log *zap.SugaredLogger, name string) {
-	containers := spec.Containers
-	for index := range containers {
-		container := &containers[index]
-		for envIndex := range container.Env {
-			env := &container.Env[envIndex]
-			if newImage, ok := imageTransformer.ImageForEnvVar(env, container.Name); ok {
-				env.Value = newImage
-			}
-		}
-	}
-}
-
-func updateCachingImage(imageTransformer ImageTransformer, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
-	var image = &caching.Image{}
-	if err := scheme.Scheme.Convert(u, image, nil); err != nil {
-		log.Error(err, "Error converting Unstructured to Image", "unstructured", u, "image", image)
-		return err
+	// Replace direct image YAML references.
+	if image, ok := registry.Override[img.Name]; ok {
+		img.Spec.Image = image
+	} else if registry.Default != "" {
+		// No matches found. Use default setting and replace potential container name placeholder.
+		img.Spec.Image = strings.ReplaceAll(registry.Default, containerNameVariable, img.Name)
 	}
 
-	log.Debugw("Updating Image", "name", u.GetName(), "registry", imageTransformer)
+	// Add potential ImagePullSecrets
+	if len(registry.ImagePullSecrets) > 0 {
+		log.Debugf("Adding ImagePullSecrets: %v", registry.ImagePullSecrets)
+		img.Spec.ImagePullSecrets = append(img.Spec.ImagePullSecrets, registry.ImagePullSecrets...)
+	}
 
-	updateImageSpec(image, imageTransformer, log)
-	if err := scheme.Scheme.Convert(image, u, nil); err != nil {
+	if err := scheme.Scheme.Convert(img, u, nil); err != nil {
 		return err
 	}
 	// Cleanup zero-value default to prevent superfluous updates
@@ -231,19 +155,4 @@ func updateCachingImage(imageTransformer ImageTransformer, u *unstructured.Unstr
 
 	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
 	return nil
-}
-
-// updateImageSpec updates the image of a with a new registry and tag
-func updateImageSpec(image *caching.Image, imageTransformer ImageTransformer, log *zap.SugaredLogger) {
-	if newImage, _ := imageTransformer.ImageForImage(image, ""); newImage != "" {
-		log.Debugf("Updating image from: %v, to: %v", image.Spec.Image, newImage)
-		image.Spec.Image = newImage
-	}
-	image.Spec.ImagePullSecrets = imageTransformer.HandleImagePullSecrets(image.Spec.ImagePullSecrets, log)
-	log.Debugw("Finished updating image", "image", image.GetName())
-}
-
-func updateContainer(container *corev1.Container, newImage string, log *zap.SugaredLogger) {
-	log.Debugf("Updating container image from: %v, to: %v", container.Image, newImage)
-	container.Image = newImage
 }


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

The code here contained so many indirections, that it was IMO impossible to follow. This fixes that, gets rid of unnecessary interfaces etc. and straight up makes things easier to read.

/assign @houshengbo 
