### PR TITLE
Fix the issue with alpha and beta transition

### DIFF
--- a/pkg/apis/operator/v1alpha1/istioconfig.go
+++ b/pkg/apis/operator/v1alpha1/istioconfig.go
@@ -27,10 +27,10 @@ func ConvertToIstioConfig(source *KnativeServing) base.IstioIngressConfiguration
 		istioConfig = source.Spec.Ingress.Istio
 	}
 
-	if istioConfig.KnativeIngressGateway == nil {
+	if istioConfig.KnativeIngressGateway == nil && source.Spec.DeprecatedKnativeIngressGateway.Selector != nil {
 		istioConfig.KnativeIngressGateway = &source.Spec.DeprecatedKnativeIngressGateway
 	}
-	if istioConfig.KnativeLocalGateway == nil {
+	if istioConfig.KnativeLocalGateway == nil && source.Spec.DeprecatedClusterLocalGateway.Selector != nil {
 		istioConfig.KnativeLocalGateway = &source.Spec.DeprecatedClusterLocalGateway
 	}
 

--- a/pkg/apis/operator/v1alpha1/istioconfig_test.go
+++ b/pkg/apis/operator/v1alpha1/istioconfig_test.go
@@ -105,6 +105,34 @@ func TestConvertToIstioConfig(t *testing.T) {
 				Selector: map[string]string{"istio": "cluster-local"},
 			},
 		},
+	}, {
+		name: "No ingress Gateway will be passed into the istio configuration if no ingress Gateway is available",
+		ks: &KnativeServing{
+			Spec: KnativeServingSpec{
+				Ingress: &IngressConfigs{
+					Istio: base.IstioIngressConfiguration{
+						KnativeIngressGateway: &base.IstioGatewayOverride{
+							Selector: map[string]string{"istio": "knative-ingress-istio"},
+						},
+					},
+				},
+			},
+		},
+		expectedIstioConfig: base.IstioIngressConfiguration{
+			KnativeIngressGateway: &base.IstioGatewayOverride{
+				Selector: map[string]string{"istio": "knative-ingress-istio"},
+			},
+			KnativeLocalGateway: nil,
+		},
+	}, {
+		name: "No ingress Gateway will be passed into the istio configuration if deprecated ingress Gateway is not available",
+		ks: &KnativeServing{
+			Spec: KnativeServingSpec{},
+		},
+		expectedIstioConfig: base.IstioIngressConfiguration{
+			KnativeIngressGateway: nil,
+			KnativeLocalGateway:   nil,
+		},
 	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			istioConfig := ConvertToIstioConfig(tt.ks)

--- a/pkg/apis/operator/v1alpha1/knativeeventing_conversion.go
+++ b/pkg/apis/operator/v1alpha1/knativeeventing_conversion.go
@@ -25,63 +25,49 @@ import (
 )
 
 func convertFromSourceConfigsBeta(ke *v1beta1.KnativeEventing) *SourceConfigs {
-	ceph := base.CephSourceConfiguration{}
-	github := base.GithubSourceConfiguration{}
-	gitlab := base.GitlabSourceConfiguration{}
-	kafka := base.KafkaSourceConfiguration{}
-	natss := base.NatssSourceConfiguration{}
-	rabbitmq := base.RabbitmqSourceConfiguration{}
-	redis := base.RedisSourceConfiguration{}
-
 	if ke.Spec.Source != nil {
-		ceph = ke.Spec.Source.Ceph
-		github = ke.Spec.Source.Github
-		gitlab = ke.Spec.Source.Gitlab
-		kafka = ke.Spec.Source.Kafka
-		natss = ke.Spec.Source.Natss
-		rabbitmq = ke.Spec.Source.Rabbitmq
-		redis = ke.Spec.Source.Redis
+		ceph := ke.Spec.Source.Ceph
+		github := ke.Spec.Source.Github
+		gitlab := ke.Spec.Source.Gitlab
+		kafka := ke.Spec.Source.Kafka
+		natss := ke.Spec.Source.Natss
+		rabbitmq := ke.Spec.Source.Rabbitmq
+		redis := ke.Spec.Source.Redis
+		return &SourceConfigs{
+			Ceph:     ceph,
+			Github:   github,
+			Gitlab:   gitlab,
+			Kafka:    kafka,
+			Natss:    natss,
+			Rabbitmq: rabbitmq,
+			Redis:    redis,
+		}
 	}
 
-	return &SourceConfigs{
-		Ceph:     ceph,
-		Github:   github,
-		Gitlab:   gitlab,
-		Kafka:    kafka,
-		Natss:    natss,
-		Rabbitmq: rabbitmq,
-		Redis:    redis,
-	}
+	return nil
 }
 
 func convertToSourceConfigs(ke *KnativeEventing) *v1beta1.SourceConfigs {
-	ceph := base.CephSourceConfiguration{}
-	github := base.GithubSourceConfiguration{}
-	gitlab := base.GitlabSourceConfiguration{}
-	kafka := base.KafkaSourceConfiguration{}
-	natss := base.NatssSourceConfiguration{}
-	rabbitmq := base.RabbitmqSourceConfiguration{}
-	redis := base.RedisSourceConfiguration{}
-
 	if ke.Spec.Source != nil {
-		ceph = ke.Spec.Source.Ceph
-		github = ke.Spec.Source.Github
-		gitlab = ke.Spec.Source.Gitlab
-		kafka = ke.Spec.Source.Kafka
-		natss = ke.Spec.Source.Natss
-		rabbitmq = ke.Spec.Source.Rabbitmq
-		redis = ke.Spec.Source.Redis
+		ceph := ke.Spec.Source.Ceph
+		github := ke.Spec.Source.Github
+		gitlab := ke.Spec.Source.Gitlab
+		kafka := ke.Spec.Source.Kafka
+		natss := ke.Spec.Source.Natss
+		rabbitmq := ke.Spec.Source.Rabbitmq
+		redis := ke.Spec.Source.Redis
+		return &v1beta1.SourceConfigs{
+			Ceph:     ceph,
+			Github:   github,
+			Gitlab:   gitlab,
+			Kafka:    kafka,
+			Natss:    natss,
+			Rabbitmq: rabbitmq,
+			Redis:    redis,
+		}
 	}
 
-	return &v1beta1.SourceConfigs{
-		Ceph:     ceph,
-		Github:   github,
-		Gitlab:   gitlab,
-		Kafka:    kafka,
-		Natss:    natss,
-		Rabbitmq: rabbitmq,
-		Redis:    redis,
-	}
+	return nil
 }
 
 // ConvertTo implements apis.Convertible

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -225,7 +225,7 @@ function create_knative_serving() {
   version=${1}
   echo ">> Creating the custom resource of Knative Serving:"
   cat <<EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1beta1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
   name: ${TEST_RESOURCE}
@@ -239,7 +239,7 @@ function create_knative_eventing() {
   version=${1}
   echo ">> Creating the custom resource of Knative Eventing:"
   cat <<-EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1beta1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing
 metadata:
   name: ${TEST_RESOURCE}
@@ -252,7 +252,7 @@ EOF
 function create_latest_custom_resource() {
   echo ">> Creating the custom resource of Knative Serving:"
   cat <<-EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1beta1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeServing
 metadata:
   name: ${TEST_RESOURCE}
@@ -263,7 +263,7 @@ EOF
 
   echo ">> Creating the custom resource of Knative Eventing:"
   cat <<-EOF | kubectl apply -f -
-apiVersion: operator.knative.dev/v1beta1
+apiVersion: operator.knative.dev/v1alpha1
 kind: KnativeEventing
 metadata:
   name: ${TEST_RESOURCE}


### PR DESCRIPTION
Fixes: #970
KnativeServing transition between v1alpha1 and v1beta1 used to fail due to nil pointer, if the ingress configuration is empty.
This PR fixed this issue for the conversion webhook.