### PR TITLE
Install Gateway API CRDs for multicluster tests

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -346,6 +346,20 @@ function create_spoke_cluster() {
   KUBECONFIG="${SPOKE_HOST_KUBECONFIG}" kubectl -n kube-system rollout status deployment/coredns --timeout=120s || return 1
 }
 
+function install_spoke_gateway_api_crds() {
+  echo ">> Installing Gateway API CRDs on spoke"
+  KUBECONFIG="${SPOKE_HOST_KUBECONFIG}" kubectl apply --server-side -f "${SPOKE_GATEWAY_API_CRD_URL}" || return 1
+
+  local crd
+  for crd in \
+    gatewayclasses.gateway.networking.k8s.io \
+    gateways.gateway.networking.k8s.io \
+    httproutes.gateway.networking.k8s.io \
+    referencegrants.gateway.networking.k8s.io; do
+    KUBECONFIG="${SPOKE_HOST_KUBECONFIG}" kubectl wait --for=condition=Established --timeout=60s "crd/${crd}" || return 1
+  done
+}
+
 function delete_spoke_cluster() {
   if kind get clusters 2>/dev/null | grep -q "^${SPOKE_CLUSTER_NAME}$"; then
     kind delete cluster --name "${SPOKE_CLUSTER_NAME}" --kubeconfig "${SPOKE_HOST_KUBECONFIG}"
@@ -537,6 +551,7 @@ function setup_multicluster_e2e() {
   done
 
   create_spoke_cluster || return 1
+  install_spoke_gateway_api_crds || return 1
   install_cluster_inventory_crd || return 1
   install_access_provider_config || return 1
   apply_cluster_profile "default" || return 1

--- a/test/e2e-tests-multicluster.sh
+++ b/test/e2e-tests-multicluster.sh
@@ -38,10 +38,12 @@ source "$(dirname "$0")/e2e-common.sh"
 : "${MC_PROVIDER_TOKEN_MOUNT_PATH:=/etc/cluster-inventory/access}"
 : "${MC_PROVIDER_PLUGIN_MOUNT_PATH:=/etc/cluster-inventory/plugin}"
 : "${MC_PROVIDER_NAME:=e2e-static-token}"
+: "${SPOKE_GATEWAY_API_CRD_URL:=https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/experimental-install.yaml}"
 export SPOKE_CLUSTER_NAME SPOKE_KUBECONFIG SPOKE_HOST_KUBECONFIG
 export CLUSTER_INVENTORY_CRD_URL MC_PROVIDER_CONFIGMAP MC_PROVIDER_TOKEN_SECRET
 export MC_PROVIDER_MOUNT_PATH MC_PROVIDER_TOKEN_MOUNT_PATH
 export MC_PROVIDER_PLUGIN_MOUNT_PATH MC_PROVIDER_NAME
+export SPOKE_GATEWAY_API_CRD_URL
 
 function knative_setup() {
   create_namespace


### PR DESCRIPTION
## What
- Install Gateway API v1.4.1 experimental CRDs on the spoke kind cluster during multicluster e2e setup.
- Wait for the GatewayClass, Gateway, HTTPRoute, and ReferenceGrant CRDs to become Established before wiring the ClusterProfile.

## Why
The multicluster Serving test enables net-gateway-api on the spoke cluster, but the spoke cluster did not install Gateway API CRDs first. With the 1.22 net-gateway-api controller manifest, the controller exposes readiness/liveness probes and stays unavailable when the required Gateway API resources are missing.
