### PR TITLE
[release-1.18] Updated the hack lib to the lastest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/code-generator v0.32.2
 	knative.dev/caching v0.0.0-20250415164313-8f20a1163dbf
 	knative.dev/eventing v0.45.4
-	knative.dev/hack v0.0.0-20250331013814-c577ed9f7775
+	knative.dev/hack v0.0.0-20251022160748-50b120a65f30
 	knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883
 	knative.dev/reconciler-test v0.0.0-20250415170512-23f86169156f
 	knative.dev/serving v0.45.1

--- a/go.sum
+++ b/go.sum
@@ -1718,8 +1718,8 @@ knative.dev/caching v0.0.0-20250415164313-8f20a1163dbf h1:qQnKB6mx+beHzsoKU8aKrR
 knative.dev/caching v0.0.0-20250415164313-8f20a1163dbf/go.mod h1:q8ma7YxJ8Dofr+5kf3qR72A/7Zxl9uqQlOdMwNgCXY4=
 knative.dev/eventing v0.45.4 h1:M0HjsFipG6AD+ZMYRXqbSsQfBK4BXlFGEQcsCDlR9mk=
 knative.dev/eventing v0.45.4/go.mod h1:Fz5VjV/vWVN93UfTX3lzc+uFrvJ9wxiiKrRIPhQxoj8=
-knative.dev/hack v0.0.0-20250331013814-c577ed9f7775 h1:UstB8/aowofYFHjLyZdPh1K7qB9BCx+lP1WuiCspYRE=
-knative.dev/hack v0.0.0-20250331013814-c577ed9f7775/go.mod h1:R0ritgYtjLDO9527h5vb5X6gfvt5LCrJ55BNbVDsWiY=
+knative.dev/hack v0.0.0-20251022160748-50b120a65f30 h1:4fzUJrTmIbqgttXMBuLFC7/m2p0146EM3h9Wn2pBm9U=
+knative.dev/hack v0.0.0-20251022160748-50b120a65f30/go.mod h1:R0ritgYtjLDO9527h5vb5X6gfvt5LCrJ55BNbVDsWiY=
 knative.dev/networking v0.0.0-20250415164913-6268d931d247 h1:BQcW8ur+WAmj6GCpYHyUyWoaJWVTs/75W1EObUV/bdA=
 knative.dev/networking v0.0.0-20250415164913-6268d931d247/go.mod h1:Y6OMRz/12RC8fzVa3gAB6K8BR415xbF4z35IAbdMHFc=
 knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883 h1:UeOY7009M0EHwdyW3P35Fc1U6FJHzBrj6Gf370do8zY=

--- a/vendor/knative.dev/hack/infra-library.sh
+++ b/vendor/knative.dev/hack/infra-library.sh
@@ -21,7 +21,7 @@ source "$(dirname "${BASH_SOURCE[0]:-$0}")/library.sh"
 
 # Default Kubernetes version to use for GKE, if not overridden with
 # the `--cluster-version` parameter.
-readonly GKE_DEFAULT_CLUSTER_VERSION="1.31"
+readonly GKE_DEFAULT_CLUSTER_VERSION="1.32"
 
 # Dumps the k8s api server metrics. Spins up a proxy, waits a little bit and
 # dumps the metrics to ${ARTIFACTS}/k8s.metrics.txt

