### PR TITLE
Add image transformer for Knative Serving Queue Proxy sidecar

### DIFF
--- a/pkg/reconciler/common/images.go
+++ b/pkg/reconciler/common/images.go
@@ -43,12 +43,22 @@ var (
 	delimiter             = "/"
 )
 
+const (
+	configMapDeployment  = "config-deployment"
+	queueSidecarImageKey = "queue-sidecar-image"
+	queueProxyOverride   = "queue-proxy"
+)
+
 // ImageTransform updates image with a new registry and tag
 func ImageTransform(registry *base.Registry, log *zap.SugaredLogger) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		// Image resources are handled quite differently, so branch them out early
 		if u.GetKind() == "Image" && u.GetAPIVersion() == "caching.internal.knative.dev/v1alpha1" {
 			return updateCachingImage(registry, u, log)
+		}
+
+		if u.GetKind() == "ConfigMap" && u.GetName() == configMapDeployment {
+			return updateQueueProxyImage(registry, u, log)
 		}
 
 		// Handle all resources that contain a PodSpec.
@@ -180,6 +190,15 @@ func updateCachingImage(registry *base.Registry, u *unstructured.Unstructured, l
 
 	log.Debugw("Finished conversion", "name", u.GetName(), "unstructured", u.Object)
 	return nil
+}
+
+func updateQueueProxyImage(registry *base.Registry, u *unstructured.Unstructured, log *zap.SugaredLogger) error {
+	image, ok := registry.Override[queueProxyOverride]
+	if !ok {
+		return nil
+	}
+	log.Debugw("Updating queue-sidecar-image", "image", image)
+	return unstructured.SetNestedField(u.Object, image, "data", queueSidecarImageKey)
 }
 
 func getImageName(fullImageURL string) string {

--- a/pkg/reconciler/common/images_test.go
+++ b/pkg/reconciler/common/images_test.go
@@ -21,6 +21,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes/scheme"
 	caching "knative.dev/caching/pkg/apis/caching/v1alpha1"
 	"knative.dev/operator/pkg/apis/operator/base"
@@ -358,6 +359,53 @@ func TestImageTransform(t *testing.T) {
 			err := scheme.Scheme.Convert(&unstructuredImage, image, nil)
 			util.AssertEqual(t, err, nil)
 			util.AssertDeepEqual(t, image.Spec, tt.expected)
+		})
+	}
+}
+
+func TestQueueProxyImageTransform(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		registry base.Registry
+		expected string
+	}{{
+		name: "OverridesQueueSidecarImage",
+		registry: base.Registry{
+			Override: map[string]string{
+				"queue-proxy": "registry.my-org.com/knative-serving-queue:1.22.0",
+			},
+		},
+		expected: "registry.my-org.com/knative-serving-queue:1.22.0",
+	}, {
+		name:     "NoOverrideKeepsOriginal",
+		registry: base.Registry{},
+		expected: "gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:abcdef",
+	}, {
+		name: "OtherOverridesDoNotAffectQueueSidecar",
+		registry: base.Registry{
+			Override: map[string]string{
+				"activator": "registry.my-org.com/activator:1.22.0",
+			},
+		},
+		expected: "gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:abcdef",
+	}} {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &unstructured.Unstructured{}
+			cm.SetUnstructuredContent(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "config-deployment",
+				},
+				"data": map[string]interface{}{
+					"queue-sidecar-image": "gcr.io/knative-releases/knative.dev/serving/cmd/queue@sha256:abcdef",
+				},
+			})
+			transform := ImageTransform(&tt.registry, log)
+			err := transform(cm)
+			util.AssertEqual(t, err, nil)
+			val, _, _ := unstructured.NestedString(cm.Object, "data", "queue-sidecar-image")
+			util.AssertEqual(t, val, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #2313

## Proposed Changes

* Adds image transformer for Knative Serving Queue Proxy sidecar

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix `KnativeServing` registry override not overriding image for Knative Serving Queue Proxy sidecar
```
