### PR TITLE
Add more env vars for pingsource adapter env var preservation

### DIFF
--- a/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
+++ b/pkg/reconciler/knativeeventing/common/replicasenvvarstransform.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	envVarNames = sets.NewString(system.NamespaceEnvKey, "K_METRICS_CONFIG", "K_LOGGING_CONFIG",
-		"K_LEADER_ELECTION_CONFIG", "K_NO_SHUTDOWN_AFTER", "K_SINK_TIMEOUT")
+		"K_LEADER_ELECTION_CONFIG", "K_NO_SHUTDOWN_AFTER", "K_SINK_TIMEOUT", "K_TRACING_CONFIG", "NAMESPACE")
 )
 
 type unstructuredGetter interface {

--- a/pkg/reconciler/knativeeventing/common/replicasenvvarstransform_test.go
+++ b/pkg/reconciler/knativeeventing/common/replicasenvvarstransform_test.go
@@ -63,6 +63,10 @@ func TestPingsourceMTAadapterTransform(t *testing.T) {
                   value: ''
                 - name: K_LOGGING_CONFIG_1
                   value: 'overwrite'
+                - name: K_TRACING_CONFIG
+                  value: 'to be overwritten'
+                - name: NAMESPACE
+                  value: 'to be overwritten'
   existing:
     apiVersion: apps/v1
     kind: Deployment
@@ -88,6 +92,10 @@ func TestPingsourceMTAadapterTransform(t *testing.T) {
                   value: 'old'
                 - name: K_LOGGING_CONFIG_1
                   value: 'old'
+                - name: K_TRACING_CONFIG
+                  value: 'old'
+                - name: NAMESPACE
+                  value: 'old'
   expected:
     apiVersion: apps/v1
     kind: Deployment
@@ -110,6 +118,10 @@ func TestPingsourceMTAadapterTransform(t *testing.T) {
                 - name: K_METRICS_CONFIG
                   value: 'old'
                 - name: K_LOGGING_CONFIG
+                  value: 'old'
+                - name: K_TRACING_CONFIG
+                  value: 'old'
+                - name: NAMESPACE
                   value: 'old'
                 - name: K_LOGGING_CONFIG_1
                   value: 'overwrite'


### PR DESCRIPTION
<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Add more env vars for pingsource adapter env var preservation
* Without this, the eventing-controller and the operator are fighting to set env var values
* Related to https://github.com/knative/operator/issues/393
* Ideally, we should find a way to fix this problem for good! Current solution is to maintain the env vars manually.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
