### PR TITLE
Propagate manifests paths earlier to operator status

### DIFF
--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -55,6 +55,14 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance base.KComponen
 		status.MarkInstallFailed(err.Error())
 		return fmt.Errorf("failed to apply (cluster)rolebindings: %w", err)
 	}
+	// Webhook configs are placeholder to be reconciled and configured by webhook controllers, not fully operational yet.
+	// They are owned by SYSTEM_NAMESPACE and reconciled once webhook deployment is started.
+	// In some cases a webhook config might be left on the cluster from previous uncompleted install/reinstall attempts.
+	// Such pre-existing webhook config can block creation of ConfigMap and other resource that are validated, resulting
+	// in a deadlock installation loop. For this reasons
+	if err := InstallWebhookConfigs(ctx, manifest, instance); err != nil {
+		return err
+	}
 	if err := manifest.Filter(mf.Not(mf.Any(role, rolebinding, webhook, webhookDependentResources))).Apply(); err != nil {
 		status.MarkInstallFailed(err.Error())
 		if ks, ok := instance.(*v1beta1.KnativeServing); ok && strings.Contains(err.Error(), gatewayNotMatch) &&
@@ -71,6 +79,7 @@ func Install(ctx context.Context, manifest *mf.Manifest, instance base.KComponen
 
 // InstallWebhookConfigs applies the Webhook manifest resources and updates the given status accordingly.
 func InstallWebhookConfigs(ctx context.Context, manifest *mf.Manifest, instance base.KComponent) error {
+	logging.FromContext(ctx).Debug("Installing webhook configurations")
 	status := instance.GetStatus()
 	if err := manifest.Filter(webhook).Apply(); err != nil {
 		status.MarkInstallFailed(err.Error())

--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -56,9 +56,9 @@ func TestInstall(t *testing.T) {
 		*clusterRole.DeepCopy(),
 		*roleBinding.DeepCopy(),
 		*clusterRoleBinding.DeepCopy(),
-		*deployment.DeepCopy(),
 		*mutatingWebhookConfiguration.DeepCopy(),
 		*validatingWebhookConfiguration.DeepCopy(),
+		*deployment.DeepCopy(),
 	}
 
 	client := &fakeClient{}
@@ -79,10 +79,6 @@ func TestInstall(t *testing.T) {
 	}
 	if err := Install(context.TODO(), &manifest, instance); err != nil {
 		t.Fatalf("Install() = %v, want no error", err)
-	}
-
-	if err := InstallWebhookConfigs(context.TODO(), &manifest, instance); err != nil {
-		t.Fatalf("InstallWebhookConfigs() = %v, want no error", err)
 	}
 
 	if err := MarkStatusSuccess(context.TODO(), &manifest, instance); err != nil {

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -141,9 +141,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1beta1.KnativeEvent
 		r.transform,
 		r.handleTLSResources,
 		manifests.Install,
+		manifests.SetManifestPaths, // setting path right after applying manifests to populate paths
 		common.CheckDeployments,
-		common.InstallWebhookConfigs,
-		manifests.SetManifestPaths,
 		common.MarkStatusSuccess,
 		common.DeleteObsoleteResources(ctx, ke, r.installed),
 	}

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -88,6 +88,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
 	}
 
 	if manifest == nil {
+		logger.Warnf("No manifest found; no cluster-scoped resources will be finalized")
 		return nil
 	}
 
@@ -123,10 +124,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
 		r.appendExtensionManifests,
 		r.transform,
 		manifests.Install,
+		manifests.SetManifestPaths, // setting path right after applying manifests to populate paths
 		common.CheckDeployments,
-		common.InstallWebhookConfigs,
 		common.InstallWebhookDependentResources,
-		manifests.SetManifestPaths,
 		common.MarkStatusSuccess,
 		common.DeleteObsoleteResources(ctx, ks, r.installed),
 	}


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Propagate manifests paths earlier to operator status

```release-note
Propagate manifests paths earlier to operator status
```

A background, that could be capture in the issue, but pls bear with me. 

A common error pattern from status or operator logs:
```
    - lastTransitionTime: "2025-05-12T08:03:24Z"
      message: 'Install failed with message: Internal error occurred: failed calling
        webhook "config.webhook.serving.knative.dev": failed to call webhook: Post
        "https://webhook.knative-serving.svc:443/config-validation?timeout=10s": service
        "webhook" not found'
      reason: Error
      status: "False"
      type: InstallSucceeded 
```

In some cases of failed operator installation on OpenShift we have seen stuck install or reinstall attempts. The issue was in leftover webhook configurations. Our mutating and validating webhook are by design choice owned by `SYSTEM_NAMESPACE` of the particular operator resource, e.g. `knative-serving` or `knative-eventing`. A failed installation might caused by insufficient resources, PDB not being satisfied for all pods etc. 
In those cases in the current impl we won't propagate `status.manifets[]` paths until all deployments are ready. Meanwhile, whenever user tries to delete original CR and re-create new one, there's no cluster-scoped resource deleted by manifests. Manifest are not yet updated in the status, FinalizeKind ends [here](https://github.com/knative/operator/blob/main/pkg/reconciler/knativeserving/knativeserving.go#L90-L92). This leaves cluster-scoped webhook in place, likely already configured without backend deployed. Other resource owned by CR are deleted by garbage collector, but webhook are not if namespace is not deleted by user. 

Subsequent attempts to create in the same namespace, e.g. KnativeServing CR in `knative-serving` that contains ingress class fails on validation webhook /config-map not reachable error. 

I've moved `InstallWebhookConfigs` into `Install` to be applied just after roles are created. That should guarantee any pre-existing webhook configs are rendered inactive. We only apply non-operational [placeholder](https://github.com/knative/operator/blob/main/cmd/operator/kodata/knative-serving/1.18.1/2-serving-core.yaml#L9319-L9345), that's [reconciled](https://github.com/knative/pkg/blob/main/webhook/configmaps/configmaps.go#L118) once webhook is started and connected to validation backend.   

In addition, I've moved `SetManifestPaths` right after `Install` to populate `status.manifests` as soon as resources are appplied to cluster. That should cause cleanup of cluster-resource even for not yet ready installations.

I'll will look into adding e2e tests for leftover webhook case, but meanwhile I'd like to see if tests passes with the changes.

/cc @houshengbo @skonto @maschmid @dprotaso 
