### PR TITLE
Configure httpRedirect on istio gateway in helm

### DIFF
--- a/config/charts/knative-operator/templates/operator.yaml
+++ b/config/charts/knative-operator/templates/operator.yaml
@@ -4875,6 +4875,13 @@ spec:
                                       type: string
                                   type: object
                                 tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
                                   properties:
                                     mode:
                                       description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
@@ -4884,6 +4891,11 @@ spec:
                                       description: TLS certificate name.
                                       format: string
                                       type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
                                   type: object
                               type: object
                             type: array
@@ -4924,6 +4936,13 @@ spec:
                                       type: string
                                   type: object
                                 tls:
+                                  nullable: true
+                                  oneOf:
+                                  - required:
+                                    - mode
+                                    - credentialName
+                                  - required:
+                                    - httpsRedirect
                                   properties:
                                     mode:
                                       description: TLS mode can be SIMPLE, MUTUAL, ISTIO_MUTUAL.
@@ -4933,6 +4952,11 @@ spec:
                                       description: TLS certificate name.
                                       format: string
                                       type: string
+                                    httpsRedirect:
+                                      description: If set to true, the load balancer will send a 301 redirect
+                                        to HTTPS for all HTTP requests. Should be used only for HTTP listener,
+                                        is mutually exclusive with all other TLS options.
+                                      type: boolean
                                   type: object
                               type: object
                             type: array


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #
Update knative-serving CRD to allow configuring of HTTP->HTTPS redirection on Istio Gateway through helm chart. Currently through knative operator helm chart HTTP->HTTPS redirection on Istio Gateway is not configurable. This was done only in Knative operator manifest file in this PR: https://github.com/knative/operator/pull/1912

Issue: https://github.com/knative/operator/issues/1944
