### PR TITLE
Eventing TLS: Add trust manager resources to filter

### DIFF
--- a/pkg/reconciler/knativeeventing/eventing_tls.go
+++ b/pkg/reconciler/knativeeventing/eventing_tls.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	tlsResourcesPred = byGroup("cert-manager.io")
+	tlsResourcesPred = mf.Any(byGroup("cert-manager.io"), byGroup("trust.cert-manager.io"))
 )
 
 func (r *Reconciler) handleTLSResources(ctx context.Context, manifests *mf.Manifest, comp base.KComponent) error {


### PR DESCRIPTION
Eventing TLS will have trust manager resources in the artifacts and we need to manage them as the core cert-manager resources.