### PR TITLE
remove defunct markdown linting variable

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -21,9 +21,6 @@
 # Use the flags --build-tests, --unit-tests and --integration-tests
 # to run a specific set of tests.
 
-# Markdown linting failures don't show up properly in Gubernator resulting
-# in a net-negative contributor experience.
-export DISABLE_MD_LINTING=1
 export GO111MODULE=on
 
 source $(dirname $0)/../vendor/knative.dev/hack/presubmit-tests.sh


### PR DESCRIPTION
Removing dead variable from the presubmit test script

Addresses https://github.com/knative/hack/issues/200
