### PR TITLE
Add the conversion function for v1alpha1 and v1beta1

### DIFF
--- a/pkg/apis/operator/v1alpha1/deploymentoverride.go
+++ b/pkg/apis/operator/v1alpha1/deploymentoverride.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"knative.dev/operator/pkg/apis/operator/base"
+)
+
+// ConvertToDeploymentOverride merges the ResourceRequirementsOverride into the DeploymentOverride
+func ConvertToDeploymentOverride(source base.KComponent) []base.DeploymentOverride {
+	mergedDeploymentOverride := source.GetSpec().GetDeploymentOverride()
+	// Make a copy of source.GetSpec().GetDeploymentOverride()
+	deploymentOverrideCopy := make([]base.DeploymentOverride, 0, len(mergedDeploymentOverride))
+	for _, override := range mergedDeploymentOverride {
+		copy := *override.DeepCopy()
+		deploymentOverrideCopy = append(deploymentOverrideCopy, copy)
+	}
+
+	for _, resource := range source.GetSpec().GetResources() {
+		resourceCopy := resource.DeepCopy()
+		deploymentOverrideCopy = addResourceIntoDeployment(deploymentOverrideCopy, *resourceCopy)
+	}
+	return deploymentOverrideCopy
+}
+
+func addResourceIntoDeployment(deploymentOverrides []base.DeploymentOverride,
+	resource base.ResourceRequirementsOverride) []base.DeploymentOverride {
+	// If it does not exist, add the resource requirement as a new
+	// item; if it does, modify the existing resource requirement.
+	deployFound := false
+	for key, deploymentOverride := range deploymentOverrides {
+		if deploymentOverride.Name == resource.Container {
+			deployFound = true
+			containerFound := false
+			for containerKey, deployResource := range deploymentOverride.Resources {
+				if deployResource.Container == resource.Container {
+					containerFound = true
+					if len(deployResource.Limits) == 0 && len(deployResource.Requests) == 0 {
+						deploymentOverrides[key].Resources[containerKey].Limits = resource.Limits
+						deploymentOverrides[key].Resources[containerKey].Requests = resource.Requests
+					}
+				}
+			}
+
+			if !containerFound {
+				deploymentOverrides[key].Resources = append(deploymentOverrides[key].Resources, resource)
+			}
+		}
+	}
+	if !deployFound {
+		newDeployOverride := base.DeploymentOverride{}
+		// Take the container name as the deployment name.
+		newDeployOverride.Name = resource.Container
+		newDeployOverride.Resources = append(newDeployOverride.Resources, resource)
+		deploymentOverrides = append(deploymentOverrides, newDeployOverride)
+	}
+	return deploymentOverrides
+}

