### PR TITLE
feat: add workflow_dispatch to publish helm workflow, remove unneeded fetch

### DIFF
--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+
 jobs:
   release:
 
@@ -31,21 +33,17 @@ jobs:
           mv hack/find_helm_chart_releases_and_create_helm_index.sh ../.tmp/
           mv hack/gh-pages.tmpl ../.tmp/
 
-          PAGES_BRANCH="gh-pages"
-
-          git fetch --all --tags
-
-          if git show-ref --verify --quiet refs/heads/$PAGES_BRANCH || git ls-remote --exit-code --heads origin $PAGES_BRANCH; then
+          if git show-ref --verify --quiet refs/heads/gh-pages || git ls-remote --exit-code --heads origin gh-pages; then
               # Branch exists
-              git checkout $PAGES_BRANCH
-              echo "Checked out existing branch '$PAGES_BRANCH'"
+              git checkout gh-pages
+              echo "Checked out existing branch 'gh-pages'"
           else
               # Branch does not exist
-              git symbolic-ref HEAD refs/heads/$PAGES_BRANCH
+              git symbolic-ref HEAD refs/heads/gh-pages
               rm .git/index
               git clean -fdx
               echo ".tmp/" > .gitignore
-              echo "Created and checked out new branch '$PAGES_BRANCH'"
+              echo "Created and checked out new branch 'gh-pages'"
           fi
 
           mv ../.tmp ./


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

## Proposed Changes

* Fixes publish-helm workflow failing when "git fetch" is called
* Adds "workflow_dispatch" to publish-helm workflow to allow it to be triggered manually, instead of only on release

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
