### PR TITLE
Resolve the server-side CRD conflicts by adding a dummy webhook

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeeventings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -1067,4 +1067,11 @@ spec:
     singular: knativeeventing
   scope: Namespaced
   conversion:
-    strategy: None
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: default
+          path: /resource-conversion

--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -1132,4 +1132,11 @@ spec:
     singular: knativeserving
   scope: Namespaced
   conversion:
-    strategy: None
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: default
+          path: /resource-conversion

--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -23,8 +23,6 @@ metadata:
     app.kubernetes.io/version: devel
     app.kubernetes.io/name: knative-operator
 spec:
-  # Set to 0 due to the removal of CRD at v1alpha1.
-  replicas: 0
   selector:
     matchLabels:
       app: operator-webhook


### PR DESCRIPTION
Signed-off-by: Vincent Hou <shou@us.ibm.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1131 #1142

## Proposed Changes

* Add the webhook back as the conversion strategy.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