--- a/pkg/apis/operator/v1alpha1/deploymentoverride_test.go
+++ b/pkg/apis/operator/v1alpha1/deploymentoverride_test.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func makeExpectedDeploymentOverrideNonEmpty() []base.DeploymentOverride {
+	return []base.DeploymentOverride{
+		{
+			Name:         "webhook",
+			Labels:       map[string]string{"e": "f"},
+			Annotations:  map[string]string{"g": "h"},
+			Replicas:     4,
+			NodeSelector: map[string]string{"env": "prod"},
+			Tolerations: []corev1.Toleration{{
+				Key:      corev1.TaintNodeUnschedulable,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							PodAffinityTerm: v1.PodAffinityTerm{
+								Namespaces: []string{"test"},
+							},
+							Weight: 10,
+						},
+					},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinity{},
+			},
+		}, {
+			Name: "webhook-not-exist",
+			Resources: []base.ResourceRequirementsOverride{{
+				Container: "webhook-not-exist",
+				ResourceRequirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+				},
+			}},
+		},
+	}
+}
+
+func makeExpectedExistentTestDeploymentOverride() []base.DeploymentOverride {
+	return []base.DeploymentOverride{
+		{
+			Name:         "webhook",
+			Labels:       map[string]string{"e": "f"},
+			Annotations:  map[string]string{"g": "h"},
+			Replicas:     4,
+			NodeSelector: map[string]string{"env": "prod"},
+			Tolerations: []corev1.Toleration{{
+				Key:      corev1.TaintNodeUnschedulable,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							PodAffinityTerm: v1.PodAffinityTerm{
+								Namespaces: []string{"test"},
+							},
+							Weight: 10,
+						},
+					},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinity{},
+			},
+			Resources: []base.ResourceRequirementsOverride{{
+				Container: "webhook",
+				ResourceRequirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+				},
+			}},
+		},
+	}
+}
+
+func makeExpectedDeploymentOverrideArrayOrigin() []base.DeploymentOverride {
+	return []base.DeploymentOverride{
+		{
+			Name:         "webhook",
+			Labels:       map[string]string{"e": "f"},
+			Annotations:  map[string]string{"g": "h"},
+			Replicas:     4,
+			NodeSelector: map[string]string{"env": "prod"},
+			Tolerations: []corev1.Toleration{{
+				Key:      corev1.TaintNodeUnschedulable,
+				Operator: corev1.TolerationOpExists,
+				Effect:   corev1.TaintEffectNoSchedule,
+			}},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							PodAffinityTerm: v1.PodAffinityTerm{
+								Namespaces: []string{"test"},
+							},
+							Weight: 10,
+						},
+					},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinity{},
+			},
+			Resources: []base.ResourceRequirementsOverride{{
+				Container: "webhook",
+				ResourceRequirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99m"),
+						corev1.ResourceMemory: resource.MustParse("99Mi")},
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99m"),
+						corev1.ResourceMemory: resource.MustParse("99Mi")},
+				},
+			}},
+		},
+	}
+}
+
+func makeExpectedDeploymentOverrideEmpty() []base.DeploymentOverride {
+	return []base.DeploymentOverride{
+		{
+			Name: "webhook-not-exist",
+			Resources: []base.ResourceRequirementsOverride{{
+				Container: "webhook-not-exist",
+				ResourceRequirements: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+						corev1.ResourceMemory: resource.MustParse("999Mi")},
+				},
+			}},
+		},
+	}
+}
+
+func TestConvertToDeploymentOverride(t *testing.T) {
+	expectedDeploymentOverrideEmpty := makeExpectedDeploymentOverrideEmpty()
+	expectedDeploymentOverrideNonEmpty := makeExpectedDeploymentOverrideNonEmpty()
+	expectedExistentDeploymentOverrideArray := makeExpectedExistentTestDeploymentOverride()
+	expectedDeploymentOverrideArrayOrigin := makeExpectedDeploymentOverrideArrayOrigin()
+	for _, tt := range []struct {
+		name     string
+		source   base.KComponent
+		expected []base.DeploymentOverride
+	}{{
+		name: "Knative Serving: merge the non-existent ResourceRequirementsOverride into the non-empty DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook-not-exist",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedDeploymentOverrideNonEmpty,
+	}, {
+		name: "Knative Serving: merge the existent ResourceRequirementsOverride into the non-empty DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedExistentDeploymentOverrideArray,
+	}, {
+		name: "Knative Serving: not merge the ResourceRequirementsOverride into the DeploymentOverrides due to existing DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+							Resources: []base.ResourceRequirementsOverride{{
+								Container: "webhook",
+								ResourceRequirements: corev1.ResourceRequirements{
+									Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99m"),
+										corev1.ResourceMemory: resource.MustParse("99Mi")},
+									Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("99m"),
+										corev1.ResourceMemory: resource.MustParse("99Mi")},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedDeploymentOverrideArrayOrigin,
+	}, {
+		name: "Knative Serving: not merge the ResourceRequirementsOverride into the DeploymentOverrides due to empty DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+							Resources: []base.ResourceRequirementsOverride{{
+								Container: "webhook",
+							}},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedExistentDeploymentOverrideArray,
+	}, {
+		name: "Knative Serving: merge the non-existent ResourceRequirementsOverride into the DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook-not-exist",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedDeploymentOverrideNonEmpty,
+	}, {
+		name: "Knative Serving: merge the non-existent ResourceRequirementsOverride into the DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook-not-exist",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+				},
+			},
+		},
+		expected: expectedDeploymentOverrideEmpty,
+	}, {
+		name: "Knative Serving: merge the existent ResourceRequirementsOverride into the DeploymentOverrides",
+		source: &KnativeServing{
+			Spec: KnativeServingSpec{
+				CommonSpec: base.CommonSpec{
+					Resources: []base.ResourceRequirementsOverride{{
+						Container: "webhook",
+						ResourceRequirements: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+								corev1.ResourceMemory: resource.MustParse("999Mi")},
+						},
+					}},
+					DeploymentOverride: []base.DeploymentOverride{
+						{
+							Name:         "webhook",
+							Labels:       map[string]string{"e": "f"},
+							Annotations:  map[string]string{"g": "h"},
+							Replicas:     4,
+							NodeSelector: map[string]string{"env": "prod"},
+							Tolerations: []corev1.Toleration{{
+								Key:      corev1.TaintNodeUnschedulable,
+								Operator: corev1.TolerationOpExists,
+								Effect:   corev1.TaintEffectNoSchedule,
+							}},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{},
+								PodAffinity: &corev1.PodAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+										{
+											PodAffinityTerm: v1.PodAffinityTerm{
+												Namespaces: []string{"test"},
+											},
+											Weight: 10,
+										},
+									},
+								},
+								PodAntiAffinity: &corev1.PodAntiAffinity{},
+							},
+						},
+					},
+				},
+			},
+		},
+		expected: expectedExistentDeploymentOverrideArray,
+	}} {
+
+		t.Run(tt.name, func(t *testing.T) {
+			deploymentOverrides := ConvertToDeploymentOverride(tt.source)
+			util.AssertDeepEqual(t, deploymentOverrides, tt.expected)
+		})
+	}
+}

