### PR TITLE
Take workload overrides into account for setting `SINK_BINDING_SELECTION_MODE` env var

### DIFF
--- a/pkg/apis/operator/v1beta1/knativeeventing_types.go
+++ b/pkg/apis/operator/v1beta1/knativeeventing_types.go
@@ -64,7 +64,8 @@ type KnativeEventingSpec struct {
 	// will be considered by the sinkbinding webhook;
 	// If `exclusion` is selected, namespaces/objects labelled as `bindings.knative.dev/exclude:true`
 	// will NOT be considered by the sinkbinding webhook.
-	// The default is `exclusion`.
+	// If no SINK_BINDING_SELECTION_MODE env var is given in the workloadOverrides for the
+	// sinkinding webhook, the default `exclusion` is used.
 	// +optional
 	SinkBindingSelectionMode string `json:"sinkBindingSelectionMode,omitempty"`
 

--- a/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode.go
+++ b/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode.go
@@ -79,7 +79,8 @@ func SinkBindingSelectionModeTransform(instance *eventingv1beta1.KnativeEventing
 }
 
 func sinkBindingSelectionModeFromWorkloadOverrides(instance *eventingv1beta1.KnativeEventing) string {
-	for _, workloadOverride := range instance.Spec.Workloads {
+	overrides := append(instance.Spec.Workloads, instance.Spec.DeploymentOverride...)
+	for _, workloadOverride := range overrides {
 		if workloadOverride.Name == "eventing-webhook" {
 			for _, envRequirement := range workloadOverride.Env {
 				if envRequirement.Container == "eventing-webhook" {

--- a/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode_test.go
+++ b/pkg/reconciler/knativeeventing/common/sinkbindingselectionmode_test.go
@@ -302,6 +302,52 @@ func Test_sinkBindingSelectionModeFromWorkloadOverrides(t *testing.T) {
 			want: "sbsmFromWorkloadOverride",
 		},
 		{
+			name: "should_take_deprecated_deployment_overrides_into_account_too",
+			instanceSpec: &eventingv1beta1.KnativeEventingSpec{
+				CommonSpec: base.CommonSpec{
+					DeploymentOverride: []base.WorkloadOverride{{
+						Name: "eventing-webhook",
+						Env: []base.EnvRequirementsOverride{{
+							Container: "eventing-webhook",
+							EnvVars: []corev1.EnvVar{{
+								Name:  "SINK_BINDING_SELECTION_MODE",
+								Value: "sbsmFromDeploymentOverride",
+							}},
+						}}},
+					},
+				},
+			},
+			want: "sbsmFromDeploymentOverride",
+		},
+		{
+			name: "workload_overrides_should_have_priority_over_deprecated_deployment_overrides",
+			instanceSpec: &eventingv1beta1.KnativeEventingSpec{
+				CommonSpec: base.CommonSpec{
+					Workloads: []base.WorkloadOverride{{
+						Name: "eventing-webhook",
+						Env: []base.EnvRequirementsOverride{{
+							Container: "eventing-webhook",
+							EnvVars: []corev1.EnvVar{{
+								Name:  "SINK_BINDING_SELECTION_MODE",
+								Value: "sbsmFromWorkloadOverride",
+							}},
+						}}},
+					},
+					DeploymentOverride: []base.WorkloadOverride{{
+						Name: "eventing-webhook",
+						Env: []base.EnvRequirementsOverride{{
+							Container: "eventing-webhook",
+							EnvVars: []corev1.EnvVar{{
+								Name:  "SINK_BINDING_SELECTION_MODE",
+								Value: "sbsmFromDeploymentOverride",
+							}},
+						}}},
+					},
+				},
+			},
+			want: "sbsmFromWorkloadOverride",
+		},
+		{
 			name: "should_return_empty_string_if_not_found",
 			instanceSpec: &eventingv1beta1.KnativeEventingSpec{
 				CommonSpec: base.CommonSpec{


### PR DESCRIPTION
Currently `SinkBindingSelectionModeTransform` sets the `SINK_BINDING_SELECTION_MODE` only based on the `.spec.sinkBindingSelectionMode` field.
In case `SINK_BINDING_SELECTION_MODE` is set the workload override of the eventing-webhook, this fields is ignored even when `.spec.sinkBindingSelectionMode` is set ([SRVKE-1360](https://issues.redhat.com/browse/SRVKE-1360)).

This PR addresses it and takes the `SINK_BINDING_SELECTION_MODE` env var from the workload override of the eventing-webhook into account, if `.spec.sinkBindingSelectionMode` is not set.

## Proposed Changes

* :bug: Take the `SINK_BINDING_SELECTION_MODE` env var from the workload override of the eventing-webhook into account, if `.spec.sinkBindingSelectionMode` is not set.
