### PR TITLE
Drop autoscaling/v2beta1 and policy/v1beta1

### DIFF
--- a/pkg/reconciler/common/hpa_test.go
+++ b/pkg/reconciler/common/hpa_test.go
@@ -19,7 +19,7 @@ package common
 import (
 	"testing"
 
-	"k8s.io/api/autoscaling/v2beta1"
+	v2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -70,11 +70,11 @@ func TestGetHPAName(t *testing.T) {
 }
 
 func makeUnstructuredHPA(t *testing.T, name string, minReplicas, maxReplicas int32) *unstructured.Unstructured {
-	hpa := &v2beta1.HorizontalPodAutoscaler{
+	hpa := &v2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v2beta1.HorizontalPodAutoscalerSpec{
+		Spec: v2.HorizontalPodAutoscalerSpec{
 			MinReplicas: &minReplicas,
 			MaxReplicas: maxReplicas,
 		},

--- a/pkg/reconciler/common/poddisruptionbudget_override.go
+++ b/pkg/reconciler/common/poddisruptionbudget_override.go
@@ -20,7 +20,6 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"go.uber.org/zap"
 	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -41,24 +40,13 @@ func PodDisruptionBudgetsTransform(obj base.KComponent, log *zap.SugaredLogger) 
 					return nil
 				}
 
-				if u.GetAPIVersion() == "policy/v1beta1" {
-					podDisruptionBudget := &policyv1beta1.PodDisruptionBudget{}
-					if err := scheme.Scheme.Convert(u, podDisruptionBudget, nil); err != nil {
-						return err
-					}
-					podDisruptionBudget.Spec.MinAvailable = override.MinAvailable
-					if err := scheme.Scheme.Convert(podDisruptionBudget, u, nil); err != nil {
-						return err
-					}
-				} else {
-					podDisruptionBudget := &policyv1.PodDisruptionBudget{}
-					if err := scheme.Scheme.Convert(u, podDisruptionBudget, nil); err != nil {
-						return err
-					}
-					podDisruptionBudget.Spec.MinAvailable = override.MinAvailable
-					if err := scheme.Scheme.Convert(podDisruptionBudget, u, nil); err != nil {
-						return err
-					}
+				podDisruptionBudget := &policyv1.PodDisruptionBudget{}
+				if err := scheme.Scheme.Convert(u, podDisruptionBudget, nil); err != nil {
+					return err
+				}
+				podDisruptionBudget.Spec.MinAvailable = override.MinAvailable
+				if err := scheme.Scheme.Convert(podDisruptionBudget, u, nil); err != nil {
+					return err
 				}
 
 				// Avoid superfluous updates from converted zero defaults

--- a/pkg/reconciler/common/poddisruptionbudget_override_test.go
+++ b/pkg/reconciler/common/poddisruptionbudget_override_test.go
@@ -22,103 +22,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mf "github.com/manifestival/manifestival"
 	policyv1 "k8s.io/api/policy/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"knative.dev/operator/pkg/apis/operator/base"
 	servingv1beta1 "knative.dev/operator/pkg/apis/operator/v1beta1"
 )
-
-func TestPodDisruptionBudgetsTransformV1beta1(t *testing.T) {
-	tests := []struct {
-		name            string
-		testName        string
-		overrides       []base.PodDisruptionBudgetOverride
-		expMinAvailable *intstr.IntOrString
-	}{{
-		name:     "simple override",
-		testName: "activator-pdb",
-		overrides: []base.PodDisruptionBudgetOverride{
-			{
-				Name: "activator-pdb",
-				PodDisruptionBudgetSpec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: &intstr.IntOrString{StrVal: "50%", Type: intstr.String},
-				},
-			},
-		},
-		expMinAvailable: &intstr.IntOrString{StrVal: "50%", Type: intstr.String},
-	}, {
-		name:            "no override",
-		overrides:       nil,
-		testName:        "activator-pdb",
-		expMinAvailable: &intstr.IntOrString{StrVal: "80%", Type: intstr.String},
-	}, {
-		name:     "override with no MinVailable",
-		testName: "activator-pdb",
-		overrides: []base.PodDisruptionBudgetOverride{
-			{
-				Name: "activator-pdb",
-				PodDisruptionBudgetSpec: policyv1.PodDisruptionBudgetSpec{
-					MinAvailable: nil,
-				},
-			},
-		},
-		expMinAvailable: &intstr.IntOrString{StrVal: "80%", Type: intstr.String},
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			manifest, err := mf.NewManifest("testdata/manifest.yaml")
-			if err != nil {
-				t.Fatalf("Failed to create manifest: %v", err)
-			}
-
-			ks := &servingv1beta1.KnativeServing{
-				Spec: servingv1beta1.KnativeServingSpec{
-					CommonSpec: base.CommonSpec{
-						PodDisruptionBudgetOverride: test.overrides,
-					},
-				},
-			}
-
-			manifest, err = manifest.Transform(PodDisruptionBudgetsTransform(ks, log))
-			if err != nil {
-				t.Fatalf("Failed to transform manifest: %v", err)
-			}
-
-			if test.overrides == nil {
-				for _, u := range manifest.Resources() {
-					if u.GetKind() == "PodDisruptionBudget" && u.GetName() == test.testName {
-						got := &policyv1beta1.PodDisruptionBudget{}
-						if err := scheme.Scheme.Convert(&u, got, nil); err != nil {
-							t.Fatalf("Failed to convert unstructured to PodDisruptionBudget: %v", err)
-						}
-
-						if diff := cmp.Diff(*got.Spec.MinAvailable, *test.expMinAvailable); diff != "" {
-							t.Fatalf("Unexpected minAvailable: %v", diff)
-						}
-					}
-				}
-			}
-
-			for _, override := range test.overrides {
-				for _, u := range manifest.Resources() {
-					if u.GetKind() == "PodDisruptionBudget" && u.GetName() == override.Name {
-						got := &policyv1beta1.PodDisruptionBudget{}
-						if err := scheme.Scheme.Convert(&u, got, nil); err != nil {
-							t.Fatalf("Failed to convert unstructured to PodDisruptionBudget: %v", err)
-						}
-
-						if diff := cmp.Diff(*got.Spec.MinAvailable, *test.expMinAvailable); diff != "" {
-							t.Fatalf("Unexpected minAvailable: %v", diff)
-						}
-					}
-				}
-			}
-		})
-	}
-}
 
 func TestPodDisruptionBudgetsTransformV1(t *testing.T) {
 	tests := []struct {

--- a/pkg/reconciler/common/testdata/manifest.yaml
+++ b/pkg/reconciler/common/testdata/manifest.yaml
@@ -2816,22 +2816,6 @@ spec:
               containerPort: 8008
 
 ---
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: activator-pdb
-  namespace: knative-serving
-  labels:
-    app.kubernetes.io/component: activator
-    app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.0.0"
-spec:
-  minAvailable: 80%
-  selector:
-    matchLabels:
-      app: activator
-
----
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/pkg/reconciler/common/testdata/manifest.yaml
+++ b/pkg/reconciler/common/testdata/manifest.yaml
@@ -959,7 +959,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator

--- a/pkg/reconciler/common/workload_override_test.go
+++ b/pkg/reconciler/common/workload_override_test.go
@@ -24,7 +24,7 @@ import (
 	mf "github.com/manifestival/manifestival"
 	"google.golang.org/api/googleapi"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/autoscaling/v2beta1"
+	v2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -915,7 +915,7 @@ func TestComponentsTransform(t *testing.T) {
 					for expName, d := range test.expHorizontalPodAutoscaler {
 						for _, u := range manifest.Resources() {
 							if u.GetKind() == "HorizontalPodAutoscaler" && u.GetName() == expName {
-								got := &v2beta1.HorizontalPodAutoscaler{}
+								got := &v2.HorizontalPodAutoscaler{}
 								if err := scheme.Scheme.Convert(&u, got, nil); err != nil {
 									t.Fatalf("Failed to convert unstructured to deployment: %v", err)
 								}

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/knative-eventing/0.22.1/2-eventing-core.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/knative-eventing/0.22.1/2-eventing-core.yaml
@@ -803,7 +803,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook
@@ -826,7 +826,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: eventing-webhook

--- a/pkg/reconciler/knativeeventing/source/testdata/kodata/knative-eventing/0.23.0/2-eventing-core.yaml
+++ b/pkg/reconciler/knativeeventing/source/testdata/kodata/knative-eventing/0.23.0/2-eventing-core.yaml
@@ -803,7 +803,7 @@ spec:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: eventing-webhook
@@ -826,7 +826,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: eventing-webhook

--- a/pkg/reconciler/manifests/testdata/kodata/knative-eventing/0.23.0/2-eventing-core.yaml
+++ b/pkg/reconciler/manifests/testdata/kodata/knative-eventing/0.23.0/2-eventing-core.yaml
@@ -826,7 +826,7 @@ spec:
           averageUtilization: 100
 ---
 # Webhook PDB.
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: eventing-webhook


### PR DESCRIPTION
## Proposed Changes

* As per title, these APIs are no longer supported on current supported k8s versions.

**Release Note**

```release-note
autoscaling/v2beta1 and policy/v1beta1 are no longer supported. Please use autoscaling/v2 and policy/v1 if you are using custom manifests.
```
