### PR TITLE
set HPA replica values when workload overrides are set

### DIFF
--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -23,7 +23,6 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1beta1"
 
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -74,7 +73,7 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		in:       makeUnstructuredHPA(t, "activator", 2, 5),
 		expected: makeUnstructuredHPA(t, "activator", 2, 5),
 	}, {
-		name:     "HA; adjust hpa when replicas is lerger than maxReplicas",
+		name:     "HA; adjust hpa when replicas is larger than maxReplicas",
 		config:   makeHa(6),
 		in:       makeUnstructuredHPA(t, "activator", 2, 5),
 		expected: makeUnstructuredHPA(t, "activator", 6, 9), // maxReplicas is increased by max+(replicas-min) to avoid minReplicas > maxReplicas happenning.
@@ -107,7 +106,7 @@ func TestHighAvailabilityTransform(t *testing.T) {
 					},
 				},
 			}
-			haTransform := HighAvailabilityTransform(instance, log)
+			haTransform := HighAvailabilityTransform(instance)
 			err := haTransform(tc.in)
 
 			util.AssertDeepEqual(t, err, tc.err)
@@ -139,26 +138,6 @@ func makeUnstructuredDeploymentReplicas(t *testing.T, name string, replicas int3
 	err := scheme.Scheme.Convert(d, result, nil)
 	if err != nil {
 		t.Fatalf("Could not create unstructured Deployment: %v, err: %v", d, err)
-	}
-
-	return result
-}
-
-func makeUnstructuredHPA(t *testing.T, name string, minReplicas, maxReplicas int32) *unstructured.Unstructured {
-	hpa := &autoscalingv2beta1.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: autoscalingv2beta1.HorizontalPodAutoscalerSpec{
-			MinReplicas: &minReplicas,
-			MaxReplicas: maxReplicas,
-		},
-	}
-
-	result := &unstructured.Unstructured{}
-	err := scheme.Scheme.Convert(hpa, result, nil)
-	if err != nil {
-		t.Fatalf("Could not create unstructured HPA: %v, err: %v", hpa, err)
 	}
 
 	return result

