### PR TITLE
For satefulset kafka dispatchers we ignore the replica

### DIFF
--- a/pkg/reconciler/common/ha.go
+++ b/pkg/reconciler/common/ha.go
@@ -50,7 +50,7 @@ func HighAvailabilityTransform(obj base.KComponent) mf.Transformer {
 		replicas := int64(*ha.Replicas)
 
 		// Transform deployments that support HA.
-		if u.GetKind() == "Deployment" && !haUnSupported(u.GetName()) && !hasHorizontalPodAutoscaler(u.GetName()) {
+		if u.GetKind() == "Deployment" && !haUnSupported(u.GetName()) && !hasHorizontalPodOrCustomAutoscaler(u.GetName()) {
 			if err := unstructured.SetNestedField(u.Object, replicas, "spec", "replicas"); err != nil {
 				return err
 			}

--- a/pkg/reconciler/common/hpa.go
+++ b/pkg/reconciler/common/hpa.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// When a Podspecable has HPA, the replicas should be controlled by HPAs minReplicas instead of operator.
+// When a Podspecable has HPA o, the replicas should be controlled by HPAs minReplicas instead of operator.
 // Hence, skip changing the spec.replicas for these Podspecables.
-func hasHorizontalPodAutoscaler(name string) bool {
+func hasHorizontalPodOrCustomAutoscaler(name string) bool {
 	return sets.NewString(
 		"webhook",
 		"activator",
@@ -31,6 +31,8 @@ func hasHorizontalPodAutoscaler(name string) bool {
 		"eventing-webhook",
 		"mt-broker-ingress",
 		"mt-broker-filter",
+		"kafka-broker-dispatcher",
+		"kafka-source-dispatcher",
 	).Has(name)
 }
 

--- a/pkg/reconciler/common/hpa.go
+++ b/pkg/reconciler/common/hpa.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// When a Podspecable has HPA o, the replicas should be controlled by HPAs minReplicas instead of operator.
+// When a Podspecable has HPA or a custom autoscaling, the replicas should be controlled by it instead of operator.
 // Hence, skip changing the spec.replicas for these Podspecables.
 func hasHorizontalPodOrCustomAutoscaler(name string) bool {
 	return sets.NewString(

--- a/pkg/reconciler/common/hpa.go
+++ b/pkg/reconciler/common/hpa.go
@@ -33,6 +33,7 @@ func hasHorizontalPodOrCustomAutoscaler(name string) bool {
 		"mt-broker-filter",
 		"kafka-broker-dispatcher",
 		"kafka-source-dispatcher",
+		"kafka-channel-dispatcher",
 	).Has(name)
 }
 

--- a/pkg/reconciler/common/hpa_test.go
+++ b/pkg/reconciler/common/hpa_test.go
@@ -40,6 +40,12 @@ func TestHpaTransform(t *testing.T) {
 		expected: makeUnstructuredDeployment(t, "not-a-hpa"),
 		err:      nil,
 	}, {
+		name:     "Kafka Dispatcher is custom autoscaler",
+		in:       makeUnstructuredDeployment(t, "kafka-source-dispatcher"),
+		replicas: 5,
+		expected: makeUnstructuredDeploymentReplicas(t, "kafka-source-dispatcher", 1),
+		err:      nil,
+	}, {
 		name:     "minReplicas same as override",
 		in:       makeUnstructuredHPA(t, "hpa", 1, 2),
 		replicas: 1,

--- a/pkg/reconciler/common/workload_override.go
+++ b/pkg/reconciler/common/workload_override.go
@@ -49,7 +49,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				ps = &deployment.Spec.Template
 
 				// Do not set replicas, if this resource is controlled by a HPA
-				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
+				if override.Replicas != nil && !hasHorizontalPodOrCustomAutoscaler(override.Name) {
 					deployment.Spec.Replicas = override.Replicas
 				}
 			}
@@ -62,7 +62,7 @@ func OverridesTransform(overrides []base.WorkloadOverride, log *zap.SugaredLogge
 				ps = &ss.Spec.Template
 
 				// Do not set replicas, if this resource is controlled by a HPA
-				if override.Replicas != nil && !hasHorizontalPodAutoscaler(override.Name) {
+				if override.Replicas != nil && !hasHorizontalPodOrCustomAutoscaler(override.Name) {
 					ss.Spec.Replicas = override.Replicas
 				}
 			}


### PR DESCRIPTION
Fixes #

## Proposed Changes

* add statefulset kafka dispatcher to ignore `replica` list (kafka controller them). 
* they are not HPAs, hence just the update on the HPA (or custom autoscaler func)
* added test for kafka source

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
statefulset kafka dispatcher have a managed scaling via kafka controller, hence we ignore replica on those 
```