--- a/pkg/apis/operator/v1alpha1/istioconfig.go
+++ b/pkg/apis/operator/v1alpha1/istioconfig.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"knative.dev/operator/pkg/apis/operator/base"
+)
+
+// ConvertToIstioConfig merges the gateway config into the ingress istio config
+func ConvertToIstioConfig(source *KnativeServing) base.IstioIngressConfiguration {
+	istioConfig := base.IstioIngressConfiguration{}
+	if source.Spec.Ingress != nil {
+		istioConfig = source.Spec.Ingress.Istio
+	}
+
+	if istioConfig.KnativeIngressGateway == nil {
+		istioConfig.KnativeIngressGateway = &source.Spec.DeprecatedKnativeIngressGateway
+	}
+	if istioConfig.KnativeLocalGateway == nil {
+		istioConfig.KnativeLocalGateway = &source.Spec.DeprecatedClusterLocalGateway
+	}
+
+	return istioConfig
+}

--- a/pkg/apis/operator/v1alpha1/istioconfig_test.go
+++ b/pkg/apis/operator/v1alpha1/istioconfig_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestConvertToIstioConfig(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		ks                  *KnativeServing
+		expectedIstioConfig base.IstioIngressConfiguration
+	}{{
+		name: "Deprecated Ingress Gateway will be passed into the istio configuration",
+		ks: &KnativeServing{
+			Spec: KnativeServingSpec{
+				DeprecatedKnativeIngressGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "knative-ingress"},
+				},
+				DeprecatedClusterLocalGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "cluster-local"},
+				},
+			},
+		},
+		expectedIstioConfig: base.IstioIngressConfiguration{
+			KnativeIngressGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "knative-ingress"},
+			},
+			KnativeLocalGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "cluster-local"},
+			},
+		},
+	}, {
+		name: "Ingress Gateway will be passed into the istio configuration",
+		ks: &KnativeServing{
+			Spec: KnativeServingSpec{
+				DeprecatedKnativeIngressGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "knative-ingress"},
+				},
+				DeprecatedClusterLocalGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "cluster-local"},
+				},
+				Ingress: &IngressConfigs{
+					Istio: base.IstioIngressConfiguration{
+						KnativeIngressGateway: &base.IstioGatewayOverride{
+							Selector: map[string]string{"istio": "knative-ingress-istio"},
+						},
+						KnativeLocalGateway: &base.IstioGatewayOverride{
+							Selector: map[string]string{"istio": "cluster-local-istio"},
+						},
+					},
+				},
+			},
+		},
+		expectedIstioConfig: base.IstioIngressConfiguration{
+			KnativeIngressGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "knative-ingress-istio"},
+			},
+			KnativeLocalGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "cluster-local-istio"},
+			},
+		},
+	}, {
+		name: "Deprecated ingress Gateway will be passed into the istio configuration if Ingress Gateway is not available",
+		ks: &KnativeServing{
+			Spec: KnativeServingSpec{
+				DeprecatedKnativeIngressGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "knative-ingress"},
+				},
+				DeprecatedClusterLocalGateway: base.IstioGatewayOverride{
+					Selector: map[string]string{"istio": "cluster-local"},
+				},
+				Ingress: &IngressConfigs{
+					Istio: base.IstioIngressConfiguration{
+						KnativeIngressGateway: &base.IstioGatewayOverride{
+							Selector: map[string]string{"istio": "knative-ingress-istio"},
+						},
+					},
+				},
+			},
+		},
+		expectedIstioConfig: base.IstioIngressConfiguration{
+			KnativeIngressGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "knative-ingress-istio"},
+			},
+			KnativeLocalGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "cluster-local"},
+			},
+		},
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			istioConfig := ConvertToIstioConfig(tt.ks)
+			util.AssertDeepEqual(t, istioConfig, tt.expectedIstioConfig)
+		})
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeeventing_conversion.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_conversion.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	"knative.dev/pkg/apis"
+)
+
+func convertFromSourceConfigsBeta(ke *v1beta1.KnativeEventing) *SourceConfigs {
+	ceph := base.CephSourceConfiguration{}
+	github := base.GithubSourceConfiguration{}
+	gitlab := base.GitlabSourceConfiguration{}
+	kafka := base.KafkaSourceConfiguration{}
+	natss := base.NatssSourceConfiguration{}
+	rabbitmq := base.RabbitmqSourceConfiguration{}
+	redis := base.RedisSourceConfiguration{}
+
+	if ke.Spec.Source != nil {
+		ceph = ke.Spec.Source.Ceph
+		github = ke.Spec.Source.Github
+		gitlab = ke.Spec.Source.Gitlab
+		kafka = ke.Spec.Source.Kafka
+		natss = ke.Spec.Source.Natss
+		rabbitmq = ke.Spec.Source.Rabbitmq
+		redis = ke.Spec.Source.Redis
+	}
+
+	return &SourceConfigs{
+		Ceph:     ceph,
+		Github:   github,
+		Gitlab:   gitlab,
+		Kafka:    kafka,
+		Natss:    natss,
+		Rabbitmq: rabbitmq,
+		Redis:    redis,
+	}
+}
+
+func convertToSourceConfigs(ke *KnativeEventing) *v1beta1.SourceConfigs {
+	ceph := base.CephSourceConfiguration{}
+	github := base.GithubSourceConfiguration{}
+	gitlab := base.GitlabSourceConfiguration{}
+	kafka := base.KafkaSourceConfiguration{}
+	natss := base.NatssSourceConfiguration{}
+	rabbitmq := base.RabbitmqSourceConfiguration{}
+	redis := base.RedisSourceConfiguration{}
+
+	if ke.Spec.Source != nil {
+		ceph = ke.Spec.Source.Ceph
+		github = ke.Spec.Source.Github
+		gitlab = ke.Spec.Source.Gitlab
+		kafka = ke.Spec.Source.Kafka
+		natss = ke.Spec.Source.Natss
+		rabbitmq = ke.Spec.Source.Rabbitmq
+		redis = ke.Spec.Source.Redis
+	}
+
+	return &v1beta1.SourceConfigs{
+		Ceph:     ceph,
+		Github:   github,
+		Gitlab:   gitlab,
+		Kafka:    kafka,
+		Natss:    natss,
+		Rabbitmq: rabbitmq,
+		Redis:    redis,
+	}
+}
+
+// ConvertTo implements apis.Convertible
+// Converts source from v1alpha1.KnativeEventing into a higher version.
+func (ke *KnativeEventing) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *v1beta1.KnativeEventing:
+		mergedDeploymentOverride := ConvertToDeploymentOverride(ke)
+		sourceConfigs := convertToSourceConfigs(ke)
+		sink.ObjectMeta = ke.ObjectMeta
+		sink.Status = v1beta1.KnativeEventingStatus{
+			Status:    ke.Status.Status,
+			Version:   ke.Status.Version,
+			Manifests: ke.Status.Manifests,
+		}
+		sink.Spec = v1beta1.KnativeEventingSpec{
+			DefaultBrokerClass:       ke.Spec.DefaultBrokerClass,
+			SinkBindingSelectionMode: ke.Spec.SinkBindingSelectionMode,
+			Source:                   sourceConfigs,
+			CommonSpec: base.CommonSpec{
+				Config:              ke.Spec.CommonSpec.Config,
+				Registry:            ke.Spec.CommonSpec.Registry,
+				DeploymentOverride:  mergedDeploymentOverride,
+				Version:             ke.Spec.CommonSpec.Version,
+				Manifests:           ke.Spec.CommonSpec.Manifests,
+				AdditionalManifests: ke.Spec.CommonSpec.AdditionalManifests,
+				HighAvailability:    ke.Spec.CommonSpec.HighAvailability,
+			},
+		}
+
+		return nil
+	default:
+		return apis.ConvertToViaProxy(ctx, ke, &v1beta1.KnativeEventing{}, sink)
+	}
+}
+
+// ConvertFrom implements apis.Convertible
+// Converts source from a higher version into v1alpha1.KnativeEventing
+func (ke *KnativeEventing) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *v1beta1.KnativeEventing:
+		sourceConfigs := convertFromSourceConfigsBeta(source)
+		ke.ObjectMeta = source.ObjectMeta
+		ke.Status = KnativeEventingStatus{
+			Status:    source.Status.Status,
+			Version:   source.Status.Version,
+			Manifests: source.Status.Manifests,
+		}
+
+		ke.Spec = KnativeEventingSpec{
+			DefaultBrokerClass:       source.Spec.DefaultBrokerClass,
+			SinkBindingSelectionMode: source.Spec.SinkBindingSelectionMode,
+			Source:                   sourceConfigs,
+			CommonSpec: base.CommonSpec{
+				Config:              source.Spec.CommonSpec.Config,
+				Registry:            source.Spec.CommonSpec.Registry,
+				DeploymentOverride:  source.Spec.CommonSpec.DeploymentOverride,
+				Version:             source.Spec.CommonSpec.Version,
+				Manifests:           source.Spec.CommonSpec.Manifests,
+				AdditionalManifests: source.Spec.CommonSpec.AdditionalManifests,
+				HighAvailability:    source.Spec.CommonSpec.HighAvailability,
+			},
+		}
+
+		return nil
+	default:
+		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.KnativeEventing{}, ke)
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeeventing_conversion_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_conversion_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestKnativeEventingConvertTo(t *testing.T) {
+	source := &KnativeEventing{
+		Spec: KnativeEventingSpec{
+			CommonSpec: base.CommonSpec{
+				Version: "1.2",
+				Resources: []base.ResourceRequirementsOverride{{
+					Container: "webhook",
+					ResourceRequirements: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+							corev1.ResourceMemory: resource.MustParse("999Mi")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+							corev1.ResourceMemory: resource.MustParse("999Mi")},
+					},
+				}},
+			},
+			Source: &SourceConfigs{
+				Ceph: base.CephSourceConfiguration{
+					Enabled: true,
+				},
+				Github: base.GithubSourceConfiguration{
+					Enabled: false,
+				},
+			},
+			DefaultBrokerClass:       "test-class",
+			SinkBindingSelectionMode: "test-mode",
+		},
+	}
+	sink := &v1beta1.KnativeEventing{}
+	expectedResourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+			corev1.ResourceMemory: resource.MustParse("999Mi")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+			corev1.ResourceMemory: resource.MustParse("999Mi")},
+	}
+	err := source.ConvertTo(context.Background(), sink)
+	util.AssertEqual(t, err, nil)
+	util.AssertEqual(t, sink.GetSpec().GetVersion(), "1.2")
+	util.AssertEqual(t, sink.Spec.SinkBindingSelectionMode, "test-mode")
+	util.AssertEqual(t, sink.Spec.DefaultBrokerClass, "test-class")
+	util.AssertEqual(t, sink.Spec.Source.Ceph.Enabled, true)
+	util.AssertEqual(t, sink.Spec.Source.Github.Enabled, false)
+	util.AssertEqual(t, sink.Spec.DeploymentOverride[0].Resources[0].Container, "webhook")
+	util.AssertDeepEqual(t, sink.Spec.DeploymentOverride[0].Resources[0].ResourceRequirements,
+		expectedResourceRequirements)
+}
+
+func TestKnativeEventingConvertFrom(t *testing.T) {
+	ke := &KnativeEventing{}
+	source := &v1beta1.KnativeEventing{
+		Spec: v1beta1.KnativeEventingSpec{
+			CommonSpec: base.CommonSpec{
+				Version: "1.2",
+			},
+			Source: &v1beta1.SourceConfigs{
+				Ceph: base.CephSourceConfiguration{
+					Enabled: true,
+				},
+				Github: base.GithubSourceConfiguration{
+					Enabled: false,
+				},
+			},
+			DefaultBrokerClass:       "test-class",
+			SinkBindingSelectionMode: "test-mode",
+		},
+	}
+	err := ke.ConvertFrom(context.Background(), source)
+	util.AssertEqual(t, err, nil)
+	util.AssertEqual(t, ke.GetSpec().GetVersion(), "1.2")
+	util.AssertEqual(t, ke.Spec.SinkBindingSelectionMode, "test-mode")
+	util.AssertEqual(t, ke.Spec.DefaultBrokerClass, "test-class")
+	util.AssertEqual(t, ke.Spec.Source.Ceph.Enabled, true)
+	util.AssertEqual(t, ke.Spec.Source.Github.Enabled, false)
+}

