### PR TITLE
Updated source manifests for serving and eventing

### DIFF
--- a/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-controller.yaml
+++ b/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-controller.yaml
@@ -17,7 +17,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -43,7 +43,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 
@@ -67,7 +67,7 @@ kind: CustomResourceDefinition
 metadata:
   name: kafkachannels.messaging.knative.dev
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
@@ -400,7 +400,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:
@@ -456,7 +456,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
@@ -527,7 +527,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 spec:
   group: eventing.knative.dev
   names:
@@ -711,7 +711,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
@@ -1167,7 +1167,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -1200,7 +1200,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -1260,7 +1260,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   class: "keda.autoscaling.knative.dev"
   min-scale: "0"
@@ -1290,7 +1290,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   predicates: |
     []
@@ -1363,7 +1363,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -1430,7 +1430,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   predicates: |
     [
@@ -1470,7 +1470,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 data:
   config.xml: |
     <configuration>
@@ -1532,7 +1532,7 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
@@ -1592,7 +1592,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -1635,7 +1635,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -1672,7 +1672,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 rules:
   - apiGroups:
       - ""
@@ -1960,7 +1960,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -1981,7 +1981,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1996,7 +1996,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -2027,7 +2027,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     app.kubernetes.io/component: kafka-controller
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2039,7 +2039,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+        app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
         app.kubernetes.io/component: kafka-controller
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2065,7 +2065,7 @@ spec:
               weight: 100
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:3b9dbcaf014ec83aa1d5f610b0ed1b7032c7c3900cb7c43fe3f84e37f90dd06d
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:dd6aabbfad9f6ce9977f259797679654d0e723b575e959138232a6ff81675277
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -2200,7 +2200,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -2302,7 +2302,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -2323,7 +2323,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -2353,7 +2353,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -2385,7 +2385,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -2427,7 +2427,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 # The data is populated at install time.
 
 ---
@@ -2450,7 +2450,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -2484,7 +2484,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2495,7 +2495,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+        app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
         app.kubernetes.io/component: kafka-webhook-eventing
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2515,7 +2515,7 @@ spec:
       containers:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:e58167f1ff70e8a310b822e95e7725266daa697ea6a4905a9fcaf5438edb955a
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:f7aab82bc0f58bcb5473169fc78763ac9ef31d11d4c48d8a198559f8653e5e9e
           resources:
             requests:
               cpu: 20m
@@ -2585,7 +2585,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-post-install.yaml
+++ b/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-post-install.yaml
@@ -16,7 +16,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 rules:
   # we need to be able to delete old deployments
   - apiGroups:
@@ -55,7 +55,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -160,14 +160,14 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -196,7 +196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -228,7 +228,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -236,7 +236,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+        app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -244,7 +244,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:270a324f95df0c4c16873e02d4ca579be98e16c4b82e250ffb92331510ad95b5
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:afccd07febb1fae1dc20bc676d03d744ba2101536732692ac09f20cdd1d872b8
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -284,7 +284,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -292,7 +292,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+        app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.14/kafka/eventing-kafka-source.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:
@@ -178,7 +178,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 rules:
   - apiGroups:
       - ""
@@ -215,7 +215,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 
 ---
 # Copyright 2021 The Knative Authors
@@ -236,7 +236,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -267,7 +267,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+    app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
     app.kubernetes.io/component: kafka-source-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -281,7 +281,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/version: "c7ff0ae5c97c58ca1a904d4acf411b448df90aaf"
+        app.kubernetes.io/version: "adce74373e71285de9a984419e9cc2ba7c9e3cd2"
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/kind: kafka-dispatcher
@@ -308,7 +308,7 @@ spec:
         runAsUser: 1001
       containers:
         - name: kafka-source-dispatcher
-          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:8f0270957e8278b21a0af5ce679ae719ceed204f9855f264697ab4dc29115c6a
+          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:ff6b555f373f9b9a85fb947c1f465748b28e387f99c9c5e9ab282ed0637ca9f0
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-controller.yaml
+++ b/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-controller.yaml
@@ -17,7 +17,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -43,7 +43,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 
@@ -67,7 +67,7 @@ kind: CustomResourceDefinition
 metadata:
   name: kafkachannels.messaging.knative.dev
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
@@ -400,7 +400,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:
@@ -456,7 +456,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
@@ -527,7 +527,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 spec:
   group: eventing.knative.dev
   names:
@@ -711,7 +711,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
@@ -1167,7 +1167,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -1200,7 +1200,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -1260,7 +1260,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   class: "keda.autoscaling.knative.dev"
   min-scale: "0"
@@ -1290,7 +1290,7 @@ metadata:
   name: config-kafka-descheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   predicates: |
     []
@@ -1363,7 +1363,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -1430,7 +1430,7 @@ metadata:
   name: config-kafka-scheduler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   predicates: |
     [
@@ -1470,7 +1470,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 data:
   config.xml: |
     <configuration>
@@ -1532,7 +1532,7 @@ metadata:
   name: config-tracing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     knative.dev/config-propagation: original
     knative.dev/config-category: eventing
   annotations:
@@ -1592,7 +1592,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -1635,7 +1635,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -1672,7 +1672,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 rules:
   - apiGroups:
       - ""
@@ -1962,7 +1962,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -1983,7 +1983,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -1998,7 +1998,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -2029,7 +2029,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     app.kubernetes.io/component: kafka-controller
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2041,7 +2041,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+        app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
         app.kubernetes.io/component: kafka-controller
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2067,7 +2067,7 @@ spec:
               weight: 100
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:15d6a2427337da8aaa2f2279c5ec04f013df090988b5bc961e407ed403bffc2a
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:9ffb70f1648d64d385b68d3ba91f03576d0333977fa4be685d466bbdcfd7a83d
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -2202,7 +2202,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -2304,7 +2304,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -2325,7 +2325,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -2355,7 +2355,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -2387,7 +2387,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -2429,7 +2429,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 # The data is populated at install time.
 
 ---
@@ -2452,7 +2452,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -2486,7 +2486,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2497,7 +2497,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+        app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
         app.kubernetes.io/component: kafka-webhook-eventing
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2517,7 +2517,7 @@ spec:
       containers:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:be05f3189a265341f05bd5d8284438fc7a2ff484e42babe66b81a1670eee2b75
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:734f79e9d8ca8ccada18e6f6ed7e6a9684cd492553943081ef5a912b2a2d757e
           resources:
             requests:
               cpu: 20m
@@ -2587,7 +2587,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-post-install.yaml
+++ b/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-post-install.yaml
@@ -16,7 +16,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 rules:
   # we need to be able to delete old deployments
   - apiGroups:
@@ -55,7 +55,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -160,14 +160,14 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -196,7 +196,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -228,7 +228,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -236,7 +236,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+        app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
@@ -244,7 +244,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:6b138d522774b12d5ea3b2fe7d5fe4571ed426dd1193250098e2713f111da5c6
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:ca0e99e9d847ca6ee15ae88a1cd9c1310e704bd55a7e643e7b6c536273e31c02
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -284,7 +284,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -292,7 +292,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+        app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
       annotations:
         sidecar.istio.io/inject: "false"
     spec:

--- a/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.15/kafka/eventing-kafka-source.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:
@@ -178,7 +178,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 rules:
   - apiGroups:
       - ""
@@ -215,7 +215,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 
 ---
 # Copyright 2021 The Knative Authors
@@ -236,7 +236,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -267,7 +267,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+    app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
     app.kubernetes.io/component: kafka-source-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -281,7 +281,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/version: "9c96bce22e3f41194c28d62355b12f0fb9901703"
+        app.kubernetes.io/version: "961961c80f862f599c270f03781c4fcac21ba930"
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/kind: kafka-dispatcher
@@ -308,7 +308,7 @@ spec:
         runAsUser: 1001
       containers:
         - name: kafka-source-dispatcher
-          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:e265633b5f82475742e7357691dd8bb9af72d005f5e601485736aa086c01be86
+          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:3e98e65fd75502c99ec172f279777ba766408e618f7cc28e3567dab32239b29f
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config

--- a/cmd/operator/kodata/ingress/1.14/istio/net-istio.yaml
+++ b/cmd/operator/kodata/ingress/1.14/istio/net-istio.yaml
@@ -1,4 +1,4 @@
-# Generated when HEAD was d5104e5c265274c7d85b53b1472714706aafaa39
+# Generated when HEAD was 04963a98447846cfdd7f57e2abe9ff924f8aa07d
 #
 # Copyright 2019 The Knative Authors
 #
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -54,7 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -114,7 +114,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -152,7 +152,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
@@ -262,7 +262,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -280,7 +280,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -313,7 +313,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -330,14 +330,14 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.14.1"
+        app.kubernetes.io/version: "1.14.2"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:05a9cac921ac597e32601860512358992b4e01c4420b93e4322d7f2dbb3db449
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:3c29118e9736ead1b514877037b8577f588711343e42e64f993b10bd075a7657
           resources:
             requests:
               cpu: 30m
@@ -416,7 +416,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -430,14 +430,14 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.14.1"
+        app.kubernetes.io/version: "1.14.2"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:14f9bae7964564c4efceb1b4f0cd29ec3258ac149d2ab10a6ed5097775fd2422
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:504e97c906a520f649a878f5b4e3cb72cf7ee8a97165023af72abfad1b70855b
           resources:
             requests:
               cpu: 20m
@@ -515,7 +515,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 
 ---
@@ -542,7 +542,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -581,7 +581,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -620,7 +620,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -661,7 +661,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.1"
+    app.kubernetes.io/version: "1.14.2"
     networking.knative.dev/ingress-provider: istio
     networking.knative.dev/certificate-type: system-internal
     knative.dev/install-knative-certificate: "true"

--- a/cmd/operator/kodata/ingress/1.15/contour/net-contour.yaml
+++ b/cmd/operator/kodata/ingress/1.15/contour/net-contour.yaml
@@ -8,7 +8,7 @@ metadata:
     networking.knative.dev/ingress-provider: contour
     app.kubernetes.io/component: net-contour
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     serving.knative.dev/controller: "true"
 rules:
   - apiGroups: ["projectcontour.io"]
@@ -38,7 +38,7 @@ metadata:
     networking.knative.dev/ingress-provider: contour
     app.kubernetes.io/component: net-contour
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
 data:
   _example: |
     ################################
@@ -111,7 +111,7 @@ metadata:
     networking.knative.dev/ingress-provider: contour
     app.kubernetes.io/component: net-contour
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
 spec:
   replicas: 1
   selector:
@@ -123,14 +123,14 @@ spec:
         app: net-contour-controller
         app.kubernetes.io/component: net-contour
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.15.0"
+        app.kubernetes.io/version: "1.15.1"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-contour/cmd/controller@sha256:a97cc1433166aac63bdb41df3ef54578986048d1e1360656668f971854a8302c
+          image: gcr.io/knative-releases/knative.dev/net-contour/cmd/controller@sha256:7b19bdf9f6b4bf3e67af0dd8776674aebcf4c35ba3254f9725da5353eb0d009e
           resources:
             requests:
               cpu: 40m
@@ -174,7 +174,7 @@ metadata:
     networking.knative.dev/ingress-provider: contour
     app.kubernetes.io/component: net-contour
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
 spec:
   delegations:
     - secretName: routing-serving-certs

--- a/cmd/operator/kodata/ingress/1.15/istio/net-istio.yaml
+++ b/cmd/operator/kodata/ingress/1.15/istio/net-istio.yaml
@@ -1,4 +1,4 @@
-# Generated when HEAD was a8bc6245272c184df78745bbdf10b367682b154a
+# Generated when HEAD was 0887566dd474d00d084324a132da97ac2fb0c3a6
 #
 # Copyright 2019 The Knative Authors
 #
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -54,7 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -114,7 +114,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -152,7 +152,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
@@ -262,7 +262,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -280,7 +280,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -313,7 +313,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -330,14 +330,14 @@ spec:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.15.0"
+        app.kubernetes.io/version: "1.15.1"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:202d95eb2e2f7435c5de60cbd9cd3fe98f1dca25dcac7976ffc796b1204902e4
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/controller@sha256:3c8d9cba61bbdf91d2c0ddc15ce7593ee776cbf5f7b4262132e0b2230441e16b
           resources:
             requests:
               cpu: 30m
@@ -416,7 +416,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -430,14 +430,14 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "1.15.0"
+        app.kubernetes.io/version: "1.15.1"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:ff2dc41f2f7663bc6d968d0d4553af0253602dd125d5283cf8cc146d8aeafaab
+          image: gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:fc70f9b07cc855e39357bbc5166e933074473e10ecf01d78ee289f6b8c968890
           resources:
             requests:
               cpu: 20m
@@ -515,7 +515,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 
 ---
@@ -542,7 +542,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -581,7 +581,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -620,7 +620,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:

--- a/cmd/operator/kodata/ingress/1.15/kourier/kourier.yaml
+++ b/cmd/operator/kodata/ingress/1.15/kourier/kourier.yaml
@@ -20,7 +20,7 @@ metadata:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -45,7 +45,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 data:
   envoy-bootstrap.yaml: |
@@ -174,7 +174,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 data:
   _example: |
@@ -254,7 +254,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -264,7 +264,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -293,7 +293,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -327,7 +327,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   strategy:
@@ -349,7 +349,7 @@ spec:
         app: net-kourier-controller
     spec:
       containers:
-        - image: gcr.io/knative-releases/knative.dev/net-kourier/cmd/kourier@sha256:c9016f34165c5118373c75dcc373d1cd802fe37ffa9e1bce65960942a59bc5f1
+        - image: gcr.io/knative-releases/knative.dev/net-kourier/cmd/kourier@sha256:0f345516b3d172dac408c08e58f1318056e8461861ba15f1a0215370ddd6e685
           name: controller
           env:
             - name: CERTS_SECRET_NAMESPACE
@@ -417,7 +417,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   ports:
@@ -456,7 +456,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   strategy:
@@ -575,7 +575,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   ports:
@@ -599,7 +599,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   ports:
@@ -623,7 +623,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   minReplicas: 1
@@ -649,7 +649,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: kourier
     app.kubernetes.io/component: net-kourier
-    app.kubernetes.io/version: "1.15.0"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/name: knative-serving
 spec:
   minAvailable: 80%

--- a/cmd/operator/kodata/knative-serving/1.15.1/1-serving-crds.yaml
+++ b/cmd/operator/kodata/knative-serving/1.15.1/1-serving-crds.yaml
@@ -1,0 +1,6536 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Certificate is responsible for provisioning a SSL certificate for the
+            given hosts. It is a Knative abstraction for various SSL certificate
+            provisioning solutions (such as cert-manager or self-signed SSL certificate).
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: |-
+                    DNSNames is a list of DNS names the Certificate could support.
+                    The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                domain:
+                  description: Domain is the top level domain of the values for DNSNames.
+                  type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: |-
+                Status is the current state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: |-
+                    HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled
+                    in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: |-
+                      HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs
+                      to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: |-
+                    The expiration time of the TLS certificate stored in the secret named
+                    by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - kcert
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - config
+      - cfg
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: LatestCreated
+          type: string
+          jsonPath: .status.latestCreatedRevisionName
+        - name: LatestReady
+          type: string
+          jsonPath: .status.latestReadyRevisionName
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Configuration represents the "floating HEAD" of a linear history of Revisions.
+            Users create new Revisions by updating the Configuration's spec.
+            The "latest created" revision's name is available under status, as is the
+            "latest ready" revision's name.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConfigurationSpec holds the desired state of the Configuration (from the client).
+              type: object
+              properties:
+                template:
+                  description: Template holds the latest specification for the Revision to be stamped out.
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        annotations:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        finalizers:
+                          type: array
+                          items:
+                            type: string
+                        labels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      description: RevisionSpec holds the desired state of the Revision (from the client).
+                      type: object
+                      required:
+                        - containers
+                      properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
+                        containerConcurrency:
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
+                          type: integer
+                          format: int64
+                        containers:
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
+                          type: array
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            type: object
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      type: object
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  type: object
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  type: object
+                                  required:
+                                    - containerPort
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      type: integer
+                                      format: int32
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                      default: TCP
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
+                                    type: array
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  requests:
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                type: object
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                      drop:
+                                        description: Removed capabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  type: object
+                                  required:
+                                    - mountPath
+                                    - name
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
+                        enableServiceLinks:
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
+                        imagePullSecrets:
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: array
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            type: object
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
+                            sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        serviceAccountName:
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                          type: string
+                        shareProcessNamespace:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        timeoutSeconds:
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
+                          type: integer
+                          format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        volumes:
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
+                          type: array
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    type: array
+                                    items:
+                                      description: Projection that may be projected along with other supported volume types
+                                      type: object
+                                      properties:
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          type: object
+                                          required:
+                                            - path
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              type: integer
+                                              format: int64
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+            status:
+              description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                latestCreatedRevisionName:
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
+                  type: string
+                latestReadyRevisionName:
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterdomainclaims.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the ClusterDomainClaim.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: |-
+                    Namespace is the namespace which is allowed to create a DomainMapping
+                    using this ClusterDomainClaim's name.
+                  type: string
+  names:
+    kind: ClusterDomainClaim
+    plural: clusterdomainclaims
+    singular: clusterdomainclaim
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - cdc
+  scope: Cluster
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: domainmappings.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      "schema":
+        "openAPIV3Schema":
+          description: DomainMapping is a mapping from a custom hostname to an Addressable.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - ref
+              properties:
+                ref:
+                  description: |-
+                    Ref specifies the target of the Domain Mapping.
+
+
+                    The object identified by the Ref must be an Addressable with a URL of the
+                    form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,
+                    and `{name}` and `{namespace}` are the name and namespace of a Kubernetes
+                    Service.
+
+
+                    This contract is satisfied by Knative types such as Knative Services and
+                    Knative Routes, and by Kubernetes Services.
+                  type: object
+                  required:
+                    - kind
+                    - name
+                  properties:
+                    address:
+                      description: Address points to a specific Address Name.
+                      type: string
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    group:
+                      description: |-
+                        Group of the API, without the version of the group. This can be used as an alternative to the APIVersion, and then resolved using ResolveGroup.
+                        Note: This API is EXPERIMENTAL and might break anytime. For more details: https://github.com/knative/eventing/issues/5086
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        This is optional field, it gets defaulted to the object holding it if left out.
+                      type: string
+                tls:
+                  description: TLS allows the DomainMapping to terminate TLS traffic with an existing secret.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the existing secret used to terminate TLS traffic.
+                      type: string
+            status:
+              description: |-
+                Status is the current state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a DomainMapping to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                url:
+                  description: URL is the URL of this DomainMapping.
+                  type: string
+  names:
+    kind: DomainMapping
+    plural: domainmappings
+    singular: domainmapping
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - dm
+  scope: Namespaced
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
+            by a backend. An Ingress can be configured to give services externally-reachable URLs, load
+            balance traffic, offer name based virtual hosting, etc.
+
+
+            This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress
+            which some highlighted modifications.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                httpOption:
+                  description: |-
+                    HTTPOption is the option of HTTP. It has the following two values:
+                    `HTTPOptionEnabled`, `HTTPOptionRedirected`
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: |-
+                      IngressRule represents the rules mapping the paths under a specified host to
+                      the related backend services. Incoming requests are first evaluated for a host
+                      match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: |-
+                          Host is the fully qualified domain name of a network host, as defined
+                          by RFC 3986. Note the following deviations from the "host" part of the
+                          URI as defined in the RFC:
+                          1. IPs are not allowed. Currently a rule value can only apply to the
+                          	  IP in the Spec of the parent .
+                          2. The `:` delimiter is not respected because ports are not allowed.
+                          	  Currently the port of an Ingress is implicitly :80 for http and
+                          	  :443 for https.
+                          Both these may change in the future.
+                          If the host is unspecified, the Ingress routes all traffic based on the
+                          specified IngressRuleValue.
+                          If multiple matching Hosts were provided, the first rule will take precedent.
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: |-
+                          HTTP represents a rule to apply against incoming requests. If the
+                          rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: |-
+                              A collection of paths that map requests to backends.
+
+
+                              If they are multiple matching paths, the first match takes precedence.
+                            type: array
+                            items:
+                              description: |-
+                                HTTPIngressPath associates a path regex with a backend. Incoming URLs matching
+                                the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: |-
+                                    AppendHeaders allow specifying additional HTTP headers to add
+                                    before forwarding a request to the destination service.
+
+
+                                    NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: |-
+                                    Headers defines header matching rules which is a map from a header name
+                                    to HeaderMatch which specify a matching condition.
+                                    When a request matched with all the header matching rules,
+                                    the request is routed by the corresponding ingress rule.
+                                    If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: |-
+                                      HeaderMatch represents a matching value of Headers in HTTPIngressPath.
+                                      Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: |-
+                                    Path represents a literal prefix to which this rule should apply.
+                                    Currently it can contain characters disallowed from the conventional
+                                    "path" part of a URL as defined by RFC 3986. Paths must begin with
+                                    a '/'. If unspecified, the path defaults to a catch all sending
+                                    traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: |-
+                                    RewriteHost rewrites the incoming request's host header.
+
+
+                                    This field is currently experimental and not supported by all Ingress
+                                    implementations.
+                                  type: string
+                                splits:
+                                  description: |-
+                                    Splits defines the referenced service endpoints to which the traffic
+                                    will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: |-
+                                          AppendHeaders allow specifying additional HTTP headers to add
+                                          before forwarding a request to the destination service.
+
+
+                                          NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: |-
+                                          Specifies the split percentage, a number between 0 and 100.  If
+                                          only one split is specified, we default to 100.
+
+
+                                          NOTE: This differs from K8s Ingress to allow percentage split.
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: |-
+                                          Specifies the namespace of the referenced service.
+
+
+                                          NOTE: This differs from K8s Ingress to allow routing to different namespaces.
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: |-
+                          Visibility signifies whether this rule should `ClusterLocal`. If it's not
+                          specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: |-
+                    TLS configuration. Currently Ingress only supports a single TLS
+                    port: 443. If multiple members of this list specify different hosts, they
+                    will be multiplexed on the same port according to the hostname specified
+                    through the SNI TLS extension, if the ingress controller fulfilling the
+                    ingress supports SNI.
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: |-
+                          Hosts is a list of hosts included in the TLS certificate. The values in
+                          this list must match the name/s used in the tlsSecret. Defaults to the
+                          wildcard host setting for the loadbalancer controller fulfilling this
+                          Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: |-
+                          SecretNamespace is the namespace of the secret used to terminate SSL traffic.
+                          If not set the namespace should be assumed to be the same as the Ingress.
+                          If set the secret should have the same namespace as the Ingress otherwise
+                          the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: |-
+                Status is the current state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
+                        type: object
+                        properties:
+                          domain:
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: |-
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
+                            type: string
+                          ip:
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
+                        type: object
+                        properties:
+                          domain:
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: |-
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
+                            type: string
+                          ip:
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - kingress
+      - king
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+      - knative-internal
+      - autoscaling
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: Metric represents a resource to configure the metric collector with.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Metric (from the client).
+              type: object
+              required:
+                - panicWindow
+                - scrapeTarget
+                - stableWindow
+              properties:
+                panicWindow:
+                  description: PanicWindow is the aggregation window for metrics where quick reactions are needed.
+                  type: integer
+                  format: int64
+                scrapeTarget:
+                  description: ScrapeTarget is the K8s service that publishes the metric endpoint.
+                  type: string
+                stableWindow:
+                  description: StableWindow is the aggregation window for metrics in a stable state.
+                  type: integer
+                  format: int64
+            status:
+              description: Status communicates the observed state of the Metric (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+      - knative-internal
+      - autoscaling
+    shortNames:
+      - kpa
+      - pa
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: DesiredScale
+          type: integer
+          jsonPath: ".status.desiredScale"
+        - name: ActualScale
+          type: integer
+          jsonPath: ".status.actualScale"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
+            components instantiate autoscalers.  This definition is an abstraction that may be backed
+            by multiple definitions.  For more information, see the Knative Pluggability presentation:
+            https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the PodAutoscaler (from the client).
+              type: object
+              required:
+                - protocolType
+                - scaleTargetRef
+              properties:
+                containerConcurrency:
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed
+                    in-flight (concurrent) requests per container of the Revision.
+                    Defaults to `0` which means unlimited concurrency.
+                  type: integer
+                  format: int64
+                protocolType:
+                  description: The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
+                  type: string
+                reachability:
+                  description: |-
+                    Reachability specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).
+                    Defaults to `ReachabilityUnknown`
+                  type: string
+                scaleTargetRef:
+                  description: |-
+                    ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
+                    is responsible for quickly right-sizing.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  x-kubernetes-map-type: atomic
+            status:
+              description: Status communicates the observed state of the PodAutoscaler (from the controller).
+              type: object
+              required:
+                - metricsServiceName
+                - serviceName
+              properties:
+                actualScale:
+                  description: ActualScale shows the actual number of replicas for the revision.
+                  type: integer
+                  format: int32
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                desiredScale:
+                  description: DesiredScale shows the current desired number of replicas for the revision.
+                  type: integer
+                  format: int32
+                metricsServiceName:
+                  description: |-
+                    MetricsServiceName is the K8s Service name that provides revision metrics.
+                    The service is managed by the PA object.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                serviceName:
+                  description: |-
+                    ServiceName is the K8s Service name that serves the revision, scaled by this PA.
+                    The service is created and owned by the ServerlessService object owned by this PA.
+                  type: string
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - rev
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Config Name
+          type: string
+          jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+        - name: Generation
+          type: string # int in string form :(
+          jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+        - name: Actual Replicas
+          type: integer
+          jsonPath: ".status.actualReplicas"
+        - name: Desired Replicas
+          type: integer
+          jsonPath: ".status.desiredReplicas"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Revision is an immutable snapshot of code and configuration.  A revision
+            references a container image. Revisions are created by updates to a
+            Configuration.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RevisionSpec holds the desired state of the Revision (from the client).
+              type: object
+              required:
+                - containers
+              properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                automountServiceAccountToken:
+                  description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                  type: boolean
+                containerConcurrency:
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                    requests per container of the Revision.  Defaults to `0` which means
+                    concurrency to the application is not limited, and the system decides the
+                    target concurrency for the autoscaler.
+                  type: integer
+                  format: int64
+                containers:
+                  description: |-
+                    List of containers belonging to the pod.
+                    Containers cannot currently be added or removed.
+                    There must be at least one container in a Pod.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: A single application container that you want to run within a pod.
+                    type: object
+                    properties:
+                      args:
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        type: array
+                        items:
+                          type: string
+                      command:
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        type: array
+                        items:
+                          type: string
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              type: object
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  type: object
+                                  required:
+                                    - key
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  type: object
+                                  required:
+                                    - key
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          type: object
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must be defined
+                                  type: boolean
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be defined
+                                  type: boolean
+                              x-kubernetes-map-type: atomic
+                      image:
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      livenessProbe:
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      name:
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: ContainerPort represents a network port in a single container.
+                          type: object
+                          required:
+                            - containerPort
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              type: integer
+                              format: int32
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                              default: TCP
+                        x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      resources:
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            type: array
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          requests:
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
+                              drop:
+                                description: Removed capabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                      startupProbe:
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      terminationMessagePath:
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
+                        type: string
+                      volumeMounts:
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within a container.
+                          type: object
+                          required:
+                            - mountPath
+                            - name
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                      workingDir:
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
+                        type: string
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
+                enableServiceLinks:
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                  type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: |-
+                    IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                    to stay open while not receiving any bytes from the user's application. If
+                    unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
+                imagePullSecrets:
+                  description: |-
+                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                  type: array
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: |-
+                    List of initialization containers belonging to the pod.
+                    Init containers are executed in order prior to containers being started. If any
+                    init container fails, the pod is considered to have failed and is handled according
+                    to its restartPolicy. The name for an init container or normal container must be
+                    unique among all containers.
+                    Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                    The resourceRequirements of an init container are taken into account during scheduling
+                    by finding the highest request/limit for each resource type, and then using the max of
+                    of that value or the sum of the normal containers. Limits are applied to init containers
+                    in a similar fashion.
+                    Init containers cannot currently be added or removed.
+                    Cannot be updated.
+                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: |-
+                    ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                    routing layer will wait for a request delivered to a container to begin
+                    sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                  type: string
+                shareProcessNamespace:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
+                timeoutSeconds:
+                  description: |-
+                    TimeoutSeconds is the maximum duration in seconds that the request instance
+                    is allowed to respond to a request. If unspecified, a system default will
+                    be provided.
+                  type: integer
+                  format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                volumes:
+                  description: |-
+                    List of volumes that can be mounted by containers belonging to the pod.
+                    More info: https://kubernetes.io/docs/concepts/storage/volumes
+                  type: array
+                  items:
+                    description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      configMap:
+                        description: configMap represents a configMap that should populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode is optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          items:
+                            description: |-
+                              items if unspecified, each key-value pair in the Data field of the referenced
+                              ConfigMap will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the ConfigMap,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                                - key
+                                - path
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
+                                  type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
+                            type: string
+                          optional:
+                            description: optional specify whether the ConfigMap or its keys must be defined
+                            type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: |-
+                          name of the volume.
+                          Must be a DNS_LABEL and unique within the pod.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      projected:
+                        description: projected items for all in one resources secrets, configmaps, and downward API
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode are the mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          sources:
+                            description: sources is the list of volume projections
+                            type: array
+                            items:
+                              description: Projection that may be projected along with other supported volume types
+                              type: object
+                              properties:
+                                configMap:
+                                  description: configMap information about the configMap data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        type: object
+                                        required:
+                                          - key
+                                          - path
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        type: object
+                                        required:
+                                          - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            type: object
+                                            required:
+                                              - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                            type: object
+                                            required:
+                                              - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            x-kubernetes-map-type: atomic
+                                secret:
+                                  description: secret information about the secret data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        type: object
+                                        required:
+                                          - key
+                                          - path
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: optional field specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                serviceAccountToken:
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
+                                  type: object
+                                  required:
+                                    - path
+                                  properties:
+                                    audience:
+                                      description: |-
+                                        audience is the intended audience of the token. A recipient of a token
+                                        must identify itself with an identifier specified in the audience of the
+                                        token, and otherwise should reject the token. The audience defaults to the
+                                        identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: |-
+                                        expirationSeconds is the requested duration of validity of the service
+                                        account token. As the token approaches expiration, the kubelet volume
+                                        plugin will proactively rotate the service account token. The kubelet will
+                                        start trying to rotate the token if the token is older than 80 percent of
+                                        its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                        and must be at least 10 minutes.
+                                      type: integer
+                                      format: int64
+                                    path:
+                                      description: |-
+                                        path is the path relative to the mount point of the file to project the
+                                        token into.
+                                      type: string
+                      secret:
+                        description: |-
+                          secret represents a secret that should populate this volume.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode is Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values
+                              for mode bits. Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          items:
+                            description: |-
+                              items If unspecified, each key-value pair in the Data field of the referenced
+                              Secret will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the Secret,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                                - key
+                                - path
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
+                                  type: string
+                          optional:
+                            description: optional field specify whether the Secret or its keys must be defined
+                            type: boolean
+                          secretName:
+                            description: |-
+                              secretName is the name of the secret in the pod's namespace to use.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                            type: string
+            status:
+              description: RevisionStatus communicates the observed state of the Revision (from the controller).
+              type: object
+              properties:
+                actualReplicas:
+                  description: ActualReplicas reflects the amount of ready pods running this revision.
+                  type: integer
+                  format: int32
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                containerStatuses:
+                  description: |-
+                    ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
+                        type: string
+                desiredReplicas:
+                  description: DesiredReplicas reflects the desired amount of pods running this revision.
+                  type: integer
+                  format: int32
+                initContainerStatuses:
+                  description: |-
+                    InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
+                        type: string
+                logUrl:
+                  description: |-
+                    LogURL specifies the generated logging url for this particular revision
+                    based on the revision url template specified in the controller's config.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - rt
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Route is responsible for configuring ingress over a collection of Revisions.
+            Some of the Revisions a Route distributes traffic over may be specified by
+            referencing the Configuration responsible for creating them; in these cases
+            the Route is additionally responsible for monitoring the Configuration for
+            "latest ready revision" changes, and smoothly rolling out latest revisions.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Route (from the client).
+              type: object
+              properties:
+                traffic:
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+            status:
+              description: Status communicates the observed state of the Route (from the controller).
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a Route to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                traffic:
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
+                    LatestReadyRevisionName that we last observed.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+                url:
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  type: string
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ServerlessService is a proxy for the K8s service objects containing the
+            endpoints for the revision, whether those are endpoints of the activator or
+            revision pods.
+            See: https://knative.page.link/naxz for details.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: |-
+                    NumActivators contains number of Activators that this revision should be
+                    assigned.
+                    O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: |-
+                    ObjectRef defines the resource that this ServerlessService
+                    is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: |-
+                    The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
+                    serving imports networking, so just use string.
+                  type: string
+            status:
+              description: |-
+                Status is the current state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: |-
+                    PrivateServiceName holds the name of a core K8s Service resource that
+                    load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: |-
+                    ServiceName holds the name of a core K8s Service resource that
+                    load balances over the pods backing this Revision (activator or revision).
+                  type: string
+      additionalPrinterColumns:
+        - name: Mode
+          type: string
+          jsonPath: ".spec.mode"
+        - name: Activators
+          type: integer
+          jsonPath: ".spec.numActivators"
+        - name: ServiceName
+          type: string
+          jsonPath: ".status.serviceName"
+        - name: PrivateServiceName
+          type: string
+          jsonPath: ".status.privateServiceName"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - sks
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - kservice
+      - ksvc
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: LatestCreated
+          type: string
+          jsonPath: .status.latestCreatedRevisionName
+        - name: LatestReady
+          type: string
+          jsonPath: .status.latestReadyRevisionName
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Service acts as a top-level container that manages a Route and Configuration
+            which implement a network service. Service exists to provide a singular
+            abstraction which can be access controlled, reasoned about, and which
+            encapsulates software lifecycle decisions such as rollout policy and
+            team resource ownership. Service acts only as an orchestrator of the
+            underlying Routes and Configurations (much as a kubernetes Deployment
+            orchestrates ReplicaSets), and its usage is optional but recommended.
+
+
+            The Service's controller will track the statuses of its owned Configuration
+            and Route, reflecting their statuses and conditions as its own.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                ServiceSpec represents the configuration for the Service object.
+                A Service's specification is the union of the specifications for a Route
+                and Configuration.  The Service restricts what can be expressed in these
+                fields, e.g. the Route must reference the provided Configuration;
+                however, these limitations also enable friendlier defaulting,
+                e.g. Route never needs a Configuration name, and may be defaulted to
+                the appropriate "run latest" spec.
+              type: object
+              properties:
+                template:
+                  description: Template holds the latest specification for the Revision to be stamped out.
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        annotations:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        finalizers:
+                          type: array
+                          items:
+                            type: string
+                        labels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      description: RevisionSpec holds the desired state of the Revision (from the client).
+                      type: object
+                      required:
+                        - containers
+                      properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
+                        containerConcurrency:
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
+                          type: integer
+                          format: int64
+                        containers:
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
+                          type: array
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            type: object
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      type: object
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  type: object
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  type: object
+                                  required:
+                                    - containerPort
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      type: integer
+                                      format: int32
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                      default: TCP
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
+                                    type: array
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  requests:
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                type: object
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                      drop:
+                                        description: Removed capabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  type: object
+                                  required:
+                                    - mountPath
+                                    - name
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
+                        enableServiceLinks:
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
+                        imagePullSecrets:
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: array
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            type: object
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
+                            sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        serviceAccountName:
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                          type: string
+                        shareProcessNamespace:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        timeoutSeconds:
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
+                          type: integer
+                          format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        volumes:
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
+                          type: array
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    type: array
+                                    items:
+                                      description: Projection that may be projected along with other supported volume types
+                                      type: object
+                                      properties:
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          type: object
+                                          required:
+                                            - path
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              type: integer
+                                              format: int64
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+                traffic:
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+            status:
+              description: ServiceStatus represents the Status stanza of the Service resource.
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a Route to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                latestCreatedRevisionName:
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
+                  type: string
+                latestReadyRevisionName:
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                traffic:
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
+                    LatestReadyRevisionName that we last observed.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+                url:
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  type: string
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+      - knative-internal
+      - caching
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Image is a Knative abstraction that encapsulates the interface by which Knative
+            components express a desire to have a particular image cached.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: |-
+                    ImagePullSecrets contains the names of the Kubernetes Secrets containing login
+                    information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods
+                    will run this container.  This is potentially used to authenticate the image pull
+                    if the service account has attached pull secrets.  For more information:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+
+---

--- a/cmd/operator/kodata/knative-serving/1.15.1/2-serving-core.yaml
+++ b/cmd/operator/kodata/knative-serving/1.15.1/2-serving-core.yaml
@@ -1,0 +1,9310 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+
+---
+# Copyright 2023 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-activator
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/controller: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+    resourceNames: ["routing-serving-certs", "knative-serving-certs"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-activator-cluster
+  labels:
+    serving.knative.dev/controller: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["revisions"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use this aggregated ClusterRole when you need readonly access to "Addressables"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  # Named like this to avoid clashing with eventing's existing `addressable-resolver` role
+  # (which should be identical, but isn't guaranteed to be installed alongside serving).
+  name: knative-serving-aggregated-addressable-resolver
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        duck.knative.dev/addressable: "true"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-addressable-resolver
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+    # Labeled to facilitate aggregated cluster roles that act on Addressables.
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+  - apiGroups:
+      - serving.knative.dev
+    resources:
+      - routes
+      - routes/status
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: ["serving.knative.dev"]
+    resources: ["*"]
+    verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-namespaced-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-core
+  labels:
+    serving.knative.dev/controller: "true"
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "secrets", "configmaps", "endpoints", "services", "events", "serviceaccounts"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints/restricted"] # Permission for RestrictedEndpointsAdmission
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["namespaces/finalizers"] # finalizers are needed for the owner reference of the webhook
+    verbs: ["update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/finalizers"] # finalizers are needed for the owner reference of the webhook
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["serving.knative.dev", "autoscaling.internal.knative.dev", "networking.internal.knative.dev"]
+    resources: ["*", "*/status", "*/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "deletecollection", "patch", "watch"]
+  - apiGroups: ["caching.internal.knative.dev"]
+    resources: ["images"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "clusterissuers", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles"]
+    verbs: ["delete"]
+    resourceNames: ["knative-serving-certmanager"]
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-podspecable-binding
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+    # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
+    duck.knative.dev/podspecable: "true"
+# Do not use this role directly. These rules will be added to the "podspecable-binder" role.
+rules:
+  - apiGroups:
+      - serving.knative.dev
+    resources:
+      - configurations
+      - services
+    verbs:
+      - list
+      - watch
+      - patch
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: knative-serving-admin
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        serving.knative.dev/controller: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-admin
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-controller-addressable-resolver
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-aggregated-addressable-resolver
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: knative-serving-activator
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+subjects:
+  - kind: ServiceAccount
+    name: activator
+    namespace: knative-serving
+roleRef:
+  kind: Role
+  name: knative-serving-activator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-serving-activator-cluster
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+subjects:
+  - kind: ServiceAccount
+    name: activator
+    namespace: knative-serving
+roleRef:
+  kind: ClusterRole
+  name: knative-serving-activator-cluster
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: images.caching.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: caching.internal.knative.dev
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+      - knative-internal
+      - caching
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Image is a Knative abstraction that encapsulates the interface by which Knative
+            components express a desire to have a particular image cached.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Image (from the client).
+              type: object
+              required:
+                - image
+              properties:
+                image:
+                  description: Image is the name of the container image url to cache across the cluster.
+                  type: string
+                imagePullSecrets:
+                  description: |-
+                    ImagePullSecrets contains the names of the Kubernetes Secrets containing login
+                    information used by the Pods which will run this container.
+                  type: array
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    x-kubernetes-map-type: atomic
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods
+                    will run this container.  This is potentially used to authenticate the image pull
+                    if the service account has attached pull secrets.  For more information:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
+                  type: string
+            status:
+              description: Status communicates the observed state of the Image (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Image
+          type: string
+          jsonPath: .spec.image
+
+---
+apiVersion: networking.internal.knative.dev/v1alpha1
+kind: Certificate
+metadata:
+  annotations:
+    networking.knative.dev/certificate.class: cert-manager.certificate.networking.knative.dev
+  labels:
+    networking.knative.dev/certificate-type: system-internal
+  name: routing-serving-certs
+  namespace: knative-serving
+spec:
+  dnsNames:
+    - kn-routing
+    - data-plane.knative.dev # for reverse-compatibility with net-* implementations that do not work with multi-SANs
+  secretName: routing-serving-certs
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Certificate is responsible for provisioning a SSL certificate for the
+            given hosts. It is a Knative abstraction for various SSL certificate
+            provisioning solutions (such as cert-manager or self-signed SSL certificate).
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - dnsNames
+                - secretName
+              properties:
+                dnsNames:
+                  description: |-
+                    DNSNames is a list of DNS names the Certificate could support.
+                    The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
+                  type: array
+                  items:
+                    type: string
+                domain:
+                  description: Domain is the top level domain of the values for DNSNames.
+                  type: string
+                secretName:
+                  description: SecretName is the name of the secret resource to store the SSL certificate in.
+                  type: string
+            status:
+              description: |-
+                Status is the current state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                http01Challenges:
+                  description: |-
+                    HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled
+                    in order to get the TLS certificate..
+                  type: array
+                  items:
+                    description: |-
+                      HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs
+                      to fulfill.
+                    type: object
+                    properties:
+                      serviceName:
+                        description: ServiceName is the name of the service to serve HTTP01 challenge requests.
+                        type: string
+                      serviceNamespace:
+                        description: ServiceNamespace is the namespace of the service to serve HTTP01 challenge requests.
+                        type: string
+                      servicePort:
+                        description: ServicePort is the port of the service to serve HTTP01 challenge requests.
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      url:
+                        description: URL is the URL that the HTTP01 challenge is expected to serve on.
+                        type: string
+                notAfter:
+                  description: |-
+                    The expiration time of the TLS certificate stored in the secret named
+                    by this resource in spec.secretName.
+                  type: string
+                  format: date-time
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+  names:
+    kind: Certificate
+    plural: certificates
+    singular: certificate
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - kcert
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - config
+      - cfg
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: LatestCreated
+          type: string
+          jsonPath: .status.latestCreatedRevisionName
+        - name: LatestReady
+          type: string
+          jsonPath: .status.latestReadyRevisionName
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Configuration represents the "floating HEAD" of a linear history of Revisions.
+            Users create new Revisions by updating the Configuration's spec.
+            The "latest created" revision's name is available under status, as is the
+            "latest ready" revision's name.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConfigurationSpec holds the desired state of the Configuration (from the client).
+              type: object
+              properties:
+                template:
+                  description: Template holds the latest specification for the Revision to be stamped out.
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        annotations:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        finalizers:
+                          type: array
+                          items:
+                            type: string
+                        labels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      description: RevisionSpec holds the desired state of the Revision (from the client).
+                      type: object
+                      required:
+                        - containers
+                      properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
+                        containerConcurrency:
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
+                          type: integer
+                          format: int64
+                        containers:
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
+                          type: array
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            type: object
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      type: object
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  type: object
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  type: object
+                                  required:
+                                    - containerPort
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      type: integer
+                                      format: int32
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                      default: TCP
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
+                                    type: array
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  requests:
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                type: object
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                      drop:
+                                        description: Removed capabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  type: object
+                                  required:
+                                    - mountPath
+                                    - name
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
+                        enableServiceLinks:
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
+                        imagePullSecrets:
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: array
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            type: object
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
+                            sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        serviceAccountName:
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                          type: string
+                        shareProcessNamespace:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        timeoutSeconds:
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
+                          type: integer
+                          format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        volumes:
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
+                          type: array
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    type: array
+                                    items:
+                                      description: Projection that may be projected along with other supported volume types
+                                      type: object
+                                      properties:
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          type: object
+                                          required:
+                                            - path
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              type: integer
+                                              format: int64
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+            status:
+              description: ConfigurationStatus communicates the observed state of the Configuration (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                latestCreatedRevisionName:
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
+                  type: string
+                latestReadyRevisionName:
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterdomainclaims.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: ClusterDomainClaim is a cluster-wide reservation for a particular domain name.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the ClusterDomainClaim.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - namespace
+              properties:
+                namespace:
+                  description: |-
+                    Namespace is the namespace which is allowed to create a DomainMapping
+                    using this ClusterDomainClaim's name.
+                  type: string
+  names:
+    kind: ClusterDomainClaim
+    plural: clusterdomainclaims
+    singular: clusterdomainclaim
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - cdc
+  scope: Cluster
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: domainmappings.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      "schema":
+        "openAPIV3Schema":
+          description: DomainMapping is a mapping from a custom hostname to an Addressable.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - ref
+              properties:
+                ref:
+                  description: |-
+                    Ref specifies the target of the Domain Mapping.
+
+
+                    The object identified by the Ref must be an Addressable with a URL of the
+                    form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,
+                    and `{name}` and `{namespace}` are the name and namespace of a Kubernetes
+                    Service.
+
+
+                    This contract is satisfied by Knative types such as Knative Services and
+                    Knative Routes, and by Kubernetes Services.
+                  type: object
+                  required:
+                    - kind
+                    - name
+                  properties:
+                    address:
+                      description: Address points to a specific Address Name.
+                      type: string
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    group:
+                      description: |-
+                        Group of the API, without the version of the group. This can be used as an alternative to the APIVersion, and then resolved using ResolveGroup.
+                        Note: This API is EXPERIMENTAL and might break anytime. For more details: https://github.com/knative/eventing/issues/5086
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        This is optional field, it gets defaulted to the object holding it if left out.
+                      type: string
+                tls:
+                  description: TLS allows the DomainMapping to terminate TLS traffic with an existing secret.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    secretName:
+                      description: SecretName is the name of the existing secret used to terminate TLS traffic.
+                      type: string
+            status:
+              description: |-
+                Status is the current state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a DomainMapping to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                url:
+                  description: URL is the URL of this DomainMapping.
+                  type: string
+  names:
+    kind: DomainMapping
+    plural: domainmappings
+    singular: domainmapping
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - dm
+  scope: Namespaced
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ingresses.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
+            by a backend. An Ingress can be configured to give services externally-reachable URLs, load
+            balance traffic, offer name based virtual hosting, etc.
+
+
+            This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress
+            which some highlighted modifications.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                httpOption:
+                  description: |-
+                    HTTPOption is the option of HTTP. It has the following two values:
+                    `HTTPOptionEnabled`, `HTTPOptionRedirected`
+                  type: string
+                rules:
+                  description: A list of host rules used to configure the Ingress.
+                  type: array
+                  items:
+                    description: |-
+                      IngressRule represents the rules mapping the paths under a specified host to
+                      the related backend services. Incoming requests are first evaluated for a host
+                      match, then routed to the backend associated with the matching IngressRuleValue.
+                    type: object
+                    properties:
+                      hosts:
+                        description: |-
+                          Host is the fully qualified domain name of a network host, as defined
+                          by RFC 3986. Note the following deviations from the "host" part of the
+                          URI as defined in the RFC:
+                          1. IPs are not allowed. Currently a rule value can only apply to the
+                          	  IP in the Spec of the parent .
+                          2. The `:` delimiter is not respected because ports are not allowed.
+                          	  Currently the port of an Ingress is implicitly :80 for http and
+                          	  :443 for https.
+                          Both these may change in the future.
+                          If the host is unspecified, the Ingress routes all traffic based on the
+                          specified IngressRuleValue.
+                          If multiple matching Hosts were provided, the first rule will take precedent.
+                        type: array
+                        items:
+                          type: string
+                      http:
+                        description: |-
+                          HTTP represents a rule to apply against incoming requests. If the
+                          rule is satisfied, the request is routed to the specified backend.
+                        type: object
+                        required:
+                          - paths
+                        properties:
+                          paths:
+                            description: |-
+                              A collection of paths that map requests to backends.
+
+
+                              If they are multiple matching paths, the first match takes precedence.
+                            type: array
+                            items:
+                              description: |-
+                                HTTPIngressPath associates a path regex with a backend. Incoming URLs matching
+                                the path are forwarded to the backend.
+                              type: object
+                              required:
+                                - splits
+                              properties:
+                                appendHeaders:
+                                  description: |-
+                                    AppendHeaders allow specifying additional HTTP headers to add
+                                    before forwarding a request to the destination service.
+
+
+                                    NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                                headers:
+                                  description: |-
+                                    Headers defines header matching rules which is a map from a header name
+                                    to HeaderMatch which specify a matching condition.
+                                    When a request matched with all the header matching rules,
+                                    the request is routed by the corresponding ingress rule.
+                                    If it is empty, the headers are not used for matching
+                                  type: object
+                                  additionalProperties:
+                                    description: |-
+                                      HeaderMatch represents a matching value of Headers in HTTPIngressPath.
+                                      Currently, only the exact matching is supported.
+                                    type: object
+                                    required:
+                                      - exact
+                                    properties:
+                                      exact:
+                                        type: string
+                                path:
+                                  description: |-
+                                    Path represents a literal prefix to which this rule should apply.
+                                    Currently it can contain characters disallowed from the conventional
+                                    "path" part of a URL as defined by RFC 3986. Paths must begin with
+                                    a '/'. If unspecified, the path defaults to a catch all sending
+                                    traffic to the backend.
+                                  type: string
+                                rewriteHost:
+                                  description: |-
+                                    RewriteHost rewrites the incoming request's host header.
+
+
+                                    This field is currently experimental and not supported by all Ingress
+                                    implementations.
+                                  type: string
+                                splits:
+                                  description: |-
+                                    Splits defines the referenced service endpoints to which the traffic
+                                    will be forwarded to.
+                                  type: array
+                                  items:
+                                    description: IngressBackendSplit describes all endpoints for a given service and port.
+                                    type: object
+                                    required:
+                                      - serviceName
+                                      - serviceNamespace
+                                      - servicePort
+                                    properties:
+                                      appendHeaders:
+                                        description: |-
+                                          AppendHeaders allow specifying additional HTTP headers to add
+                                          before forwarding a request to the destination service.
+
+
+                                          NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                      percent:
+                                        description: |-
+                                          Specifies the split percentage, a number between 0 and 100.  If
+                                          only one split is specified, we default to 100.
+
+
+                                          NOTE: This differs from K8s Ingress to allow percentage split.
+                                        type: integer
+                                      serviceName:
+                                        description: Specifies the name of the referenced service.
+                                        type: string
+                                      serviceNamespace:
+                                        description: |-
+                                          Specifies the namespace of the referenced service.
+
+
+                                          NOTE: This differs from K8s Ingress to allow routing to different namespaces.
+                                        type: string
+                                      servicePort:
+                                        description: Specifies the port of the referenced service.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                      visibility:
+                        description: |-
+                          Visibility signifies whether this rule should `ClusterLocal`. If it's not
+                          specified then it defaults to `ExternalIP`.
+                        type: string
+                tls:
+                  description: |-
+                    TLS configuration. Currently Ingress only supports a single TLS
+                    port: 443. If multiple members of this list specify different hosts, they
+                    will be multiplexed on the same port according to the hostname specified
+                    through the SNI TLS extension, if the ingress controller fulfilling the
+                    ingress supports SNI.
+                  type: array
+                  items:
+                    description: IngressTLS describes the transport layer security associated with an Ingress.
+                    type: object
+                    properties:
+                      hosts:
+                        description: |-
+                          Hosts is a list of hosts included in the TLS certificate. The values in
+                          this list must match the name/s used in the tlsSecret. Defaults to the
+                          wildcard host setting for the loadbalancer controller fulfilling this
+                          Ingress, if left unspecified.
+                        type: array
+                        items:
+                          type: string
+                      secretName:
+                        description: SecretName is the name of the secret used to terminate SSL traffic.
+                        type: string
+                      secretNamespace:
+                        description: |-
+                          SecretNamespace is the namespace of the secret used to terminate SSL traffic.
+                          If not set the namespace should be assumed to be the same as the Ingress.
+                          If set the secret should have the same namespace as the Ingress otherwise
+                          the behaviour is undefined and not supported.
+                        type: string
+            status:
+              description: |-
+                Status is the current state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateLoadBalancer:
+                  description: PrivateLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
+                        type: object
+                        properties:
+                          domain:
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: |-
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
+                            type: string
+                          ip:
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+                publicLoadBalancer:
+                  description: PublicLoadBalancer contains the current status of the load-balancer.
+                  type: object
+                  properties:
+                    ingress:
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
+                      type: array
+                      items:
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
+                        type: object
+                        properties:
+                          domain:
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
+                            type: string
+                          domainInternal:
+                            description: |-
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
+                            type: string
+                          ip:
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
+                            type: string
+                          meshOnly:
+                            description: MeshOnly is set if the Ingress is only load-balanced through a Service mesh.
+                            type: boolean
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: Ingress
+    plural: ingresses
+    singular: ingress
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - kingress
+      - king
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.autoscaling.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  names:
+    kind: Metric
+    plural: metrics
+    singular: metric
+    categories:
+      - knative-internal
+      - autoscaling
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: Metric represents a resource to configure the metric collector with.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Metric (from the client).
+              type: object
+              required:
+                - panicWindow
+                - scrapeTarget
+                - stableWindow
+              properties:
+                panicWindow:
+                  description: PanicWindow is the aggregation window for metrics where quick reactions are needed.
+                  type: integer
+                  format: int64
+                scrapeTarget:
+                  description: ScrapeTarget is the K8s service that publishes the metric endpoint.
+                  type: string
+                stableWindow:
+                  description: StableWindow is the aggregation window for metrics in a stable state.
+                  type: integer
+                  format: int64
+            status:
+              description: Status communicates the observed state of the Metric (from the controller).
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: podautoscalers.autoscaling.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: autoscaling.internal.knative.dev
+  names:
+    kind: PodAutoscaler
+    plural: podautoscalers
+    singular: podautoscaler
+    categories:
+      - knative-internal
+      - autoscaling
+    shortNames:
+      - kpa
+      - pa
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: DesiredScale
+          type: integer
+          jsonPath: ".status.desiredScale"
+        - name: ActualScale
+          type: integer
+          jsonPath: ".status.actualScale"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
+            components instantiate autoscalers.  This definition is an abstraction that may be backed
+            by multiple definitions.  For more information, see the Knative Pluggability presentation:
+            https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the PodAutoscaler (from the client).
+              type: object
+              required:
+                - protocolType
+                - scaleTargetRef
+              properties:
+                containerConcurrency:
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed
+                    in-flight (concurrent) requests per container of the Revision.
+                    Defaults to `0` which means unlimited concurrency.
+                  type: integer
+                  format: int64
+                protocolType:
+                  description: The application-layer protocol. Matches `ProtocolType` inferred from the revision spec.
+                  type: string
+                reachability:
+                  description: |-
+                    Reachability specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).
+                    Defaults to `ReachabilityUnknown`
+                  type: string
+                scaleTargetRef:
+                  description: |-
+                    ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
+                    is responsible for quickly right-sizing.
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  x-kubernetes-map-type: atomic
+            status:
+              description: Status communicates the observed state of the PodAutoscaler (from the controller).
+              type: object
+              required:
+                - metricsServiceName
+                - serviceName
+              properties:
+                actualScale:
+                  description: ActualScale shows the actual number of replicas for the revision.
+                  type: integer
+                  format: int32
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                desiredScale:
+                  description: DesiredScale shows the current desired number of replicas for the revision.
+                  type: integer
+                  format: int32
+                metricsServiceName:
+                  description: |-
+                    MetricsServiceName is the K8s Service name that provides revision metrics.
+                    The service is managed by the PA object.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                serviceName:
+                  description: |-
+                    ServiceName is the K8s Service name that serves the revision, scaled by this PA.
+                    The service is created and owned by the ServerlessService object owned by this PA.
+                  type: string
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: revisions.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Revision
+    plural: revisions
+    singular: revision
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - rev
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Config Name
+          type: string
+          jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
+        - name: Generation
+          type: string # int in string form :(
+          jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+        - name: Actual Replicas
+          type: integer
+          jsonPath: ".status.actualReplicas"
+        - name: Desired Replicas
+          type: integer
+          jsonPath: ".status.desiredReplicas"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Revision is an immutable snapshot of code and configuration.  A revision
+            references a container image. Revisions are created by updates to a
+            Configuration.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RevisionSpec holds the desired state of the Revision (from the client).
+              type: object
+              required:
+                - containers
+              properties:
+                affinity:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                automountServiceAccountToken:
+                  description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                  type: boolean
+                containerConcurrency:
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                    requests per container of the Revision.  Defaults to `0` which means
+                    concurrency to the application is not limited, and the system decides the
+                    target concurrency for the autoscaler.
+                  type: integer
+                  format: int64
+                containers:
+                  description: |-
+                    List of containers belonging to the pod.
+                    Containers cannot currently be added or removed.
+                    There must be at least one container in a Pod.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: A single application container that you want to run within a pod.
+                    type: object
+                    properties:
+                      args:
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        type: array
+                        items:
+                          type: string
+                      command:
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        type: array
+                        items:
+                          type: string
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              type: object
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  type: object
+                                  required:
+                                    - key
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  type: object
+                                  required:
+                                    - key
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                      envFrom:
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvFromSource represents the source of a set of ConfigMaps
+                          type: object
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must be defined
+                                  type: boolean
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be defined
+                                  type: boolean
+                              x-kubernetes-map-type: atomic
+                      image:
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      livenessProbe:
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      name:
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: ContainerPort represents a network port in a single container.
+                          type: object
+                          required:
+                            - containerPort
+                          properties:
+                            containerPort:
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
+                              type: integer
+                              format: int32
+                            name:
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
+                              type: string
+                            protocol:
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                              default: TCP
+                        x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      resources:
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            type: array
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                          requests:
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                            additionalProperties:
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              x-kubernetes-int-or-string: true
+                      securityContext:
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          capabilities:
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            properties:
+                              add:
+                                description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
+                              drop:
+                                description: Removed capabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities type
+                                  type: string
+                          readOnlyRootFilesystem:
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: integer
+                            format: int64
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                      startupProbe:
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                        type: object
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            type: object
+                            required:
+                              - port
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                type: integer
+                                format: int32
+                              service:
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
+                                type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            properties:
+                              host:
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  type: object
+                                  required:
+                                    - name
+                                    - value
+                                  properties:
+                                    name:
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: |-
+                                  Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP port.
+                            type: object
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                            type: integer
+                            format: int32
+                      terminationMessagePath:
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
+                        type: string
+                      terminationMessagePolicy:
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
+                        type: string
+                      volumeMounts:
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: VolumeMount describes a mounting of a Volume within a container.
+                          type: object
+                          required:
+                            - mountPath
+                            - name
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                      workingDir:
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
+                        type: string
+                dnsConfig:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                  type: string
+                enableServiceLinks:
+                  description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                  type: boolean
+                hostAliases:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                idleTimeoutSeconds:
+                  description: |-
+                    IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                    to stay open while not receiving any bytes from the user's application. If
+                    unspecified, a system default will be provided.
+                  type: integer
+                  format: int64
+                imagePullSecrets:
+                  description: |-
+                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                  type: array
+                  items:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    type: object
+                    properties:
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
+                        type: string
+                    x-kubernetes-map-type: atomic
+                initContainers:
+                  description: |-
+                    List of initialization containers belonging to the pod.
+                    Init containers are executed in order prior to containers being started. If any
+                    init container fails, the pod is considered to have failed and is handled according
+                    to its restartPolicy. The name for an init container or normal container must be
+                    unique among all containers.
+                    Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                    The resourceRequirements of an init container are taken into account during scheduling
+                    by finding the highest request/limit for each resource type, and then using the max of
+                    of that value or the sum of the normal containers. Limits are applied to init containers
+                    in a similar fashion.
+                    Init containers cannot currently be added or removed.
+                    Cannot be updated.
+                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                nodeSelector:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-map-type: atomic
+                priorityClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                responseStartTimeoutSeconds:
+                  description: |-
+                    ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                    routing layer will wait for a request delivered to a container to begin
+                    sending any network traffic.
+                  type: integer
+                  format: int64
+                runtimeClassName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                schedulerName:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                  type: string
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                serviceAccountName:
+                  description: |-
+                    ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                  type: string
+                shareProcessNamespace:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                  type: boolean
+                  x-kubernetes-preserve-unknown-fields: true
+                timeoutSeconds:
+                  description: |-
+                    TimeoutSeconds is the maximum duration in seconds that the request instance
+                    is allowed to respond to a request. If unspecified, a system default will
+                    be provided.
+                  type: integer
+                  format: int64
+                tolerations:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                topologySpreadConstraints:
+                  description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                  type: array
+                  items:
+                    description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                volumes:
+                  description: |-
+                    List of volumes that can be mounted by containers belonging to the pod.
+                    More info: https://kubernetes.io/docs/concepts/storage/volumes
+                  type: array
+                  items:
+                    description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                    type: object
+                    required:
+                      - name
+                    properties:
+                      configMap:
+                        description: configMap represents a configMap that should populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode is optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          items:
+                            description: |-
+                              items if unspecified, each key-value pair in the Data field of the referenced
+                              ConfigMap will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the ConfigMap,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                                - key
+                                - path
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
+                                  type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
+                            type: string
+                          optional:
+                            description: optional specify whether the ConfigMap or its keys must be defined
+                            type: boolean
+                        x-kubernetes-map-type: atomic
+                      emptyDir:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      name:
+                        description: |-
+                          name of the volume.
+                          Must be a DNS_LABEL and unique within the pod.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      persistentVolumeClaim:
+                        description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      projected:
+                        description: projected items for all in one resources secrets, configmaps, and downward API
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode are the mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          sources:
+                            description: sources is the list of volume projections
+                            type: array
+                            items:
+                              description: Projection that may be projected along with other supported volume types
+                              type: object
+                              properties:
+                                configMap:
+                                  description: configMap information about the configMap data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        type: object
+                                        required:
+                                          - key
+                                          - path
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        type: object
+                                        required:
+                                          - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            type: object
+                                            required:
+                                              - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                            type: object
+                                            required:
+                                              - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            x-kubernetes-map-type: atomic
+                                secret:
+                                  description: secret information about the secret data to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        type: object
+                                        required:
+                                          - key
+                                          - path
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                    optional:
+                                      description: optional field specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  x-kubernetes-map-type: atomic
+                                serviceAccountToken:
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
+                                  type: object
+                                  required:
+                                    - path
+                                  properties:
+                                    audience:
+                                      description: |-
+                                        audience is the intended audience of the token. A recipient of a token
+                                        must identify itself with an identifier specified in the audience of the
+                                        token, and otherwise should reject the token. The audience defaults to the
+                                        identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: |-
+                                        expirationSeconds is the requested duration of validity of the service
+                                        account token. As the token approaches expiration, the kubelet volume
+                                        plugin will proactively rotate the service account token. The kubelet will
+                                        start trying to rotate the token if the token is older than 80 percent of
+                                        its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                        and must be at least 10 minutes.
+                                      type: integer
+                                      format: int64
+                                    path:
+                                      description: |-
+                                        path is the path relative to the mount point of the file to project the
+                                        token into.
+                                      type: string
+                      secret:
+                        description: |-
+                          secret represents a secret that should populate this volume.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: |-
+                              defaultMode is Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values
+                              for mode bits. Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
+                            type: integer
+                            format: int32
+                          items:
+                            description: |-
+                              items If unspecified, each key-value pair in the Data field of the referenced
+                              Secret will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the Secret,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                                - key
+                                - path
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
+                                  type: string
+                          optional:
+                            description: optional field specify whether the Secret or its keys must be defined
+                            type: boolean
+                          secretName:
+                            description: |-
+                              secretName is the name of the secret in the pod's namespace to use.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                            type: string
+            status:
+              description: RevisionStatus communicates the observed state of the Revision (from the controller).
+              type: object
+              properties:
+                actualReplicas:
+                  description: ActualReplicas reflects the amount of ready pods running this revision.
+                  type: integer
+                  format: int32
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                containerStatuses:
+                  description: |-
+                    ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
+                        type: string
+                desiredReplicas:
+                  description: DesiredReplicas reflects the desired amount of pods running this revision.
+                  type: integer
+                  format: int32
+                initContainerStatuses:
+                  description: |-
+                    InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
+                  type: array
+                  items:
+                    description: ContainerStatus holds the information of container name and image digest value
+                    type: object
+                    properties:
+                      imageDigest:
+                        type: string
+                      name:
+                        type: string
+                logUrl:
+                  description: |-
+                    LogURL specifies the generated logging url for this particular revision
+                    based on the revision url template specified in the controller's config.
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: routes.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Route
+    plural: routes
+    singular: route
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - rt
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Route is responsible for configuring ingress over a collection of Revisions.
+            Some of the Revisions a Route distributes traffic over may be specified by
+            referencing the Configuration responsible for creating them; in these cases
+            the Route is additionally responsible for monitoring the Configuration for
+            "latest ready revision" changes, and smoothly rolling out latest revisions.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec holds the desired state of the Route (from the client).
+              type: object
+              properties:
+                traffic:
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+            status:
+              description: Status communicates the observed state of the Route (from the controller).
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a Route to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                traffic:
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
+                    LatestReadyRevisionName that we last observed.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+                url:
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  type: string
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serverlessservices.networking.internal.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+spec:
+  group: networking.internal.knative.dev
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ServerlessService is a proxy for the K8s service objects containing the
+            endpoints for the revision, whether those are endpoints of the activator or
+            revision pods.
+            See: https://knative.page.link/naxz for details.
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                Spec is the desired state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              required:
+                - objectRef
+                - protocolType
+              properties:
+                mode:
+                  description: Mode describes the mode of operation of the ServerlessService.
+                  type: string
+                numActivators:
+                  description: |-
+                    NumActivators contains number of Activators that this revision should be
+                    assigned.
+                    O means — assign all.
+                  type: integer
+                  format: int32
+                objectRef:
+                  description: |-
+                    ObjectRef defines the resource that this ServerlessService
+                    is responsible for making "serverless".
+                  type: object
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  x-kubernetes-map-type: atomic
+                protocolType:
+                  description: |-
+                    The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
+                    serving imports networking, so just use string.
+                  type: string
+            status:
+              description: |-
+                Status is the current state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+              type: object
+              properties:
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                privateServiceName:
+                  description: |-
+                    PrivateServiceName holds the name of a core K8s Service resource that
+                    load balances over the user service pods backing this Revision.
+                  type: string
+                serviceName:
+                  description: |-
+                    ServiceName holds the name of a core K8s Service resource that
+                    load balances over the pods backing this Revision (activator or revision).
+                  type: string
+      additionalPrinterColumns:
+        - name: Mode
+          type: string
+          jsonPath: ".spec.mode"
+        - name: Activators
+          type: integer
+          jsonPath: ".spec.numActivators"
+        - name: ServiceName
+          type: string
+          jsonPath: ".status.serviceName"
+        - name: PrivateServiceName
+          type: string
+          jsonPath: ".status.privateServiceName"
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+  names:
+    kind: ServerlessService
+    plural: serverlessservices
+    singular: serverlessservice
+    categories:
+      - knative-internal
+      - networking
+    shortNames:
+      - sks
+  scope: Namespaced
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Note: The schema part of the spec is auto-generated by hack/update-schemas.sh.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/addressable: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - kservice
+      - ksvc
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: URL
+          type: string
+          jsonPath: .status.url
+        - name: LatestCreated
+          type: string
+          jsonPath: .status.latestCreatedRevisionName
+        - name: LatestReady
+          type: string
+          jsonPath: .status.latestReadyRevisionName
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Service acts as a top-level container that manages a Route and Configuration
+            which implement a network service. Service exists to provide a singular
+            abstraction which can be access controlled, reasoned about, and which
+            encapsulates software lifecycle decisions such as rollout policy and
+            team resource ownership. Service acts only as an orchestrator of the
+            underlying Routes and Configurations (much as a kubernetes Deployment
+            orchestrates ReplicaSets), and its usage is optional but recommended.
+
+
+            The Service's controller will track the statuses of its owned Configuration
+            and Route, reflecting their statuses and conditions as its own.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
+          type: object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                ServiceSpec represents the configuration for the Service object.
+                A Service's specification is the union of the specifications for a Route
+                and Configuration.  The Service restricts what can be expressed in these
+                fields, e.g. the Route must reference the provided Configuration;
+                however, these limitations also enable friendlier defaulting,
+                e.g. Route never needs a Configuration name, and may be defaulted to
+                the appropriate "run latest" spec.
+              type: object
+              properties:
+                template:
+                  description: Template holds the latest specification for the Revision to be stamped out.
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        annotations:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        finalizers:
+                          type: array
+                          items:
+                            type: string
+                        labels:
+                          type: object
+                          additionalProperties:
+                            type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    spec:
+                      description: RevisionSpec holds the desired state of the Revision (from the client).
+                      type: object
+                      required:
+                        - containers
+                      properties:
+                        affinity:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-affinity
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        automountServiceAccountToken:
+                          description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                          type: boolean
+                        containerConcurrency:
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
+                          type: integer
+                          format: int64
+                        containers:
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
+                          type: array
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            type: object
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                type: array
+                                items:
+                                  type: string
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  type: object
+                                  required:
+                                    - name
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      type: object
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: This is accessible behind a feature flag - kubernetes.podspec-fieldref
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          type: object
+                                          required:
+                                            - key
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  type: object
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      type: object
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      x-kubernetes-map-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  type: object
+                                  required:
+                                    - containerPort
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      type: integer
+                                      format: int32
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                      default: TCP
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
+                                    type: array
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                                  requests:
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                    additionalProperties:
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      x-kubernetes-int-or-string: true
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                type: object
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    properties:
+                                      add:
+                                        description: This is accessible behind a feature flag - kubernetes.containerspec-addcapabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                      drop:
+                                        description: Removed capabilities
+                                        type: array
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: integer
+                                    format: int64
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                type: object
+                                properties:
+                                  exec:
+                                    description: Exec specifies the action to take.
+                                    type: object
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        type: array
+                                        items:
+                                          type: string
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  grpc:
+                                    description: GRPC specifies an action involving a GRPC port.
+                                    type: object
+                                    required:
+                                      - port
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        type: integer
+                                        format: int32
+                                      service:
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                  httpGet:
+                                    description: HTTPGet specifies the http request to perform.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        type: array
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          type: object
+                                          required:
+                                            - name
+                                            - value
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                                  periodSeconds:
+                                    description: How often (in seconds) to perform the probe.
+                                    type: integer
+                                    format: int32
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    type: integer
+                                    format: int32
+                                  tcpSocket:
+                                    description: TCPSocket specifies an action involving a TCP port.
+                                    type: object
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        x-kubernetes-int-or-string: true
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    type: integer
+                                    format: int32
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                type: array
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  type: object
+                                  required:
+                                    - mountPath
+                                    - name
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                        dnsConfig:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnsconfig
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        dnsPolicy:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-dnspolicy
+                          type: string
+                        enableServiceLinks:
+                          description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Knative defaults this to false.'
+                          type: boolean
+                        hostAliases:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-hostaliases
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        idleTimeoutSeconds:
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
+                          type: integer
+                          format: int64
+                        imagePullSecrets:
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                          type: array
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            type: object
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                type: string
+                            x-kubernetes-map-type: atomic
+                        initContainers:
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-init-containers
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        nodeSelector:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-nodeselector
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                          x-kubernetes-map-type: atomic
+                        priorityClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-priorityclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        responseStartTimeoutSeconds:
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
+                            sending any network traffic.
+                          type: integer
+                          format: int64
+                        runtimeClassName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-runtimeclassname
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        schedulerName:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-schedulername
+                          type: string
+                          x-kubernetes-preserve-unknown-fields: true
+                        securityContext:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-securitycontext
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        serviceAccountName:
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                          type: string
+                        shareProcessNamespace:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-shareproccessnamespace
+                          type: boolean
+                          x-kubernetes-preserve-unknown-fields: true
+                        timeoutSeconds:
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
+                          type: integer
+                          format: int64
+                        tolerations:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-tolerations
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        topologySpreadConstraints:
+                          description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                          type: array
+                          items:
+                            description: This is accessible behind a feature flag - kubernetes.podspec-topologyspreadconstraints
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        volumes:
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
+                          type: array
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            type: object
+                            required:
+                              - name
+                            properties:
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                x-kubernetes-map-type: atomic
+                              emptyDir:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-emptydir
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              persistentVolumeClaim:
+                                description: This is accessible behind a feature flag - kubernetes.podspec-persistent-volume-claim
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  sources:
+                                    description: sources is the list of volume projections
+                                    type: array
+                                    items:
+                                      description: Projection that may be projected along with other supported volume types
+                                      type: object
+                                      properties:
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              type: array
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                type: object
+                                                required:
+                                                  - path
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                    type: object
+                                                    required:
+                                                      - fieldPath
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    type: object
+                                                    required:
+                                                      - resource
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    x-kubernetes-map-type: atomic
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          type: object
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              type: array
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                type: object
+                                                required:
+                                                  - key
+                                                  - path
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    type: integer
+                                                    format: int32
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                            name:
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          type: object
+                                          required:
+                                            - path
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              type: integer
+                                              format: int64
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                type: object
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    type: integer
+                                    format: int32
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    type: array
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      type: object
+                                      required:
+                                        - key
+                                        - path
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          type: integer
+                                          format: int32
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+                traffic:
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+            status:
+              description: ServiceStatus represents the Status stanza of the Service resource.
+              type: object
+              properties:
+                address:
+                  description: Address holds the information needed for a Route to be the target of an event.
+                  type: object
+                  properties:
+                    CACerts:
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
+                      type: string
+                    audience:
+                      description: Audience is the OIDC audience for this address.
+                      type: string
+                    name:
+                      description: Name is the name of the address.
+                      type: string
+                    url:
+                      type: string
+                annotations:
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
+                  type: object
+                  additionalProperties:
+                    type: string
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
+                        type: string
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                latestCreatedRevisionName:
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
+                  type: string
+                latestReadyRevisionName:
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
+                  type: string
+                observedGeneration:
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
+                  type: integer
+                  format: int64
+                traffic:
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
+                    LatestReadyRevisionName that we last observed.
+                  type: array
+                  items:
+                    description: TrafficTarget holds a single entry of the routing table for a Route.
+                    type: object
+                    properties:
+                      configurationName:
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
+                          RevisionName.
+                        type: string
+                      latestRevision:
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
+                        type: boolean
+                      percent:
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
+                        type: integer
+                        format: int64
+                      revisionName:
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
+                        type: string
+                      tag:
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
+                        type: string
+                      url:
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
+                        type: string
+                url:
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  type: string
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: caching.internal.knative.dev/v1alpha1
+kind: Image
+metadata:
+  name: queue-proxy
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: queue-proxy
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  # This is the Go import path for the binary that is containerized
+  # and substituted here.
+  image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:f1ee8a3efa298ea7b985a66bc9067d64e8b74c21701293fe6f507404f147ba9c
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-autoscaler
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "47c2487f"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # The Revision ContainerConcurrency field specifies the maximum number
+    # of requests the Container can handle at once. Container concurrency
+    # target percentage is how much of that maximum to use in a stable
+    # state. E.g. if a Revision specifies ContainerConcurrency of 10, then
+    # the Autoscaler will try to maintain 7 concurrent connections per pod
+    # on average.
+    # Note: this limit will be applied to container concurrency set at every
+    # level (ConfigMap, Revision Spec or Annotation).
+    # For legacy and backwards compatibility reasons, this value also accepts
+    # fractional values in (0, 1] interval (i.e. 0.7 ⇒ 70%).
+    # Thus minimal percentage value must be greater than 1.0, or it will be
+    # treated as a fraction.
+    # NOTE: that this value does not affect actual number of concurrent requests
+    #       the user container may receive, but only the average number of requests
+    #       that the revision pods will receive.
+    container-concurrency-target-percentage: "70"
+
+    # The container concurrency target default is what the Autoscaler will
+    # try to maintain when concurrency is used as the scaling metric for the
+    # Revision and the Revision specifies unlimited concurrency.
+    # When revision explicitly specifies container concurrency, that value
+    # will be used as a scaling target for autoscaler.
+    # When specifying unlimited concurrency, the autoscaler will
+    # horizontally scale the application based on this target concurrency.
+    # This is what we call "soft limit" in the documentation, i.e. it only
+    # affects number of pods and does not affect the number of requests
+    # individual pod processes.
+    # The value must be a positive number such that the value multiplied
+    # by container-concurrency-target-percentage is greater than 0.01.
+    # NOTE: that this value will be adjusted by application of
+    #       container-concurrency-target-percentage, i.e. by default
+    #       the system will target on average 70 concurrent requests
+    #       per revision pod.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    container-concurrency-target-default: "100"
+
+    # The requests per second (RPS) target default is what the Autoscaler will
+    # try to maintain when RPS is used as the scaling metric for a Revision and
+    # the Revision specifies unlimited RPS. Even when specifying unlimited RPS,
+    # the autoscaler will horizontally scale the application based on this
+    # target RPS.
+    # Must be greater than 1.0.
+    # NOTE: Only one metric can be used for autoscaling a Revision.
+    requests-per-second-target-default: "200"
+
+    # The target burst capacity specifies the size of burst in concurrent
+    # requests that the system operator expects the system will receive.
+    # Autoscaler will try to protect the system from queueing by introducing
+    # Activator in the request path if the current spare capacity of the
+    # service is less than this setting.
+    # If this setting is 0, then Activator will be in the request path only
+    # when the revision is scaled to 0.
+    # If this setting is > 0 and container-concurrency-target-percentage is
+    # 100% or 1.0, then activator will always be in the request path.
+    # -1 denotes unlimited target-burst-capacity and activator will always
+    # be in the request path.
+    # Other negative values are invalid.
+    target-burst-capacity: "211"
+
+    # When operating in a stable mode, the autoscaler operates on the
+    # average concurrency over the stable window.
+    # Stable window must be in whole seconds.
+    stable-window: "60s"
+
+    # When observed average concurrency during the panic window reaches
+    # panic-threshold-percentage the target concurrency, the autoscaler
+    # enters panic mode. When operating in panic mode, the autoscaler
+    # scales on the average concurrency over the panic window which is
+    # panic-window-percentage of the stable-window.
+    # Must be in the [1, 100] range.
+    # When computing the panic window it will be rounded to the closest
+    # whole second, at least 1s.
+    panic-window-percentage: "10.0"
+
+    # The percentage of the container concurrency target at which to
+    # enter panic mode when reached within the panic window.
+    panic-threshold-percentage: "200.0"
+
+    # Max scale up rate limits the rate at which the autoscaler will
+    # increase pod count. It is the maximum ratio of desired pods versus
+    # observed pods.
+    # Cannot be less or equal to 1.
+    # I.e with value of 2.0 the number of pods can at most go N to 2N
+    # over single Autoscaler period (2s), but at least N to
+    # N+1, if Autoscaler needs to scale up.
+    max-scale-up-rate: "1000.0"
+
+    # Max scale down rate limits the rate at which the autoscaler will
+    # decrease pod count. It is the maximum ratio of observed pods versus
+    # desired pods.
+    # Cannot be less or equal to 1.
+    # I.e. with value of 2.0 the number of pods can at most go N to N/2
+    # over single Autoscaler evaluation period (2s), but at
+    # least N to N-1, if Autoscaler needs to scale down.
+    max-scale-down-rate: "2.0"
+
+    # Scale to zero feature flag.
+    enable-scale-to-zero: "true"
+
+    # Scale to zero grace period is the time an inactive revision is left
+    # running before it is scaled to zero (must be positive, but recommended
+    # at least a few seconds if running with mesh networking).
+    # This is the upper limit and is provided not to enforce timeout after
+    # the revision stopped receiving requests for stable window, but to
+    # ensure network reprogramming to put activator in the path has completed.
+    # If the system determines that a shorter period is satisfactory,
+    # then the system will only wait that amount of time before scaling to 0.
+    # NOTE: this period might actually be 0, if activator has been
+    # in the request path sufficiently long.
+    # If there is necessity for the last pod to linger longer use
+    # scale-to-zero-pod-retention-period flag.
+    scale-to-zero-grace-period: "30s"
+
+    # Scale to zero pod retention period defines the minimum amount
+    # of time the last pod will remain after Autoscaler has decided to
+    # scale to zero.
+    # This flag is for the situations where the pod startup is very expensive
+    # and the traffic is bursty (requiring smaller windows for fast action),
+    # but patchy.
+    # The larger of this flag and `scale-to-zero-grace-period` will effectively
+    # determine how the last pod will hang around.
+    scale-to-zero-pod-retention-period: "0s"
+
+    # pod-autoscaler-class specifies the default pod autoscaler class
+    # that should be used if none is specified. If omitted,
+    # the Knative Pod Autoscaler (KPA) is used by default.
+    pod-autoscaler-class: "kpa.autoscaling.knative.dev"
+
+    # The capacity of a single activator task.
+    # The `unit` is one concurrent request proxied by the activator.
+    # activator-capacity must be at least 1.
+    # This value is used for computation of the Activator subset size.
+    # See the algorithm here: http://bit.ly/38XiCZ3.
+    # TODO(vagababov): tune after actual benchmarking.
+    activator-capacity: "100.0"
+
+    # initial-scale is the cluster-wide default value for the initial target
+    # scale of a revision after creation, unless overridden by the
+    # "autoscaling.knative.dev/initialScale" annotation.
+    # This value must be greater than 0 unless allow-zero-initial-scale is true.
+    initial-scale: "1"
+
+    # allow-zero-initial-scale controls whether either the cluster-wide initial-scale flag,
+    # or the "autoscaling.knative.dev/initialScale" annotation, can be set to 0.
+    allow-zero-initial-scale: "false"
+
+    # min-scale is the cluster-wide default value for the min scale of a revision,
+    # unless overridden by the "autoscaling.knative.dev/minScale" annotation.
+    min-scale: "0"
+
+    # max-scale is the cluster-wide default value for the max scale of a revision,
+    # unless overridden by the "autoscaling.knative.dev/maxScale" annotation.
+    # If set to 0, the revision has no maximum scale.
+    max-scale: "0"
+
+    # scale-down-delay is the amount of time that must pass at reduced
+    # concurrency before a scale down decision is applied. This can be useful,
+    # for example, to maintain replica count and avoid a cold start penalty if
+    # more requests come in within the scale down delay period.
+    # The default, 0s, imposes no delay at all.
+    scale-down-delay: "0s"
+
+    # max-scale-limit sets the maximum permitted value for the max scale of a revision.
+    # When this is set to a positive value, a revision with a maxScale above that value
+    # (including a maxScale of "0" = unlimited) is disallowed.
+    # A value of zero (the default) allows any limit, including unlimited.
+    max-scale-limit: "0"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-certmanager
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+    networking.knative.dev/certificate-provider: cert-manager
+  annotations:
+    knative.dev/example-checksum: "b7a9a602"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this block and unindented to actually change the configuration.
+
+    # issuerRef is a reference to the issuer for external-domain certificates used for ingress.
+    # IssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://cert-manager.io/docs/concepts/issuer/
+    # for more details about IssuerRef configuration.
+    # If the issuerRef is not specified, the self-signed `knative-selfsigned-issuer` ClusterIssuer is used.
+    issuerRef: |
+      kind: ClusterIssuer
+      name: letsencrypt-issuer
+
+    # clusterLocalIssuerRef is a reference to the issuer for cluster-local-domain certificates used for ingress.
+    # clusterLocalIssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://cert-manager.io/docs/concepts/issuer/
+    # for more details about ClusterInternalIssuerRef configuration.
+    # If the clusterLocalIssuerRef is not specified, the self-signed `knative-selfsigned-issuer` ClusterIssuer is used.
+    clusterLocalIssuerRef: |
+      kind: ClusterIssuer
+      name: your-company-issuer
+
+    # systemInternalIssuerRef is a reference to the issuer for certificates for system-internal-tls certificates used by Knative internal components.
+    # systemInternalIssuerRef should be either `ClusterIssuer` or `Issuer`.
+    # Please refer `IssuerRef` in https://cert-manager.io/docs/concepts/issuer/
+    # for more details about ClusterInternalIssuerRef configuration.
+    # If the systemInternalIssuerRef is not specified, the self-signed `knative-selfsigned-issuer` ClusterIssuer is used.
+    systemInternalIssuerRef: |
+      kind: ClusterIssuer
+      name: knative-selfsigned-issuer
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-defaults
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "5b64ff5c"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # revision-timeout-seconds contains the default number of
+    # seconds to use for the revision's per-request timeout, if
+    # none is specified.
+    revision-timeout-seconds: "300"  # 5 minutes
+
+    # max-revision-timeout-seconds contains the maximum number of
+    # seconds that can be used for revision-timeout-seconds.
+    # This value must be greater than or equal to revision-timeout-seconds.
+    # If omitted, the system default is used (600 seconds).
+    #
+    # If this value is increased, the activator's terminationGracePeriodSeconds
+    # should also be increased to prevent in-flight requests being disrupted.
+    max-revision-timeout-seconds: "600"  # 10 minutes
+
+    # revision-response-start-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while waiting to
+    # receive any bytes from the user's application, if none is specified.
+    #
+    # This defaults to 'revision-timeout-seconds'
+    revision-response-start-timeout-seconds: "300"
+
+    # revision-idle-timeout-seconds contains the default number of
+    # seconds a request will be allowed to stay open while not receiving any
+    # bytes from the user's application, if none is specified.
+    revision-idle-timeout-seconds: "0"  # infinite
+
+    # revision-cpu-request contains the cpu allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    # Below is an example of setting revision-cpu-request.
+    # By default, it is not set by Knative.
+    revision-cpu-request: "400m"  # 0.4 of a CPU (aka 400 milli-CPU)
+
+    # revision-memory-request contains the memory allocation to assign
+    # to revisions by default.  If omitted, no value is specified
+    # and the system default is used.
+    # Below is an example of setting revision-memory-request.
+    # By default, it is not set by Knative.
+    revision-memory-request: "100M"  # 100 megabytes of memory
+
+    # revision-ephemeral-storage-request contains the ephemeral storage
+    # allocation to assign to revisions by default.  If omitted, no value is
+    # specified and the system default is used.
+    revision-ephemeral-storage-request: "500M"  # 500 megabytes of storage
+
+    # revision-cpu-limit contains the cpu allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    # Below is an example of setting revision-cpu-limit.
+    # By default, it is not set by Knative.
+    revision-cpu-limit: "1000m"  # 1 CPU (aka 1000 milli-CPU)
+
+    # revision-memory-limit contains the memory allocation to limit
+    # revisions to by default.  If omitted, no value is specified
+    # and the system default is used.
+    # Below is an example of setting revision-memory-limit.
+    # By default, it is not set by Knative.
+    revision-memory-limit: "200M"  # 200 megabytes of memory
+
+    # revision-ephemeral-storage-limit contains the ephemeral storage
+    # allocation to limit revisions to by default.  If omitted, no value is
+    # specified and the system default is used.
+    revision-ephemeral-storage-limit: "750M"  # 750 megabytes of storage
+
+    # container-name-template contains a template for the default
+    # container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    container-name-template: "user-container"
+
+    # init-container-name-template contains a template for the default
+    # init container name, if none is specified.  This field supports
+    # Go templating and is supplied with the ObjectMeta of the
+    # enclosing Service or Configuration, so values such as
+    # {{.Name}} are also valid.
+    init-container-name-template: "init-container"
+
+    # container-concurrency specifies the maximum number
+    # of requests the Container can handle at once, and requests
+    # above this threshold are queued.  Setting a value of zero
+    # disables this throttling and lets through as many requests as
+    # the pod receives.
+    container-concurrency: "0"
+
+    # The container concurrency max limit is an operator setting ensuring that
+    # the individual revisions cannot have arbitrary large concurrency
+    # values, or autoscaling targets. `container-concurrency` default setting
+    # must be at or below this value.
+    #
+    # Must be greater than 1.
+    #
+    # Note: even with this set, a user can choose a containerConcurrency
+    # of 0 (i.e. unbounded) unless allow-container-concurrency-zero is
+    # set to "false".
+    container-concurrency-max-limit: "1000"
+
+    # allow-container-concurrency-zero controls whether users can
+    # specify 0 (i.e. unbounded) for containerConcurrency.
+    allow-container-concurrency-zero: "true"
+
+    # enable-service-links specifies the default value used for the
+    # enableServiceLinks field of the PodSpec, when it is omitted by the user.
+    # See: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service
+    #
+    # This is a tri-state flag with possible values of (true|false|default).
+    #
+    # In environments with large number of services it is suggested
+    # to set this value to `false`.
+    # See https://github.com/knative/serving/issues/8498.
+    enable-service-links: "false"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-deployment
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "720ddb97"
+data:
+  # This is the Go import path for the binary that is containerized
+  # and substituted here.
+  queue-sidecar-image: gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:f1ee8a3efa298ea7b985a66bc9067d64e8b74c21701293fe6f507404f147ba9c
+  _example: |-
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # List of repositories for which tag to digest resolving should be skipped
+    registries-skipping-tag-resolving: "kind.local,ko.local,dev.local"
+
+    # Maximum time allowed for an image's digests to be resolved.
+    digest-resolution-timeout: "10s"
+
+    # Duration we wait for the deployment to be ready before considering it failed.
+    progress-deadline: "600s"
+
+    # Sets the queue proxy's CPU request.
+    # If omitted, a default value (currently "25m"), is used.
+    queue-sidecar-cpu-request: "25m"
+
+    # Sets the queue proxy's CPU limit.
+    # If omitted, a default value (currently "1000m"), is used when
+    # `queueproxy.resource-defaults` is set to `Enabled`.
+    queue-sidecar-cpu-limit: "1000m"
+
+    # Sets the queue proxy's memory request.
+    # If omitted, a default value (currently "400Mi"), is used when
+    # `queueproxy.resource-defaults` is set to `Enabled`.
+    queue-sidecar-memory-request: "400Mi"
+
+    # Sets the queue proxy's memory limit.
+    # If omitted, a default value (currently "800Mi"), is used when
+    # `queueproxy.resource-defaults` is set to `Enabled`.
+    queue-sidecar-memory-limit: "800Mi"
+
+    # Sets the queue proxy's ephemeral storage request.
+    # If omitted, no value is specified and the system default is used.
+    queue-sidecar-ephemeral-storage-request: "512Mi"
+
+    # Sets the queue proxy's ephemeral storage limit.
+    # If omitted, no value is specified and the system default is used.
+    queue-sidecar-ephemeral-storage-limit: "1024Mi"
+
+    # Sets tokens associated with specific audiences for queue proxy - used by QPOptions
+    #
+    # For example, to add the `service-x` audience:
+    #    queue-sidecar-token-audiences: "service-x"
+    # Also supports a list of audiences, for example:
+    #    queue-sidecar-token-audiences: "service-x,service-y"
+    # If omitted, or empty, no tokens are created
+    queue-sidecar-token-audiences: ""
+
+    # Sets rootCA for the queue proxy - used by QPOptions
+    # If omitted, or empty, no rootCA is added to the golang rootCAs
+    queue-sidecar-rootca: ""
+
+    # If set, it automatically configures pod anti-affinity requirements for all Knative services.
+    # It employs the `preferredDuringSchedulingIgnoredDuringExecution` weighted pod affinity term,
+    # aligning with the Knative revision label. It yields the configuration below in all workloads' deployments:
+    # `
+    #   affinity:
+    #     podAntiAffinity:
+    #       preferredDuringSchedulingIgnoredDuringExecution:
+    #       - podAffinityTerm:
+    #           topologyKey: kubernetes.io/hostname
+    #           labelSelector:
+    #             matchLabels:
+    #               serving.knative.dev/revision: {{revision-name}}
+    #         weight: 100
+    # `
+    # This may be "none" or "prefer-spread-revision-over-nodes" (default)
+    # default-affinity-type: "prefer-spread-revision-over-nodes"
+
+    # runtime-class-name contains the selector for which runtimeClassName
+    # is selected to put in a revision.
+    # By default, it is not set by Knative.
+    #
+    # Example:
+    # runtime-class-name: |
+    #   "":
+    #     selector:
+    #       use-default-runc: "yes"
+    #   kata: {}
+    #   gvisor:
+    #     selector:
+    #       use-gvisor: "please"
+    runtime-class-name: ""
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-domain
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "26c09de5"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default value for domain.
+    # Routes having the cluster domain suffix (by default 'svc.cluster.local')
+    # will not be exposed through Ingress. You can define your own label
+    # selector to assign that domain suffix to your Route here, or you can set
+    # the label
+    #    "networking.knative.dev/visibility=cluster-local"
+    # to achieve the same effect.  This shows how to make routes having
+    # the label app=secret only exposed to the local cluster.
+    svc.cluster.local: |
+      selector:
+        app: secret
+
+    # These are example settings of domain.
+    # example.com will be used for all routes, but it is the least-specific rule so it
+    # will only be used if no other domain matches.
+    example.com: |
+
+    # example.org will be used for routes having app=nonprofit.
+    example.org: |
+      selector:
+        app: nonprofit
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-features
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "632d47dd"
+data:
+  _example: |-
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.10
+    secure-pod-defaults: "disabled"
+
+    # Indicates whether multi container support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/configuration/feature-flags/#multiple-containers
+    multi-container: "enabled"
+
+    # Indicates whether multi container probing is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/configuration/feature-flags/#multiple-container-probing
+    multi-container-probing: "disabled"
+
+    # Indicates whether Kubernetes affinity support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-affinity
+    kubernetes.podspec-affinity: "disabled"
+
+    # Indicates whether Kubernetes topologySpreadConstraints support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-topology-spread-constraints
+    kubernetes.podspec-topologyspreadconstraints: "disabled"
+
+    # Indicates whether Kubernetes hostAliases support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-host-aliases
+    kubernetes.podspec-hostaliases: "disabled"
+
+    # Indicates whether Kubernetes nodeSelector support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-node-selector
+    kubernetes.podspec-nodeselector: "disabled"
+
+    # Indicates whether Kubernetes tolerations support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-toleration
+    kubernetes.podspec-tolerations: "disabled"
+
+    # Indicates whether Kubernetes FieldRef support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-fieldref
+    kubernetes.podspec-fieldref: "disabled"
+
+    # Indicates whether Kubernetes RuntimeClassName support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-runtime-class
+    kubernetes.podspec-runtimeclassname: "disabled"
+
+    # Indicates whether Kubernetes DNSPolicy support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnspolicy
+    kubernetes.podspec-dnspolicy: "disabled"
+
+    # Indicates whether Kubernetes DNSConfig support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dnsconfig
+    kubernetes.podspec-dnsconfig: "disabled"
+
+    # This feature allows end-users to set a subset of fields on the Pod's SecurityContext
+    #
+    # When set to "enabled" or "allowed" it allows the following
+    # PodSecurityContext properties:
+    # - FSGroup
+    # - RunAsGroup
+    # - RunAsNonRoot
+    # - SupplementalGroups
+    # - RunAsUser
+    # - SeccompProfile
+    #
+    # This feature flag should be used with caution as the PodSecurityContext
+    # properties may have a side-effect on non-user sidecar containers that come
+    # from Knative or your service mesh
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-security-context
+    kubernetes.podspec-securitycontext: "disabled"
+
+    # Indicated whether sharing the process namespace via ShareProcessNamespace pod spec is allowed.
+    # This can be especially useful for sharing data from images directly between sidecars
+    #
+    # See: https://knative.dev/docs/serving/configuration/feature-flags/#kubernetes-share-process-namespace
+    kubernetes.podspec-shareprocessnamespace: "disabled"
+
+    # Indicates whether Kubernetes PriorityClassName support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-priority-class-name
+    kubernetes.podspec-priorityclassname: "disabled"
+
+    # Indicates whether Kubernetes SchedulerName support is enabled
+    #
+    # WARNING: Cannot safely be disabled once enabled.
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-scheduler-name
+    kubernetes.podspec-schedulername: "disabled"
+
+    # This feature flag allows end-users to add a subset of capabilities on the Pod's SecurityContext.
+    #
+    # When set to "enabled" or "allowed" it allows capabilities to be added to the container.
+    # For a list of possible capabilities, see https://man7.org/linux/man-pages/man7/capabilities.7.html
+    kubernetes.containerspec-addcapabilities: "disabled"
+
+    # This feature validates PodSpecs from the validating webhook
+    # against the K8s API Server.
+    #
+    # When "enabled", the server will always run the extra validation.
+    # When "allowed", the server will not run the dry-run validation by default.
+    #   However, clients may enable the behavior on an individual Service by
+    #   attaching the following metadata annotation: "features.knative.dev/podspec-dryrun":"enabled".
+    # See: https://knative.dev/docs/serving/feature-flags/#kubernetes-dry-run
+    kubernetes.podspec-dryrun: "allowed"
+
+    # Controls whether tag header based routing feature are enabled or not.
+    # 1. Enabled: enabling tag header based routing
+    # 2. Disabled: disabling tag header based routing
+    # See: https://knative.dev/docs/serving/feature-flags/#tag-header-based-routing
+    tag-header-based-routing: "disabled"
+
+    # Controls whether http2 auto-detection should be enabled or not.
+    # 1. Enabled: http2 connection will be attempted via upgrade.
+    # 2. Disabled: http2 connection will only be attempted when port name is set to "h2c".
+    autodetect-http2: "disabled"
+
+    # Controls whether volume support for EmptyDir is enabled or not.
+    # 1. Enabled: enabling EmptyDir volume support
+    # 2. Disabled: disabling EmptyDir volume support
+    kubernetes.podspec-volumes-emptydir: "enabled"
+
+    # Controls whether init containers support is enabled or not.
+    # 1. Enabled: enabling init containers support
+    # 2. Disabled: disabling init containers support
+    kubernetes.podspec-init-containers: "disabled"
+
+    # Controls whether persistent volume claim support is enabled or not.
+    # 1. Enabled: enabling persistent volume claim support
+    # 2. Disabled: disabling persistent volume claim support
+    kubernetes.podspec-persistent-volume-claim: "disabled"
+
+    # Controls whether write access for persistent volumes is enabled or not.
+    # 1. Enabled: enabling write access for persistent volumes
+    # 2. Disabled: disabling write access for persistent volumes
+    kubernetes.podspec-persistent-volume-write: "disabled"
+
+    # Controls if the queue proxy podInfo feature is enabled, allowed or disabled
+    #
+    # This feature should be enabled/allowed when using queue proxy Options (Extensions)
+    # Enabling will mount a podInfo volume to the queue proxy container.
+    # The volume will contains an 'annotations' file (from the pod's annotation field).
+    # The annotations in this file include the Service annotations set by the client creating the service.
+    # If mounted, the annotations can be accessed by queue proxy extensions at /etc/podinfo/annnotations
+    #
+    # 1. "enabled": always mount a podInfo volume
+    # 2. "disabled": never mount a podInfo volume
+    # 3. "allowed": by default, do not mount a podInfo volume
+    #   However, a client may mount the podInfo volume on an individual Service by attaching
+    #   the following metadata annotation to the Service: "features.knative.dev/queueproxy-podinfo":"enabled".
+    #
+    # NOTE THAT THIS IS AN EXPERIMENTAL / ALPHA FEATURE
+    queueproxy.mount-podinfo: "disabled"
+
+    # Default queue proxy resource requests and limits to good values for most cases if set.
+    queueproxy.resource-defaults: "disabled"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-gc
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "aa3813a8"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # ---------------------------------------
+    # Garbage Collector Settings
+    # ---------------------------------------
+    #
+    # Active
+    #   * Revisions which are referenced by a Route are considered active.
+    #   * Individual revisions may be marked with the annotation
+    #      "serving.knative.dev/no-gc":"true" to be permanently considered active.
+    #   * Active revisions are not considered for GC.
+    # Retention
+    #   * Revisions are retained if they are any of the following:
+    #       1. Active
+    #       2. Were created within "retain-since-create-time"
+    #       3. Were last referenced by a route within
+    #           "retain-since-last-active-time"
+    #       4. There are fewer than "min-non-active-revisions"
+    #     If none of these conditions are met, or if the count of revisions exceed
+    #      "max-non-active-revisions", they will be deleted by GC.
+    #     The special value "disabled" may be used to turn off these limits.
+    #
+    # Example config to immediately collect any inactive revision:
+    #    min-non-active-revisions: "0"
+    #    max-non-active-revisions: "0"
+    #    retain-since-create-time: "disabled"
+    #    retain-since-last-active-time: "disabled"
+    #
+    # Example config to always keep around the last ten non-active revisions:
+    #     retain-since-create-time: "disabled"
+    #     retain-since-last-active-time: "disabled"
+    #     max-non-active-revisions: "10"
+    #
+    # Example config to disable all garbage collection:
+    #     retain-since-create-time: "disabled"
+    #     retain-since-last-active-time: "disabled"
+    #     max-non-active-revisions: "disabled"
+    #
+    # Example config to keep recently deployed or active revisions,
+    # always maintain the last two in case of rollback, and prevent
+    # burst activity from exploding the count of old revisions:
+    #      retain-since-create-time: "48h"
+    #      retain-since-last-active-time: "15h"
+    #      min-non-active-revisions: "2"
+    #      max-non-active-revisions: "1000"
+
+    # Duration since creation before considering a revision for GC or "disabled".
+    retain-since-create-time: "48h"
+
+    # Duration since active before considering a revision for GC or "disabled".
+    retain-since-last-active-time: "15h"
+
+    # Minimum number of non-active revisions to retain.
+    min-non-active-revisions: "20"
+
+    # Maximum number of non-active revisions to retain
+    # or "disabled" to disable any maximum limit.
+    max-non-active-revisions: "1000"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "f4b71f57"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # lease-duration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    lease-duration: "60s"
+
+    # renew-deadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renew-deadline: "40s"
+
+    # retry-period is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kubernetes controllers.
+    retry-period: "10s"
+
+    # buckets is the number of buckets used to partition key space of each
+    # Reconciler. If this number is M and the replica number of the controller
+    # is N, the N replicas will compete for the M buckets. The owner of a
+    # bucket will take care of the reconciling for the keys partitioned into
+    # that bucket.
+    buckets: "1"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: knative-serving
+  annotations:
+    knative.dev/example-checksum: "9f25d429"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # Common configuration for all Knative codebase
+    zap-logger-config: |
+      {
+        "level": "info",
+        "development": false,
+        "outputPaths": ["stdout"],
+        "errorOutputPaths": ["stderr"],
+        "encoding": "json",
+        "encoderConfig": {
+          "timeKey": "timestamp",
+          "levelKey": "severity",
+          "nameKey": "logger",
+          "callerKey": "caller",
+          "messageKey": "message",
+          "stacktraceKey": "stacktrace",
+          "lineEnding": "",
+          "levelEncoder": "",
+          "timeEncoder": "iso8601",
+          "durationEncoder": "",
+          "callerEncoder": ""
+        }
+      }
+
+    # Log level overrides
+    # For all components except the queue proxy,
+    # changes are picked up immediately.
+    # For queue proxy, changes require recreation of the pods.
+    loglevel.controller: "info"
+    loglevel.autoscaler: "info"
+    loglevel.queueproxy: "info"
+    loglevel.webhook: "info"
+    loglevel.activator: "info"
+    loglevel.hpaautoscaler: "info"
+    loglevel.net-istio-controller: "info"
+    loglevel.net-contour-controller: "info"
+    loglevel.net-kourier-controller: "info"
+    loglevel.net-gateway-api-controller: "info"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-network
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "0573e07d"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # ingress-class specifies the default ingress class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Istio ingress.
+    #
+    # Note that changing the Ingress class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    ingress-class: "istio.ingress.networking.knative.dev"
+
+    # certificate-class specifies the default Certificate class
+    # to use when not dictated by Route annotation.
+    #
+    # If not specified, will use the Cert-Manager Certificate.
+    #
+    # Note that changing the Certificate class of an existing Route
+    # will result in undefined behavior.  Therefore it is best to only
+    # update this value during the setup of Knative, to avoid getting
+    # undefined behavior.
+    certificate-class: "cert-manager.certificate.networking.knative.dev"
+
+    # namespace-wildcard-cert-selector specifies a LabelSelector which
+    # determines which namespaces should have a wildcard certificate
+    # provisioned.
+    #
+    # Use an empty value to disable the feature (this is the default):
+    #   namespace-wildcard-cert-selector: ""
+    #
+    # Use an empty object to enable for all namespaces
+    #   namespace-wildcard-cert-selector: {}
+    #
+    # Useful labels include the "kubernetes.io/metadata.name" label to
+    # avoid provisioning a certificate for the "kube-system" namespaces.
+    # Use the following selector to match pre-1.0 behavior of using
+    # "networking.knative.dev/disableWildcardCert" to exclude namespaces:
+    #
+    # matchExpressions:
+    # - key: "networking.knative.dev/disableWildcardCert"
+    #   operator: "NotIn"
+    #   values: ["true"]
+    namespace-wildcard-cert-selector: ""
+
+    # domain-template specifies the golang text template string to use
+    # when constructing the Knative service's DNS name. The default
+    # value is "{{.Name}}.{{.Namespace}}.{{.Domain}}".
+    #
+    # Valid variables defined in the template include Name, Namespace, Domain,
+    # Labels, and Annotations. Name will be the result of the tag-template
+    # below, if a tag is specified for the route.
+    #
+    # Changing this value might be necessary when the extra levels in
+    # the domain name generated is problematic for wildcard certificates
+    # that only support a single level of domain name added to the
+    # certificate's domain. In those cases you might consider using a value
+    # of "{{.Name}}-{{.Namespace}}.{{.Domain}}", or removing the Namespace
+    # entirely from the template. When choosing a new value be thoughtful
+    # of the potential for conflicts - for example, when users choose to use
+    # characters such as `-` in their service, or namespace, names.
+    # {{.Annotations}} or {{.Labels}} can be used for any customization in the
+    # go template if needed.
+    # We strongly recommend keeping namespace part of the template to avoid
+    # domain name clashes:
+    # eg. '{{.Name}}-{{.Namespace}}.{{ index .Annotations "sub"}}.{{.Domain}}'
+    # and you have an annotation {"sub":"foo"}, then the generated template
+    # would be {Name}-{Namespace}.foo.{Domain}
+    domain-template: "{{.Name}}.{{.Namespace}}.{{.Domain}}"
+
+    # tag-template specifies the golang text template string to use
+    # when constructing the DNS name for "tags" within the traffic blocks
+    # of Routes and Configuration.  This is used in conjunction with the
+    # domain-template above to determine the full URL for the tag.
+    tag-template: "{{.Tag}}-{{.Name}}"
+
+    # auto-tls is deprecated and replaced by external-domain-tls
+    auto-tls: "Disabled"
+
+    # Controls whether TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster external domains (like: app.example.com)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster external domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster external domains.
+    external-domain-tls: "Disabled"
+
+    # Controls weather TLS certificates are automatically provisioned and
+    # installed in the Knative ingress to terminate TLS connections
+    # for cluster local domains (like: app.namespace.svc.<your-cluster-domain>)
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    cluster-local-domain-tls: "Disabled"
+
+    # internal-encryption is deprecated and replaced by system-internal-tls
+    internal-encryption: "false"
+
+    # system-internal-tls controls weather TLS encryption is used for connections between
+    # the internal components of Knative:
+    # - ingress to activator
+    # - ingress to queue-proxy
+    # - activator to queue-proxy
+    #
+    # Possible values for this flag are:
+    # - Enabled: enables the TLS certificate provisioning feature for cluster cluster-local domains.
+    # - Disabled: disables the TLS certificate provisioning feature for cluster cluster local domains.
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    system-internal-tls: "Disabled"
+
+    # Controls the behavior of the HTTP endpoint for the Knative ingress.
+    # It requires auto-tls to be enabled.
+    # - Enabled: The Knative ingress will be able to serve HTTP connection.
+    # - Redirected: The Knative ingress will send a 301 redirect for all
+    # http connections, asking the clients to use HTTPS.
+    #
+    # "Disabled" option is deprecated.
+    http-protocol: "Enabled"
+
+    # rollout-duration contains the minimal duration in seconds over which the
+    # Configuration traffic targets are rolled out to the newest revision.
+    rollout-duration: "0"
+
+    # autocreate-cluster-domain-claims controls whether ClusterDomainClaims should
+    # be automatically created (and deleted) as needed when DomainMappings are
+    # reconciled.
+    #
+    # If this is "false" (the default), the cluster administrator is
+    # responsible for creating ClusterDomainClaims and delegating them to
+    # namespaces via their spec.Namespace field. This setting should be used in
+    # multitenant environments which need to control which namespace can use a
+    # particular domain name in a domain mapping.
+    #
+    # If this is "true", users are able to associate arbitrary names with their
+    # services via the DomainMapping feature.
+    autocreate-cluster-domain-claims: "false"
+
+    # If true, networking plugins can add additional information to deployed
+    # applications to make their pods directly accessible via their IPs even if mesh is
+    # enabled and thus direct-addressability is usually not possible.
+    # Consumers like Knative Serving can use this setting to adjust their behavior
+    # accordingly, i.e. to drop fallback solutions for non-pod-addressable systems.
+    #
+    # NOTE: This flag is in an alpha state and is mostly here to enable internal testing
+    #       for now. Use with caution.
+    enable-mesh-pod-addressability: "false"
+
+    # mesh-compatibility-mode indicates whether consumers of network plugins
+    # should directly contact Pod IPs (most efficient), or should use the
+    # Cluster IP (less efficient, needed when mesh is enabled unless
+    # `enable-mesh-pod-addressability`, above, is set).
+    # Permitted values are:
+    #  - "auto" (default): automatically determine which mesh mode to use by trying Pod IP and falling back to Cluster IP as needed.
+    #  - "enabled": always use Cluster IP and do not attempt to use Pod IPs.
+    #  - "disabled": always use Pod IPs and do not fall back to Cluster IP on failure.
+    mesh-compatibility-mode: "auto"
+
+    # Defines the scheme used for external URLs if auto-tls is not enabled.
+    # This can be used for making Knative report all URLs as "HTTPS" for example, if you're
+    # fronting Knative with an external loadbalancer that deals with TLS termination and
+    # Knative doesn't know about that otherwise.
+    default-external-scheme: "http"
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "54abd711"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    logging.revision-url-template: "http://logging.example.com/?revisionUID=${REVISION_UID}"
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # NB: after 0.18 release logging.enable-request-log must be explicitly set to true
+    # in order for request logging to be enabled.
+    #
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, the request logging will be enabled.
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
+    # will be ignored.
+    logging.enable-request-log: "false"
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or opencensus.
+    metrics.backend-destination: prometheus
+
+    # metrics.reporting-period-seconds specifies the global metrics reporting period for control and data plane components.
+    # If a zero or negative value is passed the default reporting period is used (10 secs).
+    # If the attribute is not specified a default value is used per metrics backend.
+    # For the prometheus backend the default reporting period is 5s while for opencensus it is 60s.
+    metrics.reporting-period-seconds: "5"
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), opencensus.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.request-metrics-reporting-period-seconds specifies the request metrics reporting period in sec at queue proxy.
+    # If a zero or negative value is passed the default reporting period is used (10 secs).
+    # If the attribute is not specified, it is overridden by the value of metrics.reporting-period-seconds.
+    metrics.request-metrics-reporting-period-seconds: "5"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+
+---
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: tracing
+    app.kubernetes.io/version: "1.15.1"
+  annotations:
+    knative.dev/example-checksum: "26614636"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+    #
+    # This may be "zipkin" or "none" (default)
+    backend: "none"
+
+    # URL to zipkin collector where traces are sent.
+    # This must be specified when backend is "zipkin"
+    zipkin-endpoint: "http://zipkin.istio-system.svc.cluster.local:9411/api/v2/spans"
+
+    # Enable zipkin debug mode. This allows all spans to be sent to the server
+    # bypassing sampling.
+    debug: "false"
+
+    # Percentage (0-1) of requests to trace
+    sample-rate: "0.1"
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  minReplicas: 1
+  maxReplicas: 20
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: activator
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          # Percentage of the requested CPU
+          averageUtilization: 100
+---
+# Activator PDB. Currently we permit unavailability of 20% of tasks at the same time.
+# Given the subsetting and that the activators are partially stateful systems, we want
+# a slow rollout of the new versions and slow migration during node upgrades.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: activator-pdb
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+      app: activator
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: activator
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+spec:
+  selector:
+    matchLabels:
+      app: activator
+      role: activator
+  template:
+    metadata:
+      labels:
+        app: activator
+        role: activator
+        app.kubernetes.io/component: activator
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: activator
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: activator
+      containers:
+        - name: activator
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/activator@sha256:289637128ee638c59f43759d4a503795247024b499152925cbabad3d4ad965b1
+          # The numbers are based on performance test results from
+          # https://github.com/knative/serving/issues/1625#issuecomment-511930023
+          resources:
+            requests:
+              cpu: 300m
+              memory: 60Mi
+            limits:
+              cpu: 1000m
+              memory: 600Mi
+          env:
+            # Run Activator with GC collection when newly generated memory is 500%.
+            - name: GOGC
+              value: "500"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: http1
+              containerPort: 8012
+            - name: h2c
+              containerPort: 8013
+          readinessProbe:
+            httpGet:
+              port: 8012
+            periodSeconds: 5
+            failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              port: 8012
+            periodSeconds: 10
+            failureThreshold: 12
+            initialDelaySeconds: 15
+      # The activator (often) sits on the dataplane, and may proxy long (e.g.
+      # streaming, websockets) requests.  We give a long grace period for the
+      # activator to "lame duck" and drain outstanding requests before we
+      # forcibly terminate the pod (and outstanding connections).  This value
+      # should be at least as large as the upper bound on the Revision's
+      # timeoutSeconds property to avoid servicing events disrupting
+      # connections.
+      terminationGracePeriodSeconds: 600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: activator-service
+  namespace: knative-serving
+  labels:
+    app: activator
+    app.kubernetes.io/component: activator
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+spec:
+  selector:
+    app: activator
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+    - name: http
+      port: 80
+      targetPort: 8012
+    - name: http2
+      port: 81
+      targetPort: 8013
+    - name: https
+      port: 443
+      targetPort: 8112
+  type: ClusterIP
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: autoscaler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: autoscaler
+        app.kubernetes.io/component: autoscaler
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: autoscaler
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: controller
+      containers:
+        - name: autoscaler
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler@sha256:fb70ee517f350d0c1c5cb316aa3616c177e37681c5e1fd22b3e49cc8a57e4a1f
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: websocket
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              port: 8080
+          livenessProbe:
+            httpGet:
+              port: 8080
+            failureThreshold: 6
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler
+    app.kubernetes.io/component: autoscaler
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+  name: autoscaler
+  namespace: knative-serving
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+    - name: http
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: autoscaler
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  selector:
+    matchLabels:
+      app: controller
+  template:
+    metadata:
+      labels:
+        app: controller
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: controller
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: controller
+      containers:
+        - name: controller
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/controller@sha256:33a3f08414b614a2d48de978ac1240737e06341c8419184a8712863e812211cf
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            periodSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            periodSeconds: 5
+            failureThreshold: 3
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: probes
+              containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+  name: controller
+  namespace: knative-serving
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+  selector:
+    app: controller
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  minReplicas: 1
+  maxReplicas: 5
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: webhook
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          # Percentage of the requested CPU
+          averageUtilization: 100
+---
+# Webhook PDB.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: webhook-pdb
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  minAvailable: 80%
+  selector:
+    matchLabels:
+      app: webhook
+
+---
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webhook
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+spec:
+  selector:
+    matchLabels:
+      app: webhook
+      role: webhook
+  template:
+    metadata:
+      labels:
+        app: webhook
+        role: webhook
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/version: "1.15.1"
+        app.kubernetes.io/name: knative-serving
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: webhook
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: controller
+      containers:
+        - name: webhook
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/webhook@sha256:3c669d86c48f74861e6d558c6e6aa1e81d951af860e626a568739f330bbe8b13
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 500m
+              memory: 500Mi
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            - name: WEBHOOK_NAME
+              value: webhook
+            - name: WEBHOOK_PORT
+              value: "8443"
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/internal/serving
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: https-webhook
+              containerPort: 8443
+          readinessProbe:
+            periodSeconds: 1
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+          livenessProbe:
+            periodSeconds: 10
+            httpGet:
+              scheme: HTTPS
+              port: 8443
+            failureThreshold: 6
+            initialDelaySeconds: 20
+      # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
+      # high value that we respect whatever value it has configured for the lame duck grace period.
+      terminationGracePeriodSeconds: 300
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: webhook
+    role: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/version: "1.15.1"
+    app.kubernetes.io/name: knative-serving
+  name: webhook
+  namespace: knative-serving
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+    - name: https-webhook
+      port: 443
+      targetPort: 8443
+  selector:
+    app: webhook
+    role: webhook
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.serving.knative.dev
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+webhooks:
+  - admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+    failurePolicy: Fail
+    sideEffects: None
+    name: config.webhook.serving.knative.dev
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values: ["knative-serving"]
+        - key: app.kubernetes.io/component
+          operator: In
+          values: ["autoscaler", "controller", "logging", "networking", "observability", "tracing", "net-certmanager"]
+    timeoutSeconds: 10
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: webhook.serving.knative.dev
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+webhooks:
+  - admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+    failurePolicy: Fail
+    sideEffects: None
+    name: webhook.serving.knative.dev
+    timeoutSeconds: 10
+    rules:
+      - apiGroups:
+          - autoscaling.internal.knative.dev
+          - networking.internal.knative.dev
+          - serving.knative.dev
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+        scope: "*"
+        resources:
+          - metrics
+          - podautoscalers
+          - certificates
+          - ingresses
+          - serverlessservices
+          - configurations
+          - revisions
+          - routes
+          - services
+          - domainmappings
+          - domainmappings/status
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.serving.knative.dev
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+webhooks:
+  - admissionReviewVersions: ["v1", "v1beta1"]
+    clientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+    failurePolicy: Fail
+    sideEffects: None
+    name: validation.webhook.serving.knative.dev
+    timeoutSeconds: 10
+    rules:
+      - apiGroups:
+          - autoscaling.internal.knative.dev
+          - networking.internal.knative.dev
+          - serving.knative.dev
+        apiVersions:
+          - "*"
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        scope: "*"
+        resources:
+          - metrics
+          - podautoscalers
+          - certificates
+          - ingresses
+          - serverlessservices
+          - configurations
+          - revisions
+          - routes
+          - services
+          - domainmappings
+          - domainmappings/status
+
+---
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-certs
+  namespace: knative-serving
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+# The data is populated at install time.
+
+---

--- a/cmd/operator/kodata/knative-serving/1.15.1/3-serving-hpa.yaml
+++ b/cmd/operator/kodata/knative-serving/1.15.1/3-serving-hpa.yaml
@@ -1,0 +1,126 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: autoscaler-hpa
+  namespace: knative-serving
+  labels:
+    autoscaling.knative.dev/autoscaler-provider: hpa
+    app.kubernetes.io/component: autoscaler-hpa
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  selector:
+    matchLabels:
+      app: autoscaler-hpa
+  template:
+    metadata:
+      labels:
+        app: autoscaler-hpa
+        app.kubernetes.io/component: autoscaler-hpa
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: autoscaler-hpa
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+      serviceAccountName: controller
+      containers:
+        - name: autoscaler-hpa
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler-hpa@sha256:e7e0d37e92420218c69a8c5196e91d3698aad89b425fc27d81db964749dc64ed
+          resources:
+            requests:
+              cpu: 30m
+              memory: 40Mi
+            limits:
+              cpu: 300m
+              memory: 400Mi
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: config-logging
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: config-observability
+            # TODO(https://github.com/knative/pkg/pull/953): Remove stackdriver specific config
+            - name: METRICS_DOMAIN
+              value: knative.dev/serving
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: probes
+              scheme: HTTP
+            periodSeconds: 5
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: probes
+              scheme: HTTP
+            periodSeconds: 5
+            failureThreshold: 5
+          ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
+            - name: probes
+              containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: autoscaler-hpa
+    autoscaling.knative.dev/autoscaler-provider: hpa
+    app.kubernetes.io/component: autoscaler-hpa
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/version: "1.15.1"
+  name: autoscaler-hpa
+  namespace: knative-serving
+spec:
+  ports:
+    # Define metrics and profiling for them to be accessible within service meshes.
+    - name: http-metrics
+      port: 9090
+      targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
+  selector:
+    app: autoscaler-hpa
+
+---

--- a/cmd/operator/kodata/knative-serving/1.15.1/4-serving-post-install-jobs.yaml
+++ b/cmd/operator/kodata/knative-serving/1.15.1/4-serving-post-install-jobs.yaml
@@ -1,0 +1,140 @@
+
+---
+# /tmp/knative.WIaXNS5c/tmp.lmI1qUx172/serving-storage-version-migration.yaml
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: storage-version-migration-serving-
+  namespace: knative-serving
+  labels:
+    app: storage-version-migration-serving
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: storage-version-migration-job
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: storage-version-migration-serving
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: storage-version-migration-job
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      serviceAccountName: controller
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:7666590e746fbca7fb8a566461a5efcc3c33f462fe1b8008d07f3e67a69de02b
+          args:
+            - "services.serving.knative.dev"
+            - "configurations.serving.knative.dev"
+            - "revisions.serving.knative.dev"
+            - "routes.serving.knative.dev"
+            - "domainmappings.serving.knative.dev"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+
+---
+---
+# /tmp/knative.WIaXNS5c/tmp.lmI1qUx172/cleanup.yaml
+# Copyright 2024 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: cleanup-serving-
+  namespace: knative-serving
+  labels:
+    app: cleanup-serving
+    app.kubernetes.io/name: knative-serving
+    app.kubernetes.io/component: cleanup-job
+    app.kubernetes.io/version: "1.15.1"
+spec:
+  ttlSecondsAfterFinished: 600
+  backoffLimit: 10
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: cleanup-migration-serving
+        app.kubernetes.io/name: knative-serving
+        app.kubernetes.io/component: cleanup-job
+        app.kubernetes.io/version: "1.15.1"
+    spec:
+      serviceAccountName: controller
+      restartPolicy: OnFailure
+      containers:
+        - name: cleanup
+          # This is the Go import path for the binary that is containerized
+          # and substituted here.
+          image: gcr.io/knative-releases/knative.dev/serving/pkg/cleanup/cmd/cleanup@sha256:87e5102d5d5821db976f37f383be9f9f3fd3b62bde62ebbca63262088b764e42
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 1000m
+              memory: 1000Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+---


### PR DESCRIPTION
This PR updates serving and eventing crds to use 1.15.1 latest serving images.

Manfifests updated with the command: ./hack/update-codegen.sh.