--- a/pkg/reconciler/common/ha_test.go
+++ b/pkg/reconciler/common/ha_test.go
@@ -76,7 +76,7 @@ func TestHighAvailabilityTransform(t *testing.T) {
 		name:     "HA; adjust hpa when replicas is larger than maxReplicas",
 		config:   makeHa(6),
 		in:       makeUnstructuredHPA(t, "activator", 2, 5),
-		expected: makeUnstructuredHPA(t, "activator", 6, 9), // maxReplicas is increased by max+(replicas-min) to avoid minReplicas > maxReplicas happenning.
+		expected: makeUnstructuredHPA(t, "activator", 6, 9), // maxReplicas is increased by max+(replicas-min) to avoid minReplicas > maxReplicas happening.
 	}, {
 		name:     "HA; adjust hpa when minReplica is equal to maxReplicas",
 		config:   makeHa(3),

--- a/pkg/reconciler/common/hpa.go
+++ b/pkg/reconciler/common/hpa.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// When Deployment has HPA, the replicas should be controlled by HPA's minReplicas instead of operator.
+// Hence, skip changing the spec.replicas in deployment directory for these Deployments.
+func hasHorizontalPodAutoscaler(name string) bool {
+	return sets.NewString(
+		"webhook",
+		"activator",
+		"3scale-kourier-gateway",
+	).Has(name)
+}
+
+// hpaTransform sets the minReplicas and maxReplicas of an HPA based on a replica override value.
+// If minReplica needs to be increased, the maxReplica is increased by the same value.
+func hpaTransform(u *unstructured.Unstructured, replicas int64) error {
+	if u.GetKind() != "HorizontalPodAutoscaler" {
+		return nil
+	}
+
+	min, _, err := unstructured.NestedInt64(u.Object, "spec", "minReplicas")
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if the HPA ships with even more replicas out of the box.
+	if min >= replicas {
+		return nil
+	}
+
+	if err := unstructured.SetNestedField(u.Object, replicas, "spec", "minReplicas"); err != nil {
+		return err
+	}
+
+	max, found, err := unstructured.NestedInt64(u.Object, "spec", "maxReplicas")
+	if err != nil {
+		return err
+	}
+
+	// Do nothing if maxReplicas is not defined.
+	if !found {
+		return nil
+	}
+
+	// Increase maxReplicas to the amount that we increased,
+	// because we need to avoid minReplicas > maxReplicas happenning.
+	if err := unstructured.SetNestedField(u.Object, max+(replicas-min), "spec", "maxReplicas"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/reconciler/common/hpa.go
+++ b/pkg/reconciler/common/hpa.go
@@ -21,14 +21,32 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// When Deployment has HPA, the replicas should be controlled by HPA's minReplicas instead of operator.
-// Hence, skip changing the spec.replicas in deployment directory for these Deployments.
+// When a Podspecable has HPA, the replicas should be controlled by HPAs minReplicas instead of operator.
+// Hence, skip changing the spec.replicas for these Podspecables.
 func hasHorizontalPodAutoscaler(name string) bool {
 	return sets.NewString(
 		"webhook",
 		"activator",
 		"3scale-kourier-gateway",
+		"eventing-webhook",
+		"mt-broker-ingress",
+		"mt-broker-filter",
 	).Has(name)
+}
+
+// Maps a Podspecables name to the HPAs name.
+// Add overrides here, if your HPA is named differently to the workloads name,
+// if no override is defined, the name of the podspecable is used as HPA name.
+func getHPAName(podspecableName string) string {
+	overrides := map[string]string{
+		"mt-broker-ingress": "broker-ingress-hpa",
+		"mt-broker-filter":  "broker-filter-hpa",
+	}
+	if v, ok := overrides[podspecableName]; ok {
+		return v
+	} else {
+		return podspecableName
+	}
 }
 
 // hpaTransform sets the minReplicas and maxReplicas of an HPA based on a replica override value.
@@ -63,7 +81,7 @@ func hpaTransform(u *unstructured.Unstructured, replicas int64) error {
 	}
 
 	// Increase maxReplicas to the amount that we increased,
-	// because we need to avoid minReplicas > maxReplicas happenning.
+	// because we need to avoid minReplicas > maxReplicas happening.
 	if err := unstructured.SetNestedField(u.Object, max+(replicas-min), "spec", "maxReplicas"); err != nil {
 		return err
 	}

--- a/pkg/reconciler/common/hpa_test.go
+++ b/pkg/reconciler/common/hpa_test.go
@@ -64,6 +64,11 @@ func TestHpaTransform(t *testing.T) {
 	}
 }
 
+func TestGetHPAName(t *testing.T) {
+	util.AssertEqual(t, getHPAName("mt-broker-ingress"), "broker-ingress-hpa")
+	util.AssertEqual(t, getHPAName("activator"), "activator")
+}
+
 func makeUnstructuredHPA(t *testing.T, name string, minReplicas, maxReplicas int32) *unstructured.Unstructured {
 	hpa := &v2beta1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/common/hpa_test.go
+++ b/pkg/reconciler/common/hpa_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"k8s.io/api/autoscaling/v2beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+	util "knative.dev/operator/pkg/reconciler/common/testing"
+)
+
+func TestHpaTransform(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       *unstructured.Unstructured
+		replicas int64
+		expected *unstructured.Unstructured
+		err      error
+	}{{
+		name:     "Object is not a HPA",
+		in:       makeUnstructuredDeployment(t, "not-a-hpa"),
+		replicas: 5,
+		expected: makeUnstructuredDeployment(t, "not-a-hpa"),
+		err:      nil,
+	}, {
+		name:     "minReplicas same as override",
+		in:       makeUnstructuredHPA(t, "hpa", 1, 2),
+		replicas: 1,
+		expected: makeUnstructuredHPA(t, "hpa", 1, 2),
+		err:      nil,
+	}, {
+		name:     "minReplicas lower than override",
+		in:       makeUnstructuredHPA(t, "hpa", 1, 2),
+		replicas: 5,
+		expected: makeUnstructuredHPA(t, "hpa", 5, 6),
+		err:      nil,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			err := hpaTransform(tc.in, tc.replicas)
+
+			util.AssertDeepEqual(t, err, tc.err)
+			util.AssertDeepEqual(t, tc.in, tc.expected)
+		})
+	}
+}
+
+func makeUnstructuredHPA(t *testing.T, name string, minReplicas, maxReplicas int32) *unstructured.Unstructured {
+	hpa := &v2beta1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v2beta1.HorizontalPodAutoscalerSpec{
+			MinReplicas: &minReplicas,
+			MaxReplicas: maxReplicas,
+		},
+	}
+
+	result := &unstructured.Unstructured{}
+	err := scheme.Scheme.Convert(hpa, result, nil)
+	if err != nil {
+		t.Fatalf("Could not create unstructured HPA: %v, err: %v", hpa, err)
+	}
+
+	return result
+}

