### PR TITLE
Allow to set TopologySpreadConstraints via `spec.deployments.topologySpreadConstraints`

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeeventings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -397,6 +397,145 @@ spec:
                             type: string
                         type: object
                       type: array
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                    version:
+                      description: Version the cluster should be on.
+                      type: string
+                    volumeMounts:
+                      description: VolumeMounts allows configuration of additional VolumeMounts
+                        on the output StatefulSet definition. VolumeMounts specified will
+                        be appended to other VolumeMounts in the alertmanager container,
+                        that are generated as a result of StorageSpec objects.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within
+                          a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should
+                              be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated
+                              from the host to container and the other way around. When
+                              not set, MountPropagationNone is used. This field is beta
+                              in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the
+                              container's volume should be mounted. Behaves similarly to
+                              SubPath but environment variable references $(VAR_NAME) are
+                              expanded using the container's environment. Defaults to ""
+                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
                     affinity:
                       description: If specified, the pod's scheduling constraints.
                       properties:
@@ -1315,6 +1454,100 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     affinity:

--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -408,6 +408,145 @@ spec:
                             type: string
                         type: object
                       type: array
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
+                        type: object
+                      type: array
+                    version:
+                      description: Version the cluster should be on.
+                      type: string
+                    volumeMounts:
+                      description: VolumeMounts allows configuration of additional VolumeMounts
+                        on the output StatefulSet definition. VolumeMounts specified will
+                        be appended to other VolumeMounts in the alertmanager container,
+                        that are generated as a result of StorageSpec objects.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume within
+                          a container.
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume should
+                              be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are propagated
+                              from the host to container and the other way around. When
+                              not set, MountPropagationNone is used. This field is beta
+                              in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: Expanded path within the volume from which the
+                              container's volume should be mounted. Behaves similarly to
+                              SubPath but environment variable references $(VAR_NAME) are
+                              expanded using the container's environment. Defaults to ""
+                              (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
                     affinity:
                       description: If specified, the pod's scheduling constraints.
                       properties:
@@ -1326,6 +1465,100 @@ spec:
                               If the operator is Exists, the value should be empty, otherwise
                               just a regular string.
                             type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: If specified, the pod's topology spread constraints.
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread matching
+                          pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: LabelSelector is used to find matching pods. Pods
+                              that match this label selector are counted to determine the
+                              number of pods in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that relates
+                                    the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In, NotIn,
+                                        Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists or
+                                        DoesNotExist, the values array must be empty. This
+                                        array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field is
+                                  "key", the operator is "In", and the values array contains
+                                  only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          maxSkew:
+                            description: 'MaxSkew describes the degree to which pods may
+                              be unevenly distributed. It''s the maximum permitted difference
+                              between the number of matching pods in any two topology domains
+                              of a given topology type. For example, in a 3-zone cluster,
+                              MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3
+                              to become 1/1/1; scheduling it onto zone1(zone2) would make
+                              the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). -
+                              if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              It''s a required field. Default value is 1 and 0 is not allowed.'
+                            format: int32
+                            type: integer
+                          topologyKey:
+                            description: TopologyKey is the key of node labels. Nodes that
+                              have a label with this key and identical values are considered
+                              to be in the same topology. We consider each <key, value>
+                              as a "bucket", and try to put balanced number of pods into
+                              each bucket. It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: 'WhenUnsatisfiable indicates how to deal with a
+                              pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                              (default) tells the scheduler not to schedule it - ScheduleAnyway
+                              tells the scheduler to still schedule it It''s considered
+                              as "Unsatisfiable" if and only if placing incoming pod on
+                              any topology violates "MaxSkew". For example, in a 3-zone
+                              cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                              spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod
+                              can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2)
+                              as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In
+                              other words, the cluster can still be imbalanced, but scheduler
+                              won''t make it *more* imbalanced. It''s a required field.'
+                            type: string
+                        required:
+                        - maxSkew
+                        - topologyKey
+                        - whenUnsatisfiable
                         type: object
                       type: array
                     affinity:

