### PR TITLE
Support specifying affinity in Helm chart

### DIFF
--- a/config/charts/knative-operator/templates/operator.yaml
+++ b/config/charts/knative-operator/templates/operator.yaml
@@ -71,16 +71,10 @@ spec:
         {{ toYaml .Values.knative_operator.operator_webhook.podAnnotations }}
       {{- end }}
     spec:
-      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      {{- if .Values.knative_operator.operator_webhook.affinity }}
       affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: operator-webhook
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+      {{- toYaml .Values.knative_operator.operator_webhook.affinity | nindent 8 }}
+      {{- end }}
       {{- if and .Values.knative_operator.operator_webhook.securityContext }}
       securityContext:
         {{ toYaml .Values.knative_operator.operator_webhook.securityContext }}
@@ -6357,6 +6351,10 @@ spec:
         {{ toYaml .Values.knative_operator.knative_operator.podAnnotations }}
       {{- end }}
     spec:
+      {{- if .Values.knative_operator.knative_operator.affinity }}
+      affinity:
+      {{- toYaml .Values.knative_operator.knative_operator.affinity | nindent 8 }}
+      {{- end }}
       serviceAccountName: knative-operator
       {{- if and .Values.knative_operator.knative_operator.securityContext }}
       securityContext:

--- a/config/charts/knative-operator/values.yaml
+++ b/config/charts/knative-operator/values.yaml
@@ -2,6 +2,7 @@ knative_operator:
   knative_operator:
     image: gcr.io/knative-releases/knative.dev/operator/cmd/operator
     tag: {{ tag }}
+    affinity: {}
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
@@ -16,6 +17,16 @@ knative_operator:
   operator_webhook:
     image: gcr.io/knative-releases/knative.dev/operator/cmd/webhook
     tag: {{ tag }}
+    affinity:
+      # To avoid node becoming SPOF, spread our replicas to different nodes.
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: operator-webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
     containerSecurityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #1961 

## Proposed Changes

Allow affinity to be specified in the Helm chart. Default to the existing podAntiAffinity rule that is already in the chart.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow affinity to be specified in the Helm chart
```
