### PR TITLE
Resume the development for 1.12

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,14 +18,14 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../vendor/knative.dev/hack/e2e-tests.sh"
 
 # The previous serving release, installed by the operator. This value should be in the semantic format of major.minor.
-readonly PREVIOUS_SERVING_RELEASE_VERSION="1.10"
+readonly PREVIOUS_SERVING_RELEASE_VERSION="1.11"
 # The previous eventing release, installed by the operator. This value should be in the semantic format of major.minor.
-readonly PREVIOUS_EVENTING_RELEASE_VERSION="1.10"
+readonly PREVIOUS_EVENTING_RELEASE_VERSION="1.11"
 # The target serving/eventing release to upgrade, installed by the operator. It can be a release available under
 # kodata or an incoming new release. This value should be in the semantic format of major.minor.
-readonly TARGET_RELEASE_VERSION="1.11"
+readonly TARGET_RELEASE_VERSION="latest"
 # This is the branch name of knative repos, where we run the upgrade tests.
-readonly KNATIVE_REPO_BRANCH="release-1.11"
+readonly KNATIVE_REPO_BRANCH="${PULL_BASE_REF}"
 # Namespaces used for tests
 # This environment variable TEST_NAMESPACE defines the namespace to install Knative Serving.
 export TEST_NAMESPACE="${TEST_NAMESPACE:-knative-operator-testing}"


### PR DESCRIPTION
- Configure the prow to install 1.11 as the previous release.
- Set the current release to latest to run the upgrade tests.