### PR TITLE
Fix Helm upgrade conflict on aggregated ClusterRoles

### DIFF
--- a/config/charts/knative-operator/templates/operator.yaml
+++ b/config/charts/knative-operator/templates/operator.yaml
@@ -230,7 +230,6 @@ aggregationRule:
 # automatically.
   - matchExpressions:
       - {key: serving.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -246,7 +245,6 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-serving"]}
-rules: [] # Rules are automatically filled in by the controller manager.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -262,7 +260,6 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: eventing.knative.dev/release, operator: Exists}
-rules: [] # Rules are automatically filled in by the controller manager.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -278,7 +275,6 @@ aggregationRule:
     # automatically.
     - matchExpressions:
         - {key: app.kubernetes.io/name, operator: In, values: ["knative-eventing"]}
-rules: [] # Rules are automatically filled in by the controller manager.
 
 ---
 # Copyright 2020 The Knative Authors


### PR DESCRIPTION
Fixes #2283

## Proposed Changes

* Stop rendering `rules: []` for the Helm chart's aggregated `ClusterRole` resources.
* Leave the aggregated `ClusterRole` resources themselves managed by Helm so upgrades do not delete them.

**Release Note**

```release-note
Fixed Helm upgrades failing with server-side apply conflicts on aggregated ClusterRoles.
```
