### PR TITLE
Perf: add resource limits to operators.

### DIFF
--- a/config/charts/knative-operator/templates/operator.yaml
+++ b/config/charts/knative-operator/templates/operator.yaml
@@ -6242,6 +6242,13 @@ spec:
               value: config-observability
             - name: KUBERNETES_MIN_VERSION
               value: "{{ .Values.knative_operator.kubernetes_min_version }}"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
           ports:
             - name: metrics
               containerPort: 9090

--- a/config/manager/operator.yaml
+++ b/config/manager/operator.yaml
@@ -56,6 +56,13 @@ spec:
               value: config-observability
             - name: KUBERNETES_MIN_VERSION
               value: ""
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 100m
+              memory: 100Mi
           ports:
             - name: metrics
               containerPort: 9090


### PR DESCRIPTION
I think increasing the resource limit is a better best practice to prevent pods from using resources infinitely (this is not currently happening.)

Based on the monitoring data of our environment, I set the request and limit values to 100m/100Mi

![image](https://github.com/knative/operator/assets/22126779/17a26cc1-5e7e-4451-8456-276327d4eded)


## Proposed Changes

* knative-operator should set resource limits


**Release Note**

```release-note
NONE
```
