### PR TITLE
Add 3scale-kourier-gateway to hasHorizontalPodAutoscaler

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -37,6 +37,7 @@ func hasHorizontalPodAutoscaler(obj base.KComponent) sets.String {
 	return sets.NewString(
 		"webhook",
 		"activator",
+		"3scale-kourier-gateway",
 	)
 }
 


### PR DESCRIPTION
Since HPA was added by https://github.com/knative-sandbox/net-kourier/pull/990 we need `replicas` must be controlled via HPA instead of `Deployments`.

This patch adds 3scale-kourier-gateway to hasHorizontalPodAutoscaler.

/cc @skonto @ReToCode 