### PR TITLE
Mark operator-webhook as safe-to-evict via annotation value

### DIFF
--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: operator-webhook

--- a/config/webhook/webhook.yaml
+++ b/config/webhook/webhook.yaml
@@ -30,7 +30,6 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         sidecar.istio.io/inject: "false"
       labels:
         app: operator-webhook


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1444

## Proposed Changes

* As discussed with @dprotaso within #1444 should be safe to mark `operator-webhook` as "safe-to-evict", hence this PR

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Nothing expected from end users to switch to this new code
```