--- a/pkg/apis/operator/v1alpha1/knativeserving_conversion.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_conversion.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	"knative.dev/pkg/apis"
+)
+
+// ConvertTo implements apis.Convertible
+// Converts source from v1alpha1.KnativeServing into a higher version.
+func (ks *KnativeServing) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+	switch sink := obj.(type) {
+	case *v1beta1.KnativeServing:
+		mergedDeploymentOverride := ConvertToDeploymentOverride(ks)
+		mergedIstioConfig := ConvertToIstioConfig(ks)
+		sink.ObjectMeta = ks.ObjectMeta
+		sink.Status = v1beta1.KnativeServingStatus{
+			Status:    ks.Status.Status,
+			Version:   ks.Status.Version,
+			Manifests: ks.Status.Manifests,
+		}
+		sink.Spec = v1beta1.KnativeServingSpec{
+			ControllerCustomCerts: ks.Spec.ControllerCustomCerts,
+			Ingress: &v1beta1.IngressConfigs{
+				Istio:   mergedIstioConfig,
+				Kourier: ks.Spec.Ingress.Kourier,
+				Contour: ks.Spec.Ingress.Contour,
+			},
+			CommonSpec: base.CommonSpec{
+				Config:              ks.Spec.CommonSpec.Config,
+				Registry:            ks.Spec.CommonSpec.Registry,
+				DeploymentOverride:  mergedDeploymentOverride,
+				Version:             ks.Spec.CommonSpec.Version,
+				Manifests:           ks.Spec.CommonSpec.Manifests,
+				AdditionalManifests: ks.Spec.CommonSpec.AdditionalManifests,
+				HighAvailability:    ks.Spec.CommonSpec.HighAvailability,
+			},
+		}
+
+		return nil
+	default:
+		return apis.ConvertToViaProxy(ctx, ks, &v1beta1.KnativeServing{}, sink)
+	}
+}
+
+// ConvertFrom implements apis.Convertible
+// Converts source from a higher version into v1alpha1.KnativeServing
+func (ks *KnativeServing) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+	switch source := obj.(type) {
+	case *v1beta1.KnativeServing:
+		ks.ObjectMeta = source.ObjectMeta
+		ks.Status = KnativeServingStatus{
+			Status:    source.Status.Status,
+			Version:   source.Status.Version,
+			Manifests: source.Status.Manifests,
+		}
+
+		ks.Spec = KnativeServingSpec{
+			ControllerCustomCerts: source.Spec.ControllerCustomCerts,
+			Ingress: &IngressConfigs{
+				Istio:   source.Spec.Ingress.Istio,
+				Kourier: source.Spec.Ingress.Kourier,
+				Contour: source.Spec.Ingress.Contour,
+			},
+			CommonSpec: base.CommonSpec{
+				Config:              source.Spec.CommonSpec.Config,
+				Registry:            source.Spec.CommonSpec.Registry,
+				DeploymentOverride:  source.Spec.CommonSpec.DeploymentOverride,
+				Version:             source.Spec.CommonSpec.Version,
+				Manifests:           source.Spec.CommonSpec.Manifests,
+				AdditionalManifests: source.Spec.CommonSpec.AdditionalManifests,
+				HighAvailability:    source.Spec.CommonSpec.HighAvailability,
+			},
+		}
+
+		return nil
+	default:
+		return apis.ConvertFromViaProxy(ctx, source, &v1beta1.KnativeServing{}, ks)
+	}
+}

