### PR TITLE
Restore operator CRD conversion webhooks

### DIFF
--- a/config/charts/knative-operator/templates/crds/knativeeventings.yaml
+++ b/config/charts/knative-operator/templates/crds/knativeeventings.yaml
@@ -31,6 +31,15 @@ spec:
     plural: knativeeventings
     singular: knativeeventing
   scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: '{{ .Release.Namespace }}'
+          path: /resource-conversion
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.clusterProfileRef.name
@@ -3596,13 +3605,3 @@ spec:
     storage: true
     subresources:
       status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-      - v1beta1
-      clientConfig:
-        service:
-          name: operator-webhook
-          namespace: '{{ .Release.Namespace }}'
-          path: /resource-conversion

--- a/config/charts/knative-operator/templates/crds/knativeservings.yaml
+++ b/config/charts/knative-operator/templates/crds/knativeservings.yaml
@@ -31,6 +31,15 @@ spec:
     plural: knativeservings
     singular: knativeserving
   scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: '{{ .Release.Namespace }}'
+          path: /resource-conversion
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.clusterProfileRef.name
@@ -3867,13 +3876,3 @@ spec:
     storage: true
     subresources:
       status: {}
-  conversion:
-    strategy: Webhook
-    webhook:
-      conversionReviewVersions:
-      - v1beta1
-      clientConfig:
-        service:
-          name: operator-webhook
-          namespace: '{{ .Release.Namespace }}'
-          path: /resource-conversion

--- a/config/crd/bases/operator.knative.dev_knativeeventings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeeventings.yaml
@@ -27,6 +27,15 @@ spec:
     plural: knativeeventings
     singular: knativeeventing
   scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: knative-operator
+          path: /resource-conversion
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.clusterProfileRef.name

--- a/config/crd/bases/operator.knative.dev_knativeservings.yaml
+++ b/config/crd/bases/operator.knative.dev_knativeservings.yaml
@@ -27,6 +27,15 @@ spec:
     plural: knativeservings
     singular: knativeserving
   scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1beta1"]
+      clientConfig:
+        service:
+          name: operator-webhook
+          namespace: knative-operator
+          path: /resource-conversion
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.clusterProfileRef.name

--- a/hack/sync-helm-crds.sh
+++ b/hack/sync-helm-crds.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 # Syncs CRD definitions from config/crd/bases/ to the Helm chart templates.
-# This script transforms controller-gen output into Helm-ready CRD templates
-# by adding Helm template variables for labels and conversion webhook configuration.
+# This script transforms generated CRD bases into Helm-ready CRD templates by
+# adding Helm template variables for labels and the conversion webhook namespace.
 #
 # Usage: hack/sync-helm-crds.sh
 