--- a/pkg/apis/operator/base/common.go
+++ b/pkg/apis/operator/base/common.go
@@ -269,6 +269,10 @@ type WorkloadOverride struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+	// TopologySpreadConstraints overrides topologySpreadConstraints for the deployment.
+	// +optional
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints,omitempty"`
+
 	// Tolerations overrides tolerations for the deployment.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/pkg/apis/operator/base/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/base/zz_generated.deepcopy.go
@@ -618,6 +618,13 @@ func (in *WorkloadOverride) DeepCopyInto(out *WorkloadOverride) {
 			(*out)[key] = val
 		}
 	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))

--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -69,6 +69,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 			replaceLabels(&override, obj, ps)
 			replaceAnnotations(&override, obj, ps)
 			replaceNodeSelector(&override, ps)
+			replaceTopologySpreadConstraints(&override, ps)
 			replaceTolerations(&override, ps)
 			replaceAffinities(&override, ps)
 			replaceResources(&override, ps)
@@ -115,6 +116,12 @@ func replaceLabels(override *base.WorkloadOverride, obj metav1.Object, ps *corev
 func replaceNodeSelector(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) {
 	if len(override.NodeSelector) > 0 {
 		ps.Spec.NodeSelector = override.NodeSelector
+	}
+}
+
+func replaceTopologySpreadConstraints(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) {
+	if len(override.TopologySpreadConstraints) > 0 {
+		ps.Spec.TopologySpreadConstraints = override.TopologySpreadConstraints
 	}
 }
 

--- a/pkg/reconciler/common/workload_override_test.go
+++ b/pkg/reconciler/common/workload_override_test.go
@@ -38,17 +38,18 @@ import (
 )
 
 type expDeployments struct {
-	expLabels              map[string]string
-	expTemplateLabels      map[string]string
-	expAnnotations         map[string]string
-	expTemplateAnnotations map[string]string
-	expReplicas            int32
-	expNodeSelector        map[string]string
-	expTolerations         []corev1.Toleration
-	expAffinity            *corev1.Affinity
-	expEnv                 map[string][]corev1.EnvVar
-	expReadinessProbe      *v1.Probe
-	expLivenessProbe       *v1.Probe
+	expLabels                    map[string]string
+	expTemplateLabels            map[string]string
+	expAnnotations               map[string]string
+	expTemplateAnnotations       map[string]string
+	expReplicas                  int32
+	expNodeSelector              map[string]string
+	expTopologySpreadConstraints []corev1.TopologySpreadConstraint
+	expTolerations               []corev1.Toleration
+	expAffinity                  *corev1.Affinity
+	expEnv                       map[string][]corev1.EnvVar
+	expReadinessProbe            *v1.Probe
+	expLivenessProbe             *v1.Probe
 }
 
 func TestComponentsTransform(t *testing.T) {
@@ -63,14 +64,15 @@ func TestComponentsTransform(t *testing.T) {
 		name:     "no override",
 		override: nil,
 		expDeployment: map[string]expDeployments{"controller": {
-			expLabels:              map[string]string{"serving.knative.dev/release": "v0.13.0"},
-			expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "controller"},
-			expAnnotations:         nil,
-			expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
-			expReplicas:            0,
-			expNodeSelector:        nil,
-			expTolerations:         nil,
-			expAffinity:            nil,
+			expLabels:                    map[string]string{"serving.knative.dev/release": "v0.13.0"},
+			expTemplateLabels:            map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "controller"},
+			expAnnotations:               nil,
+			expTemplateAnnotations:       map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
+			expReplicas:                  0,
+			expNodeSelector:              nil,
+			expTopologySpreadConstraints: nil,
+			expTolerations:               nil,
+			expAffinity:                  nil,
 		}},
 	}, {
 		name: "simple override",
@@ -81,6 +83,14 @@ func TestComponentsTransform(t *testing.T) {
 				Annotations:  map[string]string{"c": "d"},
 				Replicas:     &five,
 				NodeSelector: map[string]string{"env": "prod"},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       corev1.LabelTopologyZone,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				}},
 				Tolerations: []corev1.Toleration{{
 					Key:      corev1.TaintNodeNotReady,
 					Operator: corev1.TolerationOpExists,
@@ -101,6 +111,14 @@ func TestComponentsTransform(t *testing.T) {
 			expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", "c": "d"},
 			expReplicas:            5,
 			expNodeSelector:        map[string]string{"env": "prod"},
+			expTopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelTopologyZone,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "controller"},
+				},
+			}},
 			expTolerations: []corev1.Toleration{{
 				Key:      corev1.TaintNodeNotReady,
 				Operator: corev1.TolerationOpExists,
@@ -486,6 +504,14 @@ func TestComponentsTransform(t *testing.T) {
 				Annotations:  map[string]string{"c": "d"},
 				Replicas:     &five,
 				NodeSelector: map[string]string{"env": "dev"},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       corev1.LabelTopologyZone,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				}},
 				Tolerations: []corev1.Toleration{{
 					Key:      corev1.TaintNodeNotReady,
 					Operator: corev1.TolerationOpExists,
@@ -512,6 +538,14 @@ func TestComponentsTransform(t *testing.T) {
 				Annotations:  map[string]string{"g": "h"},
 				Replicas:     &four,
 				NodeSelector: map[string]string{"env": "prod"},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       corev1.LabelTopologyZone,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				}},
 				Tolerations: []corev1.Toleration{{
 					Key:      corev1.TaintNodeUnschedulable,
 					Operator: corev1.TolerationOpExists,
@@ -542,6 +576,14 @@ func TestComponentsTransform(t *testing.T) {
 				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "true", "c": "d"},
 				expReplicas:            5,
 				expNodeSelector:        map[string]string{"env": "dev"},
+				expTopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       corev1.LabelTopologyZone,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				}},
 				expTolerations: []corev1.Toleration{{
 					Key:      corev1.TaintNodeNotReady,
 					Operator: corev1.TolerationOpExists,
@@ -569,6 +611,14 @@ func TestComponentsTransform(t *testing.T) {
 				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false", "g": "h"},
 				expReplicas:            4,
 				expNodeSelector:        map[string]string{"env": "prod"},
+				expTopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+					MaxSkew:           1,
+					TopologyKey:       corev1.LabelTopologyZone,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "controller"},
+					},
+				}},
 				expTolerations: []corev1.Toleration{{
 					Key:      corev1.TaintNodeUnschedulable,
 					Operator: corev1.TolerationOpExists,
@@ -652,6 +702,10 @@ func TestComponentsTransform(t *testing.T) {
 
 								if diff := cmp.Diff(got.Spec.Template.Spec.Tolerations, d.expTolerations); diff != "" {
 									t.Fatalf("Unexpected tolerations: %v", diff)
+								}
+
+								if diff := cmp.Diff(got.Spec.Template.Spec.TopologySpreadConstraints, d.expTopologySpreadConstraints); diff != "" {
+									t.Fatalf("Unexpected topologySpreadConstraints: %v", diff)
 								}
 
 								if diff := cmp.Diff(got.Spec.Template.Spec.Affinity, d.expAffinity); diff != "" {


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/1304

This patch adds `spec.deployments.topologySpreadConstraints` to set topologySpreadConstraints on each deployment.

For example, when the following CR is created,
```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: ks
  namespace: knative-serving
spec:
  high-availability:
    replicas: 1

  deployments:
  - name: webhook
    topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: topology.kubernetes.io/zone
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app: controller
```

The webhook deployment has `spec.template.spec.topologySpreadConstraints`.

```
$ kubectl get deploy webhook -o jsonpath={.spec.template.spec.topologySpreadConstraints}
[{"labelSelector":{"matchLabels":{"app":"controller"}},"maxSkew":1,"topologyKey":"topology.kubernetes.io/zone","whenUnsatisfiable":"DoNotSchedule"}]
```