--- a/pkg/apis/operator/v1alpha1/knativeserving_conversion_test.go
+++ b/pkg/apis/operator/v1alpha1/knativeserving_conversion_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"knative.dev/operator/pkg/apis/operator/base"
+	"knative.dev/operator/pkg/apis/operator/v1beta1"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestKnativeServingConvertTo(t *testing.T) {
+	source := &KnativeServing{
+		Spec: KnativeServingSpec{
+			CommonSpec: base.CommonSpec{
+				Version: "1.2",
+				Resources: []base.ResourceRequirementsOverride{{
+					Container: "webhook",
+					ResourceRequirements: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+							corev1.ResourceMemory: resource.MustParse("999Mi")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+							corev1.ResourceMemory: resource.MustParse("999Mi")},
+					},
+				}},
+			},
+			Ingress: &IngressConfigs{
+				Istio: base.IstioIngressConfiguration{
+					Enabled: true,
+				},
+				Contour: base.ContourIngressConfiguration{
+					Enabled: false,
+				},
+			},
+			ControllerCustomCerts: base.CustomCerts{
+				Type: "test-type",
+				Name: "test-name",
+			},
+		},
+	}
+	sink := &v1beta1.KnativeServing{}
+	expectedResourceRequirements := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+			corev1.ResourceMemory: resource.MustParse("999Mi")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("999m"),
+			corev1.ResourceMemory: resource.MustParse("999Mi")},
+	}
+	err := source.ConvertTo(context.Background(), sink)
+	util.AssertEqual(t, err, nil)
+	util.AssertEqual(t, sink.GetSpec().GetVersion(), "1.2")
+	util.AssertEqual(t, sink.Spec.ControllerCustomCerts.Name, "test-name")
+	util.AssertEqual(t, sink.Spec.ControllerCustomCerts.Type, "test-type")
+	util.AssertEqual(t, sink.Spec.Ingress.Istio.Enabled, true)
+	util.AssertEqual(t, sink.Spec.Ingress.Contour.Enabled, false)
+	util.AssertEqual(t, sink.Spec.DeploymentOverride[0].Resources[0].Container, "webhook")
+	util.AssertDeepEqual(t, sink.Spec.DeploymentOverride[0].Resources[0].ResourceRequirements,
+		expectedResourceRequirements)
+}
+
+func TestTestKnativeServingConvertFrom(t *testing.T) {
+	ke := &KnativeServing{}
+	source := &v1beta1.KnativeServing{
+		Spec: v1beta1.KnativeServingSpec{
+			CommonSpec: base.CommonSpec{
+				Version: "1.2",
+			},
+			Ingress: &v1beta1.IngressConfigs{
+				Istio: base.IstioIngressConfiguration{
+					Enabled: true,
+				},
+				Contour: base.ContourIngressConfiguration{
+					Enabled: false,
+				},
+			},
+			ControllerCustomCerts: base.CustomCerts{
+				Type: "test-type",
+				Name: "test-name",
+			},
+		},
+	}
+	err := ke.ConvertFrom(context.Background(), source)
+	util.AssertEqual(t, err, nil)
+	util.AssertEqual(t, ke.GetSpec().GetVersion(), "1.2")
+	util.AssertEqual(t, ke.Spec.ControllerCustomCerts.Name, "test-name")
+	util.AssertEqual(t, ke.Spec.ControllerCustomCerts.Type, "test-type")
+	util.AssertEqual(t, ke.Spec.Ingress.Istio.Enabled, true)
+	util.AssertEqual(t, ke.Spec.Ingress.Contour.Enabled, false)
+}

