### PR TITLE
Add clotributor link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,5 @@ For documentation on using Knative Operator, see the
 [Knative documentation site](https://www.knative.dev/docs).
 
 If you are interested in contributing, see [CONTRIBUTING.md](./CONTRIBUTING.md)
-and [DEVELOPMENT.md](./DEVELOPMENT.md).
+and [DEVELOPMENT.md](./DEVELOPMENT.md). For a list of help wanted issues across 
+Knative, take a look at [CLOTRIBUTOR](https://clotributor.dev/search?project=knative&page=1).


### PR DESCRIPTION
Part of https://github.com/knative/community/issues/1403

Adds a link to the CLOTRIBUTOR page for Knative to the README