### PR TITLE
NIT: clean up handling of generated name values

### DIFF
--- a/pkg/reconciler/common/job.go
+++ b/pkg/reconciler/common/job.go
@@ -42,8 +42,9 @@ func JobTransform(obj base.KComponent) mf.Transformer {
 			if _, ok := obj.(*v1beta1.KnativeEventing); ok {
 				component = "eventing"
 			}
-			if job.GetName() == "" {
+			if job.GetName() == "" && job.GetGenerateName() != "" {
 				job.SetName(fmt.Sprintf("%s%s-%s", job.GetGenerateName(), component, TargetVersion(obj)))
+				job.SetGenerateName("")
 			} else {
 				job.SetName(fmt.Sprintf("%s-%s-%s", job.GetName(), component, TargetVersion(obj)))
 			}

--- a/pkg/reconciler/common/job_test.go
+++ b/pkg/reconciler/common/job_test.go
@@ -88,6 +88,7 @@ func TestJobTransform(t *testing.T) {
 			var job = &batchv1.Job{}
 			err := scheme.Scheme.Convert(&unstructuredJob, job, nil)
 			util.AssertEqual(t, err, nil)
+			util.AssertDeepEqual(t, job.GenerateName, "")
 			util.AssertDeepEqual(t, job.Name, tt.expected)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

* Only read the generated name when present in the upstream manifest, and than clear it out, since we use the actual name anyways

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