--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -30,7 +30,7 @@ func transformers(ctx context.Context, obj base.KComponent) []mf.Transformer {
 	return []mf.Transformer{
 		injectOwner(obj),
 		mf.InjectNamespace(obj.GetNamespace()),
-		HighAvailabilityTransform(obj, logger),
+		HighAvailabilityTransform(obj),
 		ImageTransform(obj.GetSpec().GetRegistry(), logger),
 		JobTransform(obj),
 		ConfigMapTransform(obj.GetSpec().GetConfig(), logger),

--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -75,7 +75,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				ps = &job.Spec.Template
 			}
 
-			if u.GetKind() == "HorizontalPodAutoscaler" && u.GetName() == override.Name && override.Replicas != nil {
+			if u.GetKind() == "HorizontalPodAutoscaler" && override.Replicas != nil && u.GetName() == getHPAName(override.Name) {
 				overrideReplicas := int64(*override.Replicas)
 				if err := hpaTransform(u, overrideReplicas); err != nil {
 					return err

--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -47,7 +47,9 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				}
 				obj = deployment
 				ps = &deployment.Spec.Template
-				if override.Replicas != nil {
+
+				// Do not set replicas, if this resource is controlled by a HPA
+				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
 					deployment.Spec.Replicas = override.Replicas
 				}
 			}
@@ -58,7 +60,9 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				}
 				obj = ss
 				ps = &ss.Spec.Template
-				if override.Replicas != nil {
+
+				// Do not set replicas, if this resource is controlled by a HPA
+				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
 					ss.Spec.Replicas = override.Replicas
 				}
 			}
@@ -69,6 +73,13 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				}
 				obj = job
 				ps = &job.Spec.Template