--- a/vendor/knative.dev/hack/library.sh
+++ b/vendor/knative.dev/hack/library.sh
@@ -588,7 +588,7 @@ function report_go_test() {
   logfile="${logfile/.xml/.jsonl}"
   echo "Running go test with args: ${go_test_args[*]}"
   local gotest_retcode=0
-  go_run gotest.tools/gotestsum@v1.11.0 \
+  go_run gotest.tools/gotestsum@v1.13.0 \
     --format "${GO_TEST_VERBOSITY:-testname}" \
     --junitfile "${xml}" \
     --junitfile-testsuite-name relative \
@@ -681,7 +681,7 @@ function start_knative_eventing_extension() {
 # Parameters: $1 - tool package for go run.
 #             $2..$n - parameters passed to the tool.
 function go_run() {
-  local package
+  local package gotoolchain
   package="$1"
   if [[ "$package" != *@* ]]; then
     abort 'Package for "go_run" needs to have @version'
@@ -696,6 +696,11 @@ function go_run() {
     GORUN_PATH="$(mktemp -t -d -u gopath.XXXXXXXX)"
   fi
   export GORUN_PATH
+  gotoolchain="$(go env GOTOOLCHAIN)"
+  if [[ "$package" == knative.dev/toolbox/* ]]; then
+    gotoolchain=auto
+  fi
+  GOTOOLCHAIN="${gotoolchain}" \
   GOPATH="${GORUN_PATH}" \
   GOFLAGS='' \
     go run "$package" "$@"

--- a/vendor/knative.dev/hack/presubmit-tests.sh
+++ b/vendor/knative.dev/hack/presubmit-tests.sh
@@ -141,7 +141,7 @@ function __build_test_runner_for_module() {
   # Don't merge these two lines, or return code will always be 0.
   # Get all build tags in go code (ignore /vendor, /hack and /third_party)
   local tags
-  tags="$(go run knative.dev/toolbox/go-ls-tags@latest --joiner=,)"
+  tags="$(go_run knative.dev/toolbox/go-ls-tags@latest --joiner=,)"
   local go_pkg_dirs
   go_pkg_dirs="$(go list -tags "${tags}" ./...)" || return $?
   if [[ -z "${go_pkg_dirs}" ]]; then

--- a/vendor/knative.dev/hack/release.sh
+++ b/vendor/knative.dev/hack/release.sh
@@ -219,11 +219,15 @@ function prepare_dot_release() {
   # Use the original tag (ie. potentially with a knative- prefix) when determining the last version commit sha
   local github_tag="$(gh_tool release list --json tagName --jq '.[].tagName' | grep "${last_version}")"
   local last_release_commit="$(git rev-list -n 1 "${github_tag}")"
-  local last_release_commit_filtered="$(git rev-list --invert-grep --grep "\[skip-dot-release\]" -n 1 "${github_tag}")"
+  local last_release_commit_filtered="$(git rev-list --invert-grep --grep '^(?!\s*>).*?\[skip-dot-release\]' -n 1 "${github_tag}")"
   local release_branch_commit="$(git rev-list -n 1 upstream/"${RELEASE_BRANCH}")"
-  local release_branch_commit_filtered="$(git rev-list --invert-grep --grep "\[skip-dot-release\]" -n 1 upstream/"${RELEASE_BRANCH}")"
+  local release_branch_commit_filtered="$(git rev-list --invert-grep --grep '^(?!\s*>).*?\[skip-dot-release\]' -n 1 upstream/"${RELEASE_BRANCH}")"
+
   [[ -n "${last_release_commit}" ]] || abort "cannot get last release commit"
   [[ -n "${release_branch_commit}" ]] || abort "cannot get release branch last commit"
+  [[ -n "${last_release_commit_filtered}" ]] || abort "cannot get filtered last release commit"
+  [[ -n "${release_branch_commit_filtered}" ]] || abort "cannot get filtered release branch last commit"
+
   echo "Version ${last_version} is at commit ${last_release_commit}. Comparing using ${last_release_commit_filtered}. If it is different is because commits with the [skip-dot-release] flag in their commit body are not being considered."
   echo "Branch ${RELEASE_BRANCH} is at commit ${release_branch_commit}. Comparing using ${release_branch_commit_filtered}. If it is different is because commits with the [skip-dot-release] flag in their commit body are not being considered."
   if [[ "${last_release_commit_filtered}" == "${release_branch_commit_filtered}" ]]; then

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1522,7 +1522,7 @@ knative.dev/eventing/test/upgrade/prober/wathola/fetcher
 knative.dev/eventing/test/upgrade/prober/wathola/forwarder
 knative.dev/eventing/test/upgrade/prober/wathola/receiver
 knative.dev/eventing/test/upgrade/prober/wathola/sender
-# knative.dev/hack v0.0.0-20250331013814-c577ed9f7775
+# knative.dev/hack v0.0.0-20251022160748-50b120a65f30
 ## explicit; go 1.21
 knative.dev/hack
 # knative.dev/networking v0.0.0-20250415164913-6268d931d247


### PR DESCRIPTION
The auto release job for 1.18 has run into the issue
```
Command '__unit_test_runner_for_module' failed in module /home/prow/go/src/knative.dev/serving: 1
Step failed: default_unit_test_runner
```

This PR pulled the latest hack script to fix it.