@@ -45,23 +45,16 @@ for crd_file in "${CRD_BASES_DIR}"/*.yaml; do
 
   echo "  Processing ${filename} -> crds/${short_name}"
 
+  if [[ "$(yq eval '.spec.conversion.webhook.clientConfig.service.namespace // ""' "${crd_file}")" != "knative-operator" ]]; then
+    echo "ERROR: ${filename} is missing the operator conversion webhook. Run ./hack/update-crd-conversion.sh first." >&2
+    exit 1
+  fi
+
   # -c keeps compact sequence indentation so "- name:" stays flush with its parent key.
   if ! yq eval -c '
     .metadata.labels."app.kubernetes.io/version" = "{{ .Chart.Version }}" |
     .metadata.labels."app.kubernetes.io/name" = "knative-operator" |
-    .spec.conversion = {
-      "strategy": "Webhook",
-      "webhook": {
-        "conversionReviewVersions": ["v1beta1"],
-        "clientConfig": {
-          "service": {
-            "name": "operator-webhook",
-            "namespace": "{{ .Release.Namespace }}",
-            "path": "/resource-conversion"
-          }
-        }
-      }
-    }
+    .spec.conversion.webhook.clientConfig.service.namespace = "{{ .Release.Namespace }}"
   ' "${crd_file}" > "${target}"; then
     echo "ERROR: yq failed to process ${filename}"
     rm -f "${target}"

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -58,12 +58,20 @@ group "CRD Gen"
 # Install tools at the versions pinned in hack/tools.go (go.mod).
 GOFLAGS=-mod=mod go install sigs.k8s.io/controller-tools/cmd/controller-gen
 GOFLAGS=-mod=mod go install github.com/mikefarah/yq/v4
-export PATH="$(go env GOPATH)/bin:$PATH"
+go_bin="$(go env GOBIN)"
+if [[ -z "${go_bin}" ]]; then
+  go_bin="$(go env GOPATH)/bin"
+fi
+export PATH="${go_bin}:$PATH"
 
 GOFLAGS=-mod=mod controller-gen \
   crd:allowDangerousTypes=true,ignoreUnexportedFields=true,headerFile="${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.yaml.txt" \
   paths="${REPO_ROOT_DIR}/pkg/apis/..." \
   output:crd:dir="${REPO_ROOT_DIR}/config/crd/bases"
+
+group "Update CRD conversion webhooks"
+
+"${REPO_ROOT_DIR}/hack/update-crd-conversion.sh"
 
 group "Sync CRDs to Helm chart"
 

--- a/hack/update-crd-conversion.sh
+++ b/hack/update-crd-conversion.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Adds the conversion webhook stanza that controller-gen does not emit for the
+# operator's single-version CRDs. The release operator.yaml consumes these bases
+# directly, so this must run before any chart or release manifest generation.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CRD_BASES_DIR="${REPO_ROOT_DIR}/config/crd/bases"
+
+echo "Updating CRD conversion webhooks in ${CRD_BASES_DIR}"
+
+for crd_file in \
+  "${CRD_BASES_DIR}/operator.knative.dev_knativeeventings.yaml" \
+  "${CRD_BASES_DIR}/operator.knative.dev_knativeservings.yaml"; do
+  if [[ ! -f "${crd_file}" ]]; then
+    echo "ERROR: CRD file not found: ${crd_file}" >&2
+    exit 1
+  fi
+
+  echo "  Updating $(basename "${crd_file}")"
+  tmp="$(mktemp "${crd_file}.XXXXXX")"
+  if ! awk '
+    function emit_conversion() {
+      print "  conversion:"
+      print "    strategy: Webhook"
+      print "    webhook:"
+      print "      conversionReviewVersions: [\"v1beta1\"]"
+      print "      clientConfig:"
+      print "        service:"
+      print "          name: operator-webhook"
+      print "          namespace: knative-operator"
+      print "          path: /resource-conversion"
+    }
+
+    $0 == "  conversion:" {
+      emit_conversion()
+      inserted = 1
+      skipping = 1
+      next
+    }
+
+    skipping && $0 == "  versions:" {
+      skipping = 0
+      print
+      next
+    }
+
+    skipping {
+      next
+    }
+
+    $0 == "  versions:" && !inserted {
+      emit_conversion()
+      inserted = 1
+      print
+      next
+    }
+
+    {
+      print
+    }
+
+    END {
+      if (!inserted) {
+        print "ERROR: could not find CRD spec.versions anchor" > "/dev/stderr"
+        exit 1
+      }
+    }
+  ' "${crd_file}" > "${tmp}"; then
+    rm -f "${tmp}"
+    exit 1
+  fi
+  mv "${tmp}" "${crd_file}"
+done
+
+echo "Done. CRD conversion webhooks updated."

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -31,8 +31,9 @@ trap "cleanup" EXIT SIGINT
 cleanup
 
 # Save working tree state
-mkdir -p "${TMP_DIFFROOT}/pkg" "${TMP_DIFFROOT}/config"
+mkdir -p "${TMP_DIFFROOT}/pkg" "${TMP_DIFFROOT}/config/crd"
 cp -aR "${REPO_ROOT_DIR}/go.sum" "${REPO_ROOT_DIR}/pkg" "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}"
+cp -aR "${REPO_ROOT_DIR}/config/crd/bases" "${TMP_DIFFROOT}/config/crd/"
 cp -aR "${REPO_ROOT_DIR}/config/charts" "${TMP_DIFFROOT}/config/"
 
 # TODO(mattmoor): We should be able to rm -rf pkg/client/ and vendor/
@@ -42,9 +43,12 @@ echo "Diffing ${REPO_ROOT_DIR} against freshly generated codegen"
 ret=0
 diff -Nupr --no-dereference "${REPO_ROOT_DIR}/pkg" "${TMP_DIFFROOT}/pkg" || ret=1
 diff -Nupr --no-dereference "${REPO_ROOT_DIR}/vendor" "${TMP_DIFFROOT}/vendor" || ret=1
+diff -Nupr --no-dereference "${REPO_ROOT_DIR}/config/crd/bases" "${TMP_DIFFROOT}/config/crd/bases" || ret=1
 diff -Nupr --no-dereference "${REPO_ROOT_DIR}/config/charts" "${TMP_DIFFROOT}/config/charts" || ret=1
 
 # Restore working tree state
+rm -fr "${REPO_ROOT_DIR}/config/crd/bases"
+cp -aR "${TMP_DIFFROOT}/config/crd/bases" "${REPO_ROOT_DIR}/config/crd/"
 rm -fr "${REPO_ROOT_DIR}/config/charts"
 cp -aR "${TMP_DIFFROOT}/config/charts" "${REPO_ROOT_DIR}/config/"
 rm -fr "${TMP_DIFFROOT}/config"


### PR DESCRIPTION
<!--
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Restore the conversion webhook stanza in the generated KnativeServing and KnativeEventing CRD bases after `controller-gen` runs.
* Make Helm CRD sync derive conversion settings from the CRD bases and only template the webhook service namespace.
* Extend codegen verification to include `config/crd/bases`, so future generated CRD drift is caught.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Restore conversion webhook configuration in Knative Operator CRDs generated for release manifests.
```
