### PR TITLE
Add the configuration of selector for services

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeeventings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -1683,6 +1683,11 @@ spec:
                         type: string
                       description: Annotations overrides labels for the service
                       type: object
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: Selector overrides selector for the service
+                      type: object
               source:
                 description: The source configuration for Knative Eventing
                 properties:

--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -1715,6 +1715,11 @@ spec:
                         type: string
                       description: Annotations overrides labels for the service
                       type: object
+                    selector:
+                      additionalProperties:
+                        type: string
+                      description: Selector overrides selector for the service
+                      type: object
               ingress:
                 description: The ingress configuration for Knative Serving
                 properties:

--- a/pkg/apis/operator/base/common.go
+++ b/pkg/apis/operator/base/common.go
@@ -276,6 +276,10 @@ type ServiceOverride struct {
 	// Annotations overrides labels for the service and its template.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Selector overrides the selector for the service
+	// +optional
+	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // ResourceRequirementsOverride enables the user to override any container's

--- a/pkg/apis/operator/base/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/base/zz_generated.deepcopy.go
@@ -544,6 +544,13 @@ func (in *ServiceOverride) DeepCopyInto(out *ServiceOverride) {
 			(*out)[key] = val
 		}
 	}
+	if in.Selector != nil {
+		in, out := &in.Selector, &out.Selector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/common/services_override.go
+++ b/pkg/reconciler/common/services_override.go
@@ -41,6 +41,7 @@ func ServicesTransform(obj base.KComponent, log *zap.SugaredLogger) mf.Transform
 				}
 				overrideLabels(&override, service)
 				overrideAnnotations(&override, service)
+				overrideSelectors(&override, service)
 				if err := scheme.Scheme.Convert(service, u, nil); err != nil {
 					return err
 				}
@@ -69,5 +70,15 @@ func overrideLabels(override *base.ServiceOverride, service *corev1.Service) {
 
 	for key, val := range override.Labels {
 		service.Labels[key] = val
+	}
+}
+
+func overrideSelectors(override *base.ServiceOverride, service *corev1.Service) {
+	if service.Spec.Selector == nil {
+		service.Spec.Selector = map[string]string{}
+	}
+
+	for key, val := range override.Selector {
+		service.Spec.Selector[key] = val
 	}
 }

--- a/pkg/reconciler/common/services_override_test.go
+++ b/pkg/reconciler/common/services_override_test.go
@@ -31,6 +31,7 @@ import (
 type expServices struct {
 	expLabels      map[string]string
 	expAnnotations map[string]string
+	expSelector    map[string]string
 }
 
 func TestServicesTransform(t *testing.T) {
@@ -45,11 +46,13 @@ func TestServicesTransform(t *testing.T) {
 				Name:        "controller",
 				Labels:      map[string]string{"a": "b"},
 				Annotations: map[string]string{"c": "d"},
+				Selector:    map[string]string{"app": "f"},
 			},
 		},
 		expServices: map[string]expServices{"controller": {
 			expLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "a": "b", "app": "controller"},
 			expAnnotations: map[string]string{"c": "d"},
+			expSelector:    map[string]string{"app": "f"},
 		}},
 	}, {
 		name:     "no override",
@@ -57,6 +60,7 @@ func TestServicesTransform(t *testing.T) {
 		expServices: map[string]expServices{"controller": {
 			expLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "controller"},
 			expAnnotations: nil,
+			expSelector:    map[string]string{"app": "controller"},
 		}},
 	}}
 
@@ -93,6 +97,10 @@ func TestServicesTransform(t *testing.T) {
 						}
 
 						if diff := cmp.Diff(got.GetAnnotations(), d.expAnnotations); diff != "" {
+							t.Fatalf("Unexpected annotations: %v", diff)
+						}
+
+						if diff := cmp.Diff(got.Spec.Selector, d.expSelector); diff != "" {
 							t.Fatalf("Unexpected annotations: %v", diff)
 						}
 					}


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1054

## Proposed Changes
- The PR makes the key-value pairs in the selector stanza of the service resource configurable.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
