### PR TITLE
Allow HTTP->HTTPS redirection on Istio Gateway

### DIFF
--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -2282,6 +2282,13 @@ spec:
                                       type: string
                                   type: object
                                 tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
                                   properties:
                                     mode:
                                       description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
@@ -2291,6 +2298,11 @@ spec:
                                       description: TLS certificate name.
                                       format: string
                                       type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
                                   type: object
                               type: object
                             type: array
@@ -2331,6 +2343,13 @@ spec:
                                       type: string
                                   type: object
                                 tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
                                   properties:
                                     mode:
                                       description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
@@ -2340,6 +2359,11 @@ spec:
                                       description: TLS certificate name.
                                       format: string
                                       type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
                                   type: object
                               type: object
                             type: array


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Extends https://github.com/knative/operator/pull/1482.

One of the ServerTLSSettings on Istio Gatway is `httpsRedirect` that, according to [docs](https://istio.io/latest/docs/reference/config/networking/gateway/#ServerTLSSettings), redirects HTTP traffic to HTTPS. Usually this is a desired behaviour for production setup, the only alternative would be to not create HTTP listener at all.

PR leverages combination of `nullable` property and `oneOf` with `required` fields - this works fine currently as there is 2 distinct options (`mode: <>`, which requires `credentialName` to be set, or `httpsRedirect`, which is mutually exclusive with every other option), but it might become cumbersome if more options of different combinations are added.

Tested with the following specs:
```redirect-on
spec:
  selector:
    istio: ingressgateway
  servers:
  - hosts:
    - '*.example.com'
    port:
      name: http
      number: 80
      protocol: HTTP
    tls:
      httpsRedirect: true
  - hosts:
    - '*.example.com'
    port:
      name: https-production
      number: 443
      protocol: https
    tls:
      credentialName: example-tls
      mode: SIMPLE
```
and
```redirect-off
spec:
  selector:
    istio: ingressgateway
  servers:
  - hosts:
    - '*.example.com'
    port:
      name: http
      number: 80
      protocol: HTTP
  - hosts:
    - '*.example.com'
    port:
      name: https-production
      number: 443
      protocol: https
    tls:
      credentialName: example-tls
      mode: SIMPLE
```
Both produce correct Gateways.

Kubernetes 1.30 (EKS), Knative Operator 1.15.4, Knative Serving 1.15.0, Istio 1.23.0.

## Proposed Changes

* Allows HTTP listener on Istio Gateway to be configured with automatic HTTP->HTTPS redirection.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
feature: Istio Gateway can be configured with automatic HTTP->HTTPS redirection
```