--- a/pkg/apis/operator/v1beta1/knativeeventing_conversion.go
+++ b/pkg/apis/operator/v1beta1/knativeeventing_conversion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertTo implements apis.Convertible
+// Converts KnativeServing from v1beta1.KnativeServing into a higher version.
+func (ke *KnativeEventing) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+// Converts KnativeServing from a higher version into v1beta1.KnativeServing
+func (ke *KnativeEventing) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/operator/v1beta1/knativeeventing_conversion_test.go
+++ b/pkg/apis/operator/v1beta1/knativeeventing_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKnativeEventingConversionHighestVersion(t *testing.T) {
+	source, sink := &KnativeEventing{}, &KnativeEventing{}
+
+	if err := source.ConvertTo(context.Background(), sink); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", sink)
+	}
+
+	if err := source.ConvertFrom(context.Background(), sink); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", source)
+	}
+}

--- a/pkg/apis/operator/v1beta1/knativeserving_conversion.go
+++ b/pkg/apis/operator/v1beta1/knativeserving_conversion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+// ConvertTo implements apis.Convertible
+// Converts KnativeServing from v1beta1.KnativeServing into a higher version.
+func (ks *KnativeServing) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+// Converts KnativeServing from a higher version into v1beta1.KnativeServing
+func (ks *KnativeServing) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/operator/v1beta1/knativeserving_conversion_test.go
+++ b/pkg/apis/operator/v1beta1/knativeserving_conversion_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2022 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+)
+
+func TestKnativeServingConversionHighestVersion(t *testing.T) {
+	source, sink := &KnativeServing{}, &KnativeServing{}
+
+	if err := source.ConvertTo(context.Background(), sink); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", sink)
+	}
+
+	if err := source.ConvertFrom(context.Background(), sink); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", source)
+	}
+}


### PR DESCRIPTION
This PR has done the following updates:
* Added the conversion function between v1alpha1 and v1beta1 APIs.
* Gateways information can be passed to v1beta1 API during the v1alpha1 to v1beta1 conversion.
* System resources configuration can be passed to v1beta1 API during the v1alpha1 to v1beta1 conversion.
* The v1beta1 API removed all the deprecated fields in v1alpha1, including ResourceRequirementsOverride, DeprecatedKnativeIngressGateway and DeprecatedClusterLocalGateway.