### PR TITLE
Allow to use custom bootstrap configmap for Kourier

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -1022,6 +1022,8 @@ spec:
                         type: boolean
                       service-type:
                         type: string
+                      bootstrap-configmap:
+                        type: string
                     type: object
                 type: object
               manifests:

--- a/pkg/apis/operator/base/ingressconfiguration.go
+++ b/pkg/apis/operator/base/ingressconfiguration.go
@@ -40,6 +40,9 @@ type KourierIngressConfiguration struct {
 
 	// ServiceType specifies the service type for kourier gateway.
 	ServiceType v1.ServiceType `json:"service-type,omitempty"`
+
+	// BootstrapConfigmapName specifies the ConfigMap name which contains envoy bootstrap.
+	BootstrapConfigmapName string `json:"bootstrap-configmap,omitempty"`
 }
 
 // ContourIngressConfiguration specifies whether to enable the contour ingresses.

--- a/pkg/reconciler/knativeserving/ingress/ingress_test.go
+++ b/pkg/reconciler/knativeserving/ingress/ingress_test.go
@@ -572,7 +572,7 @@ func TestTransformers(t *testing.T) {
 				},
 			},
 		},
-		expected: 2,
+		expected: 3,
 	}, {
 		name: "Available contour ingress",
 		instance: servingv1beta1.KnativeServing{
@@ -608,7 +608,7 @@ func TestTransformers(t *testing.T) {
 				},
 			},
 		},
-		expected: 3,
+		expected: 4,
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Proposed Changes

Kourier's `kourier-bootstrap` contains the bootstrap config as https://github.com/knative-sandbox/net-kourier/blob/main/config/200-bootstrap.yaml.

As it is a raw config file, it is very difficult to customize the value on operator. So, this patch supports `bootstrap-configmap` field to use the customized bootstrap.

Usage:
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Namespace
metadata:
  name: knative-serving
---
apiVersion: operator.knative.dev/v1beta1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
spec:
  config:
    network:
      ingress-class: kourier.ingress.networking.knative.dev
  ingress:
    kourier:
      bootstrap-configmap: my-configmap
      enabled: true
```

Then, users can deploy their boostrap configmap with name `my-configmap` to use it.

**Release Note**

```release-note
Operator with Kourier supports `bootstrap-configmap` field to use customized bootstrap. 
```
