### PR TITLE
Fixing typo on actual API to use

### DIFF
--- a/pkg/apis/operator/base/common.go
+++ b/pkg/apis/operator/base/common.go
@@ -137,7 +137,7 @@ type CommonSpec struct {
 	// +optional
 	DeprecatedResources []ResourceRequirementsOverride `json:"resources,omitempty"`
 
-	// DEPRECATED. Use components
+	// DEPRECATED. Use workloads
 	// DeploymentOverride overrides Deployment configurations such as resources and replicas.
 	// +optional
 	DeploymentOverride []WorkloadOverride `json:"deployments,omitempty"`


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

## Proposed Changes

* update a deprecated API typo, since the actual referenced API was renamed during the PR

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