+			}
+
+			if u.GetKind() == "HorizontalPodAutoscaler" && u.GetName() == override.Name && override.Replicas != nil {
+				overrideReplicas := int64(*override.Replicas)
+				if err := hpaTransform(u, overrideReplicas); err != nil {
+					return err
+				}
 			}
 
 			if obj == nil {

--- a/pkg/reconciler/common/workload_override_test.go
+++ b/pkg/reconciler/common/workload_override_test.go
@@ -154,7 +154,7 @@ func TestComponentsTransform(t *testing.T) {
 			expDNSPolicy:   nil,
 		}},
 	}, {
-		name: "no replicas in deployment override, use global replicas",
+		name: "no replicas in workload override, use global replicas",
 		override: []base.WorkloadOverride{
 			{Name: "controller"},
 		},
@@ -551,7 +551,7 @@ func TestComponentsTransform(t *testing.T) {
 			},
 		}},
 	}, {
-		name: "neither replicas in deployment override nor global replicas",
+		name: "neither replicas in workload override nor global replicas",
 		override: []base.WorkloadOverride{
 			{Name: "controller"},
 		},

--- a/pkg/reconciler/common/workload_override_test.go
+++ b/pkg/reconciler/common/workload_override_test.go
@@ -154,7 +154,7 @@ func TestComponentsTransform(t *testing.T) {
 			expDNSPolicy:   nil,
 		}},
 	}, {
-		name: "no replicas in deploymentoverride, use global replicas",
+		name: "no replicas in deployment override, use global replicas",
 		override: []base.WorkloadOverride{
 			{Name: "controller"},
 		},
@@ -713,7 +713,42 @@ func TestComponentsTransform(t *testing.T) {
 			},
 		},
 	}, {
-		name: "HPA activator override minReplicas",
+		name: "activator HPA no override",
+		expDeployment: map[string]expDeployments{
+			"activator": {
+				expLabels:              map[string]string{"serving.knative.dev/release": "v0.13.0"},
+				expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "activator", "role": "activator"},
+				expAnnotations:         nil,
+				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
+				expReplicas:            0, // if hpa is used, this should never be set
+			},
+		},
+		expHorizontalPodAutoscaler: map[string]expHorizontalPodAutoscalers{
+			"activator": {
+				expMinReplicas: 1,  // defined in manifest.yaml
+				expMaxReplicas: 20, // defined in manifest.yaml
+			},
+		},
+	}, {
+		name:           "activator HPA global replicas override",
+		globalReplicas: 10,
+		expDeployment: map[string]expDeployments{
+			"activator": {
+				expLabels:              map[string]string{"serving.knative.dev/release": "v0.13.0"},
+				expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "activator", "role": "activator"},
+				expAnnotations:         nil,
+				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
+				expReplicas:            0, // if hpa is used, this should never be set
+			},
+		},
+		expHorizontalPodAutoscaler: map[string]expHorizontalPodAutoscalers{
+			"activator": {
+				expMinReplicas: 10,
+				expMaxReplicas: 29, // in manifest.yaml maxReplicas=20 +9 (difference between existing min and overwritten min)
+			},
+		},
+	}, {
+		name: "activator HPA workload override",
 		override: []base.WorkloadOverride{
 			{
 				Name:     "activator",
@@ -726,7 +761,31 @@ func TestComponentsTransform(t *testing.T) {
 				expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "activator", "role": "activator"},
 				expAnnotations:         nil,
 				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
-				expReplicas:            0,
+				expReplicas:            0, // if hpa is used, this should never be set
+			},
+		},
+		expHorizontalPodAutoscaler: map[string]expHorizontalPodAutoscalers{
+			"activator": {
+				expMinReplicas: four,
+				expMaxReplicas: 23, // in manifest.yaml maxReplicas=20 +3 (difference between existing min and overwritten min)
+			},
+		},
+	}, {
+		name:           "activator HPA global and workload override",
+		globalReplicas: 10,
+		override: []base.WorkloadOverride{
+			{
+				Name:     "activator",
+				Replicas: &four,
+			},
+		},
+		expDeployment: map[string]expDeployments{
+			"activator": {
+				expLabels:              map[string]string{"serving.knative.dev/release": "v0.13.0"},
+				expTemplateLabels:      map[string]string{"serving.knative.dev/release": "v0.13.0", "app": "activator", "role": "activator"},
+				expAnnotations:         nil,
+				expTemplateAnnotations: map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"},
+				expReplicas:            0, // if hpa is used, this should never be set
 			},
 		},
 		expHorizontalPodAutoscaler: map[string]expHorizontalPodAutoscalers{


### PR DESCRIPTION
Fixes #762

## Proposed Changes
* Set HPA `minReplicas` and `maxReplicas` when `workloads.replicas` overrides are present for an object with HPA
* Uses the same behaviour as for the `high-availability` field
* Moved HPA transformation logic to a common file
* Add Eventing HPAs to `hasHorizontalPodAutoscaler`
* Add HPA name mapping for Eventing HPAs that are named different to their target: `getHPAName`

**Release Note**
```release-note
The operator now sets HorizontalPodAutoscaler replicas (on resources with HPAs) when workload overrides are defined.
```
