### PR TITLE
Migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/cmd/operator/kodata/eventing-source/1.6/ceph/ceph.yaml
+++ b/cmd/operator/kodata/eventing-source/1.6/ceph/ceph.yaml
@@ -758,7 +758,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.6/github/github.yaml
+++ b/cmd/operator/kodata/eventing-source/1.6/github/github.yaml
@@ -1170,7 +1170,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.6/rabbitmq/rabbitmq-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.6/rabbitmq/rabbitmq-source.yaml
@@ -992,7 +992,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.6/redis/redis-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.6/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.7/ceph/ceph.yaml
+++ b/cmd/operator/kodata/eventing-source/1.7/ceph/ceph.yaml
@@ -758,7 +758,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.7/github/github.yaml
+++ b/cmd/operator/kodata/eventing-source/1.7/github/github.yaml
@@ -1170,7 +1170,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.7/rabbitmq/rabbitmq-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.7/rabbitmq/rabbitmq-source.yaml
@@ -998,7 +998,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.7/redis/redis-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.7/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.8/ceph/ceph.yaml
+++ b/cmd/operator/kodata/eventing-source/1.8/ceph/ceph.yaml
@@ -758,7 +758,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.8/github/github.yaml
+++ b/cmd/operator/kodata/eventing-source/1.8/github/github.yaml
@@ -1170,7 +1170,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.8/rabbitmq/rabbitmq-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.8/rabbitmq/rabbitmq-source.yaml
@@ -998,7 +998,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.8/redis/redis-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.8/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.9/ceph/ceph.yaml
+++ b/cmd/operator/kodata/eventing-source/1.9/ceph/ceph.yaml
@@ -758,7 +758,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.9/github/github.yaml
+++ b/cmd/operator/kodata/eventing-source/1.9/github/github.yaml
@@ -1170,7 +1170,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.9/rabbitmq/rabbitmq-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.9/rabbitmq/rabbitmq-source.yaml
@@ -998,7 +998,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/cmd/operator/kodata/eventing-source/1.9/redis/redis-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.9/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/ceph/ceph.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/ceph/ceph.yaml
@@ -757,7 +757,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/github/github.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/github/github.yaml
@@ -1160,7 +1160,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/rabbitmq/rabbitmq-source.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/rabbitmq/rabbitmq-source.yaml
@@ -808,7 +808,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/redis/redis-source.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.22/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/ceph/ceph.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/ceph/ceph.yaml
@@ -757,7 +757,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/github/github.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/github/github.yaml
@@ -1160,7 +1160,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/rabbitmq/rabbitmq-source.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/rabbitmq/rabbitmq-source.yaml
@@ -808,7 +808,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/redis/redis-source.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/eventing-source/0.23/redis/redis-source.yaml
@@ -852,7 +852,7 @@ data:
     # logging.fluentd-sidecar-image provides the fluentd sidecar image
     # to inject as a sidecar to collect logs from /var/log.
     # Must be presented if logging.enable-var-log-collection is true.
-    logging.fluentd-sidecar-image: k8s.gcr.io/fluentd-elasticsearch:v2.0.4
+    logging.fluentd-sidecar-image: registry.k8s.io/fluentd-elasticsearch:v2.0.4
 
     # logging.fluentd-sidecar-output-config provides the configuration
     # for the fluentd sidecar, which will be placed into a configmap and


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

This PR is a part of https://github.com/kubernetes/k8s.io/issues/4780.

## Proposed Changes
This PR does the following changes:
- modify all occurrences of k8s.gcr.io to registry.k8s.io.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```
NONE
```
