### PR TITLE
Revert "Propagate manifests paths earlier to operator status (#2106)"

### DIFF
--- a/pkg/reconciler/common/install_test.go
+++ b/pkg/reconciler/common/install_test.go
@@ -56,9 +56,9 @@ func TestInstall(t *testing.T) {
 		*clusterRole.DeepCopy(),
 		*roleBinding.DeepCopy(),
 		*clusterRoleBinding.DeepCopy(),
+		*deployment.DeepCopy(),
 		*mutatingWebhookConfiguration.DeepCopy(),
 		*validatingWebhookConfiguration.DeepCopy(),
-		*deployment.DeepCopy(),
 	}
 
 	client := &fakeClient{}
@@ -79,6 +79,10 @@ func TestInstall(t *testing.T) {
 	}
 	if err := Install(context.TODO(), &manifest, instance); err != nil {
 		t.Fatalf("Install() = %v, want no error", err)
+	}
+
+	if err := InstallWebhookConfigs(context.TODO(), &manifest, instance); err != nil {
+		t.Fatalf("InstallWebhookConfigs() = %v, want no error", err)
 	}
 
 	if err := MarkStatusSuccess(context.TODO(), &manifest, instance); err != nil {

--- a/pkg/reconciler/knativeeventing/knativeeventing.go
+++ b/pkg/reconciler/knativeeventing/knativeeventing.go
@@ -141,8 +141,9 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ke *v1beta1.KnativeEvent
 		r.transform,
 		r.handleTLSResources,
 		manifests.Install,
-		manifests.SetManifestPaths, // setting path right after applying manifests to populate paths
 		common.CheckDeployments,
+		common.InstallWebhookConfigs,
+		manifests.SetManifestPaths,
 		common.MarkStatusSuccess,
 		common.DeleteObsoleteResources(ctx, ke, r.installed),
 	}

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -88,7 +88,6 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, original *v1beta1.Knative
 	}
 
 	if manifest == nil {
-		logger.Warnf("No manifest found; no cluster-scoped resources will be finalized")
 		return nil
 	}
 
@@ -124,9 +123,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
 		r.appendExtensionManifests,
 		r.transform,
 		manifests.Install,
-		manifests.SetManifestPaths, // setting path right after applying manifests to populate paths
 		common.CheckDeployments,
+		common.InstallWebhookConfigs,
 		common.InstallWebhookDependentResources,
+		manifests.SetManifestPaths,
 		common.MarkStatusSuccess,
 		common.DeleteObsoleteResources(ctx, ks, r.installed),
 	}


### PR DESCRIPTION
This reverts commit 2ac3a1eaad81a89738cd7c4d13b6374c0d198b3f.

Per my last comment on #2106. Let's make sure we can revert if needed. Otherwise I'll close based on outcomes of discussion. 


/hold