### PR TITLE
Deprecate HA field

### DIFF
--- a/pkg/apis/operator/base/common.go
+++ b/pkg/apis/operator/base/common.go
@@ -163,6 +163,7 @@ type CommonSpec struct {
 	AdditionalManifests []Manifest `json:"additionalManifests,omitempty"`
 
 	// HighAvailability allows specification of HA control plane.
+	// Deprecated: use WorkloadOverride to specify the replica on a per deployment base.
 	// +optional
 	HighAvailability *HighAvailability `json:"high-availability,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Deprecate HA in fav. of `WorkloadOverride`
*
*

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The high-availability field is deprecated and will be removed in a future version. Please use WorkloadOverride to specifiy replica number
```
