### PR TITLE
Leverage the status.manifests to delete the old resources

### DIFF
--- a/pkg/reconciler/common/releases.go
+++ b/pkg/reconciler/common/releases.go
@@ -102,18 +102,7 @@ func InstalledManifest(instance base.KComponent) (mf.Manifest, error) {
 	if len(paths) == 0 {
 		return mf.Manifest{}, nil
 	}
-	manifest, err := FetchManifest(paths[0])
-	if err != nil {
-		return manifest, err
-	}
-	for i := 1; i < len(paths); i++ {
-		m, er := FetchManifest(paths[i])
-		if er != nil {
-			return manifest, er
-		}
-		manifest = manifest.Append(m)
-	}
-	return manifest, err
+	return FetchManifestFromArray(paths)
 }
 
 // IsVersionValidMigrationEligible returns the bool indicate whether the target version is valid and the installed
@@ -240,6 +229,23 @@ func FetchManifest(path string) (mf.Manifest, error) {
 		cache[path] = result
 	}
 	return result, err
+}
+
+// FetchManifestFromArray returns the manifest by either getting it from the cache, or reading them from the path.
+// The manifest is saved in the cache, if it is not available.
+func FetchManifestFromArray(paths []string) (mf.Manifest, error) {
+	manifest, err := FetchManifest(paths[0])
+	if err != nil {
+		return manifest, err
+	}
+	for i := 1; i < len(paths); i++ {
+		m, er := FetchManifest(paths[i])
+		if er != nil {
+			return manifest, er
+		}
+		manifest = manifest.Append(m)
+	}
+	return manifest, err
 }
 
 // fetchManifestFromPath returns the manifest by reading them from the path, and saves them in the cache.

--- a/pkg/reconciler/common/stages.go
+++ b/pkg/reconciler/common/stages.go
@@ -18,7 +18,6 @@ package common
 
 import (
 	"context"
-	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	"knative.dev/operator/pkg/apis/operator/base"
@@ -100,10 +99,8 @@ type ManifestFetcher func(ctx context.Context, instance base.KComponent) (*mf.Ma
 // manifest is captured in a closure before any stage might mutate the
 // instance status, e.g. Install.
 func DeleteObsoleteResources(ctx context.Context, instance base.KComponent, fetch ManifestFetcher) Stage {
-	version := TargetVersion(instance)
-	if version == instance.GetStatus().GetVersion() && len(instance.GetSpec().GetAdditionalManifests()) == 0 &&
-		len(instance.GetSpec().GetManifests()) == 0 &&
-		targetManifestPath(instance) == strings.Join(installedManifestPath(version, instance), COMMA) {
+	preManifests := instance.GetStatus().GetManifests()
+	if len(preManifests) == 0 {
 		return NoOp
 	}
 	logger := logging.FromContext(ctx)

--- a/pkg/reconciler/common/stages_test.go
+++ b/pkg/reconciler/common/stages_test.go
@@ -229,10 +229,13 @@ func TestDeleteObsoleteResources(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	deleteObsoleteResources := DeleteObsoleteResources(context.TODO(), &v1beta1.KnativeServing{},
-		func(context.Context, base.KComponent) (*mf.Manifest, error) {
-			return &manifest, nil
-		})
+	deleteObsoleteResources := DeleteObsoleteResources(context.TODO(), &v1beta1.KnativeServing{
+		Status: v1beta1.KnativeServingStatus{
+			Manifests: []string{"testdata/manifest.yaml"},
+		},
+	}, func(context.Context, base.KComponent) (*mf.Manifest, error) {
+		return &manifest, nil
+	})
 	nocms := manifest.Filter(mf.Not(mf.ByKind("ConfigMap")))
 	deleteObsoleteResources(context.TODO(), &nocms, nil)
 	// Now verify all the ConfigMaps are gone

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -143,10 +143,15 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 }
 
 func (r *Reconciler) installed(ctx context.Context, instance base.KComponent) (*mf.Manifest, error) {
-	// Create new, empty manifest with valid client and logger
-	installed := r.manifest.Append()
-	stages := common.Stages{common.AppendInstalled, source.AppendAllSources, r.transform}
-	err := stages.Execute(ctx, &installed, instance)
+	paths := instance.GetStatus().GetManifests()
+	installed, err := common.FetchManifestFromArray(paths)
+
+	if err != nil {
+		return &installed, err
+	}
+	installed = r.manifest.Append(installed)
+	stages := common.Stages{r.transform}
+	err = stages.Execute(ctx, &installed, instance)
 	return &installed, err
 }
 

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -147,10 +147,14 @@ func (r *Reconciler) transform(ctx context.Context, manifest *mf.Manifest, comp 
 }
 
 func (r *Reconciler) installed(ctx context.Context, instance base.KComponent) (*mf.Manifest, error) {
-	// Create new, empty manifest with valid client and logger
-	installed := r.manifest.Append()
-	stages := common.Stages{common.AppendInstalled, ingress.AppendInstalledIngresses, r.transform}
-	err := stages.Execute(ctx, &installed, instance)
+	paths := instance.GetStatus().GetManifests()
+	installed, err := common.FetchManifestFromArray(paths)
+	if err != nil {
+		return &installed, err
+	}
+	installed = r.manifest.Append(installed)
+	stages := common.Stages{r.transform}
+	err = stages.Execute(ctx, &installed, instance)
 	return &installed, err
 }
 


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1442

