### PR TITLE
Do not change `spec.replicas` directory for the Deployment which has HPA

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -30,6 +30,18 @@ func haUnSupported(obj base.KComponent) sets.String {
 	)
 }
 
+// When Deployment has HPA, the replicas should be controlled by HPA's minReplicas instead of operator.
+// Hence, skip changing the spec.replicas in deployment directory for these Deployments.
+func hasHorizontalPodAutoscaler(obj base.KComponent) sets.String {
+	return sets.NewString(
+		"webhook",
+		"activator",
+		"eventing-webhook",
+		"mt-broker-ingress",
+		"mt-broker-filter",
+	)
+}
+
 // HighAvailabilityTransform mutates configmaps and replicacounts of certain
 // controllers when HA control plane is specified.
 func HighAvailabilityTransform(obj base.KComponent, log *zap.SugaredLogger) mf.Transformer {
@@ -50,7 +62,7 @@ func HighAvailabilityTransform(obj base.KComponent, log *zap.SugaredLogger) mf.T
 		replicas := int64(*ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" && !haUnSupported(obj).Has(u.GetName()) {
+		if u.GetKind() == "Deployment" && !haUnSupported(obj).Has(u.GetName()) && !hasHorizontalPodAutoscaler(obj).Has(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -36,9 +36,6 @@ func hasHorizontalPodAutoscaler(obj base.KComponent) sets.String {
 	return sets.NewString(
 		"webhook",
 		"activator",
-		"eventing-webhook",
-		"mt-broker-ingress",
-		"mt-broker-filter",
 	)
 }
 

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -59,6 +59,11 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredHPA(t, "activator", 1, 4),
 		expected: makeUnstructuredHPA(t, "activator", 2, 5),
 	}, {
+		name:     "HA; do not adjust deployment directory which has HPA", // The replica should be djusted by HPA.
+		config:   makeHa(2),
+		in:       makeUnstructuredDeployment(t, "activator"),
+		expected: makeUnstructuredDeployment(t, "activator"),
+	}, {
 		name:     "HA; keep higher hpa value",
 		config:   makeHa(2),
 		in:       makeUnstructuredHPA(t, "activator", 3, 5),


### PR DESCRIPTION
When deployment has a HPA (e.g. acativator, webhook etc), the HPA should modifiy the `spec.replicas` in deployment.

However, operator's `spec.high-availability` also updates the `spec.replicas` in Deployment, so currently the replicas scaled up by HPA are terminated by the opreator due to the confliction between HPA's replica number and operator's replica number.

Operator already controlls HPA's minReplicas so this patch just skips the duplicated controll of the operator.

Fixes https://github.com/knative/operator/issues/1200

**Release Note**

```release-note
The bug which fails to scale up via HPA under the high load is fixed.
```
