### PR TITLE
Fix webhook admission control deadlock during installation

### DIFF
--- a/pkg/reconciler/common/install.go
+++ b/pkg/reconciler/common/install.go
@@ -90,6 +90,7 @@ func InstallWebhookConfigs(ctx context.Context, manifest *mf.Manifest, instance 
 
 // InstallWebhookDependentResources applies the Webhook dependent resources updates the given status accordingly.
 func InstallWebhookDependentResources(ctx context.Context, manifest *mf.Manifest, instance base.KComponent) error {
+	logging.FromContext(ctx).Debug("Installing webhook dependent resources")
 	status := instance.GetStatus()
 	if err := manifest.Filter(webhookDependentResources).Apply(); err != nil {
 		status.MarkInstallFailed(err.Error())

--- a/pkg/reconciler/knativeserving/knativeserving.go
+++ b/pkg/reconciler/knativeserving/knativeserving.go
@@ -124,9 +124,10 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, ks *v1beta1.KnativeServi
 		r.appendExtensionManifests,
 		r.transform,
 		manifests.Install,
-		manifests.SetManifestPaths, // setting path right after applying manifests to populate paths
-		common.CheckDeployments,
+		manifests.SetManifestPaths,    // setting path right after applying manifests to populate paths
+		common.CheckWebhookDeployment, // Wait for webhook to be ready before creating Certificate resources
 		common.InstallWebhookDependentResources,
+		common.CheckDeployments,
 		common.MarkStatusSuccess,
 		common.DeleteObsoleteResources(ctx, ks, r.installed),
 	}


### PR DESCRIPTION
Hi,

this PR fixes a chicken-and-egg bootstrap issue where the operator would get stuck during KnativeServing installation.

Problem:
- ValidatingWebhookConfiguration with failurePolicy=Fail intercepts KCertificate resource creation
- If KCertificate resources are created before the webhook pod is ready, the API server rejects them
- The activator deployment depends on the routing-serving-certs secret (generated from a KCertificate resource which creates a cert-manager Certificate) at runtime
- Previous stage ordering would check all deployments (including activator) before creating KCertificate (and thus cert-manager Certificate) resources, causing a deadlock

Solution:
1. Added CheckWebhookDeployment() that waits specifically for the webhook deployment to be ready before proceeding
2. Reordered reconciliation stages:
   - manifests.Install (creates all deployments and more) - unchanged
   - CheckWebhookDeployment (waits for webhook to be ready) - **new**
   - InstallWebhookDependentResources (creates Certificate resources) - unchanged
   - CheckDeployments (checks all deployments including activator) - unchanged

This ensures:
- Webhook is ready before Certificate creation (avoids admission rejection)
- Certificate resources exist before checking activator
  - `activator` might restart very few times before CM-Certificate was created by `webhook` and Secret with certificate data was created by `cert-manager`

Related functions:
- pkg/reconciler/common/deployments.go: Added CheckWebhookDeployment()
- pkg/reconciler/knativeserving/knativeserving.go: Reordered stages
- pkg/reconciler/common/install.go: Added logging for consistency


Tested locally in my kind cluster with a KnativeServing with and without `system-internal-tls` enabled.

Fixes #2178 


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix deadlock during creation of KnativeServing with system-internal-tls enabled
```

/kind bug