### PR TITLE
Improve KnativeEventing finalization for TLS resources

### DIFF
--- a/pkg/reconciler/knativeeventing/eventing_tls.go
+++ b/pkg/reconciler/knativeeventing/eventing_tls.go
@@ -30,14 +30,16 @@ import (
 	"knative.dev/operator/pkg/apis/operator/v1beta1"
 )
 
+var (
+	tlsResourcesPred = byGroup("cert-manager.io")
+)
+
 func (r *Reconciler) handleTLSResources(ctx context.Context, manifests *mf.Manifest, comp base.KComponent) error {
 	instance := comp.(*v1beta1.KnativeEventing)
 
 	if isTLSEnabled(instance) {
 		return nil
 	}
-
-	tlsResourcesPred := byGroup("cert-manager.io")
 
 	// Delete TLS resources (if present)
 	toBeDeleted := manifests.Filter(tlsResourcesPred)


### PR DESCRIPTION
For optional resources like cert-manager's Certificates and Issuers, we don't
want to fail finalization when such operators are not installed, so during
finalization, we split the resources in
- optional resources (TLS resources, etc)
- resources (core k8s resources)

Then, we delete `resources` first and after we delete optional resources
while also ignoring errors returned when such operators are not instaled.