### PR TITLE
Fix wrongly dropped transformer

### DIFF
--- a/pkg/reconciler/common/transformers.go
+++ b/pkg/reconciler/common/transformers.go
@@ -28,6 +28,7 @@ func transformers(ctx context.Context, obj base.KComponent) []mf.Transformer {
 	return []mf.Transformer{
 		mf.InjectOwner(obj),
 		mf.InjectNamespace(obj.GetNamespace()),
+		JobTransform(obj),
 		HighAvailabilityTransform(obj),
 		ImageTransform(obj.GetSpec().GetRegistry(), logger),
 		ConfigMapTransform(obj.GetSpec().GetConfig(), logger),


### PR DESCRIPTION
# Changes
https://github.com/knative/operator/pull/1577 accidentally dropped the `JobTransformer`. This adds it back.

/assign @pierDipi 