### PR TITLE
Allow to disable probe

### DIFF
--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -174,7 +174,8 @@ func replaceProbes(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) 
 	if len(override.ReadinessProbes) > 0 {
 		containers := ps.Spec.Containers
 		for i := range containers {
-			if override := findProbeOverride(override.ReadinessProbes, containers[i].Name); override != nil {
+			override := findProbeOverride(override.ReadinessProbes, containers[i].Name)
+			if override != nil {
 				overrideProbe := &v1.Probe{
 					InitialDelaySeconds:           override.InitialDelaySeconds,
 					TimeoutSeconds:                override.TimeoutSeconds,
@@ -182,6 +183,11 @@ func replaceProbes(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) 
 					SuccessThreshold:              override.SuccessThreshold,
 					FailureThreshold:              override.FailureThreshold,
 					TerminationGracePeriodSeconds: override.TerminationGracePeriodSeconds,
+				}
+				if *overrideProbe == (v1.Probe{}) {
+					//  Disable probe when users explicitly set the empty overrideProbe.
+					containers[i].ReadinessProbe = nil
+					continue
 				}
 				if containers[i].ReadinessProbe == nil {
 					containers[i].ReadinessProbe = overrideProbe
@@ -203,6 +209,11 @@ func replaceProbes(override *base.WorkloadOverride, ps *corev1.PodTemplateSpec) 
 					SuccessThreshold:              override.SuccessThreshold,
 					FailureThreshold:              override.FailureThreshold,
 					TerminationGracePeriodSeconds: override.TerminationGracePeriodSeconds,
+				}
+				if *overrideProbe == (v1.Probe{}) {
+					//  Disable probe when users explicitly set the empty overrideProbe.
+					containers[i].ReadinessProbe = nil
+					continue
 				}
 				if containers[i].LivenessProbe == nil {
 					containers[i].LivenessProbe = overrideProbe

--- a/pkg/reconciler/common/workload_override_test.go
+++ b/pkg/reconciler/common/workload_override_test.go
@@ -522,7 +522,7 @@ func TestComponentsTransform(t *testing.T) {
 				InitialDelaySeconds: 12,
 			}}},
 	}, {
-		name: "empty probe has no effect",
+		name: "empty probe drops probe",
 		override: []base.WorkloadOverride{
 			{
 				Name: "activator",
@@ -535,13 +535,6 @@ func TestComponentsTransform(t *testing.T) {
 			expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "activator", "role": "activator"},
 			expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
 			expReplicas:            0,
-			expReadinessProbe: &v1.Probe{
-				ProbeHandler: v1.ProbeHandler{
-					HTTPGet: &v1.HTTPGetAction{
-						Port:        intstr.IntOrString{IntVal: 8012},
-						HTTPHeaders: []v1.HTTPHeader{{Name: "k-kubelet-probe", Value: "activator"}},
-					}},
-			},
 			expLivenessProbe: &v1.Probe{
 				ProbeHandler: v1.ProbeHandler{
 					HTTPGet: &v1.HTTPGetAction{


### PR DESCRIPTION
## Proposed Changes

Currently it is not possible to disable {readiness,liveness}Probes. It is a problem for kourier gateway.
(Kourier's proble uses admin interface so users cannot change the admin config (`admin.address`) for debug without disabling the probe. More specifically please find `/tmp/envoy.admin` in [bootstrap.yaml](https://github.com/knative-extensions/net-kourier/blob/main/config/200-bootstrap.yaml) and [300-gateway.yaml](https://github.com/knative-extensions/net-kourier/blob/main/config/300-gateway.yaml))

Hence this patch changes to disable probe when users explicitly set the empty overrideProbe.

For example, if they have the following setting:

```yaml
  workloads:
  - livenessProbes:
    - container: kourier-gateway
    name: 3scale-kourier-gateway
```

then, drop livenessProbes from 3scale-kourier-gateway deployment.

**Release Note**

```release-note
Disable probe when explicitly settting the empty overrideProbe.
```
