### PR TITLE
Feat: Istio gateway TLS support added

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -2262,6 +2262,17 @@ spec:
                                       format: string
                                       type: string
                                   type: object
+                                tls:
+                                  properties:  
+                                    mode:
+                                      description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      description: TLS certificate name.
+                                      format: string
+                                      type: string                                      
+                                  type: object                                    
                               type: object
                             type: array
                         type: object
@@ -2300,6 +2311,17 @@ spec:
                                       format: string
                                       type: string
                                   type: object
+                                tls:
+                                  properties:  
+                                    mode:
+                                      description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
+                                      format: string
+                                      type: string
+                                    credentialName:
+                                      description: TLS certificate name.
+                                      format: string
+                                      type: string                                      
+                                  type: object                                
                               type: object
                             type: array
                         type: object


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1428
## Proposed Changes

* The change allow manual TLS setup for Istio gateway.
* The changes tested on Knative operator 1.9.5 

## Example Configuration
```
apiVersion: operator.knative.dev/v1beta1
kind: KnativeServing
metadata:
  name: knative-serving
  namespace: knative-serving
spec:
  ingress:
    istio:
      enabled: true
      knative-ingress-gateway:
        selector:
          istio: ingressgateway
        servers:
        - port:
            number: 80
            name: http
            protocol: HTTP
            target_port: 80
          hosts:
          - '*'
        - port:
            number: 443
            name: https
            protocol: HTTPS
            target_port: 8443
          tls:
            mode: SIMPLE
            credentialName: tls-certificate
          hosts:
          - '*'
  config:
    istio:
      local-gateway.knative-serving.knative-local-gateway: "knative-local-gateway.istio-system.svc.cluster.local"
```
