### PR TITLE
Added "trust.cert-manager.io" into the ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -620,10 +620,10 @@ rules:
   # Eventing TLS
   - apiGroups:
       - "cert-manager.io"
-      - "trust.cert-manager.io"
     resources:
       - certificates
       - issuers
+      - clusterissuers
     verbs:
       - create
       - delete
@@ -631,4 +631,14 @@ rules:
       - list
       - get
       - watch
-
+  - apiGroups:
+      - "trust.cert-manager.io"
+    resources:
+      - bundles
+    verbs:
+      - create
+      - delete
+      - update
+      - list
+      - get
+      - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -620,6 +620,7 @@ rules:
   # Eventing TLS
   - apiGroups:
       - "cert-manager.io"
+      - "trust.cert-manager.io"
     resources:
       - certificates
       - issuers


### PR DESCRIPTION
## Proposed Changes

* KnativeEventing is missing this apiGroup per the commit: https://github.com/knative/operator/commit/9435921aec1d1add1fb73573304a2023bab7c5a0.
