### PR TITLE
Allow to set HostNetwork via `spec.deployments.hostNetwork`

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeeventings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -397,6 +397,12 @@ spec:
                             type: string
                         type: object
                       type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
                     topologySpreadConstraints:
                       description: If specified, the pod's topology spread constraints.
                       items:
@@ -1456,6 +1462,12 @@ spec:
                             type: string
                         type: object
                       type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
                     topologySpreadConstraints:
                       description: If specified, the pod's topology spread constraints.
                       items:

--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -408,6 +408,12 @@ spec:
                             type: string
                         type: object
                       type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
                     topologySpreadConstraints:
                       description: If specified, the pod's topology spread constraints.
                       items:
@@ -1467,6 +1473,12 @@ spec:
                             type: string
                         type: object
                       type: array
+                    hostNetwork:
+                      description: Use the host's network namespace if true. Make sure to
+                        understand the security implications if you want to enable it. When
+                        hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet
+                        automatically.
+                      type: boolean
                     topologySpreadConstraints:
                       description: If specified, the pod's topology spread constraints.
                       items:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	gocloud.dev v0.22.0
 	golang.org/x/mod v0.6.0
 	golang.org/x/oauth2 v0.5.0
+	google.golang.org/api v0.110.0
 	istio.io/api v0.0.0-20220420164308-b6a03a9e477e
 	istio.io/client-go v1.13.3
 	k8s.io/api v0.25.4
@@ -123,7 +124,6 @@ require (
 	golang.org/x/tools v0.1.12 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.110.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230216225411-c8e22ba71e44 // indirect
 	google.golang.org/grpc v1.53.0 // indirect

--- a/pkg/apis/operator/base/common.go
+++ b/pkg/apis/operator/base/common.go
@@ -296,6 +296,11 @@ type WorkloadOverride struct {
 	// LivenessProbes overrides liveness probes for the containers.
 	// +optional
 	LivenessProbes []ProbesRequirementsOverride `json:"livenessProbes,omitempty"`
+
+	// HostNetwork overrides hostNetwork for the containers.
+	// When hostNetwork is enabled, this will set dnsPolicy to ClusterFirstWithHostNet automatically for the containers.
+	// +optional
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // ServiceOverride defines the configurations of the service to override.

--- a/pkg/apis/operator/base/zz_generated.deepcopy.go
+++ b/pkg/apis/operator/base/zz_generated.deepcopy.go
@@ -681,6 +681,11 @@ func (in *WorkloadOverride) DeepCopyInto(out *WorkloadOverride) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -75,6 +75,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 			replaceResources(&override, ps)
 			replaceEnv(&override, ps)
 			replaceProbes(&override, ps)
+			replaceHostNetwork(&override, ps)
 
 			if err := scheme.Scheme.Convert(obj, u, nil); err != nil {
 				return err
@@ -200,6 +201,16 @@ func replaceProbes(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) 
 				}
 				mergeProbe(overrideProbe, containers[i].LivenessProbe)
 			}
+		}
+	}
+}
+
+func replaceHostNetwork(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) {
+	if override.HostNetwork != nil {
+		ps.Spec.HostNetwork = *override.HostNetwork
+
+		if *override.HostNetwork {
+			ps.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 		}
 	}
 }


### PR DESCRIPTION
Part of https://github.com/knative/operator/issues/1362

This patch adds `spec.deployments.hostNetwork` to set hostNetwork on each deployment.
When hostNetwork is enabled, this will set `spec.deployments.hostNetwork` to `ClusterFirstWithHostNet` automatically on each deployment.

For example, when the following CR is created,

```
apiVersion: operator.knative.dev/v1alpha1
kind: KnativeServing
metadata:
  name: ks
  namespace: knative-serving
spec:
  high-availability:
    replicas: 1

  deployments:
  - name: webhook
    hostNetwork: true
```

The webhook deployment has `spec.template.spec.hostNetwork` and `spec.template.spec.dnsPolicy`.

```
$ kubectl get deploy webhook -o jsonpath={.spec.template.spec.hostNetwork}
true

$ kubectl get deploy webhook -o jsonpath={.spec.template.spec.dnsPolicy}
ClusterFirstWithHostNet
```
