### PR TITLE
Keep the default image name the same as the original

### DIFF
--- a/pkg/reconciler/common/images_test.go
+++ b/pkg/reconciler/common/images_test.go
@@ -279,13 +279,31 @@ func TestImageTransform(t *testing.T) {
 			Image: "new-registry.io/test/path/OverrideImage:new-tag",
 		},
 	}, {
-		name: "UsesNameFromDefault",
+		name: "UsesDefaultImageNameWithSha",
 		in:   "gcr.io/knative-releases/github.com/knative/serving/cmd/queue@sha256:1e40c99ff5977daa2d69873fff604c6d09651af1f9ff15aadf8849b3ee77ab45",
 		registry: base.Registry{
 			Default: "new-registry.io/test/path/${NAME}:new-tag",
 		},
 		expected: caching.ImageSpec{
-			Image: "new-registry.io/test/path/UsesNameFromDefault:new-tag",
+			Image: "new-registry.io/test/path/queue:new-tag",
+		},
+	}, {
+		name: "UsesDefaultContainerName",
+		in:   "badLink",
+		registry: base.Registry{
+			Default: "new-registry.io/test/path/${NAME}:new-tag",
+		},
+		expected: caching.ImageSpec{
+			Image: "new-registry.io/test/path/UsesDefaultContainerName:new-tag",
+		},
+	}, {
+		name: "UsesDefaultImageNameWithTag",
+		in:   "gcr.io/knative-releases/github.com/knative/serving/cmd/queue:v1.2.0",
+		registry: base.Registry{
+			Default: "new-registry.io/test/path/${NAME}:new-tag",
+		},
+		expected: caching.ImageSpec{
+			Image: "new-registry.io/test/path/queue:new-tag",
 		},
 	}, {
 		name: "AddsImagePullSecrets",


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #955

## Proposed Changes

* Keep the default name the same as the original name in the image url.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
