### PR TITLE
Fix Kourier bootstrap namespace

### DIFF
--- a/pkg/reconciler/knativeserving/ingress/ingress_test.go
+++ b/pkg/reconciler/knativeserving/ingress/ingress_test.go
@@ -58,7 +58,7 @@ func TestTransformers(t *testing.T) {
 				},
 			},
 		},
-		expected: 3,
+		expected: 4,
 	}, {
 		name: "Available contour ingress",
 		instance: servingv1beta1.KnativeServing{
@@ -109,7 +109,7 @@ func TestTransformers(t *testing.T) {
 				},
 			},
 		},
-		expected: 4,
+		expected: 5,
 	}}
 
 	for _, tt := range tests {

--- a/pkg/reconciler/knativeserving/ingress/kourier.go
+++ b/pkg/reconciler/knativeserving/ingress/kourier.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	mf "github.com/manifestival/manifestival"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,6 +35,8 @@ const (
 	kourierGatewayServiceName     = "kourier"
 	kourierDefaultVolumeName      = "kourier-bootstrap"
 	kourierGatewayDeploymentNames = "3scale-kourier-gateway"
+	kourierDefaultNamespace       = "knative-serving"
+	kourierBootstrapDataKey       = "envoy-bootstrap.yaml"
 )
 
 var kourierControllerDeploymentNames = sets.NewString("3scale-kourier-control", "net-kourier-controller")
@@ -41,6 +44,7 @@ var kourierControllerDeploymentNames = sets.NewString("3scale-kourier-control", 
 func kourierTransformers(_ context.Context, instance *v1beta1.KnativeServing) []mf.Transformer {
 	return []mf.Transformer{
 		replaceGatewayNamespace(),
+		replaceBootstrapNamespace(),
 		configureGatewayService(instance),
 		configureBootstrapConfigMap(instance),
 	}
@@ -71,6 +75,28 @@ func replaceGatewayNamespace() mf.Transformer {
 			}
 		}
 		return nil
+	}
+}
+
+// replaceBootstrapNamespace updates namespace references embedded in Kourier's
+// default bootstrap configuration.
+func replaceBootstrapNamespace() mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if u.GetKind() != "ConfigMap" || u.GetName() != kourierDefaultVolumeName {
+			return nil
+		}
+
+		configMap := &v1.ConfigMap{}
+		if err := scheme.Scheme.Convert(u, configMap, nil); err != nil {
+			return err
+		}
+
+		if bootstrap, found := configMap.Data[kourierBootstrapDataKey]; found {
+			configMap.Data[kourierBootstrapDataKey] = strings.ReplaceAll(
+				bootstrap, kourierDefaultNamespace, configMap.GetNamespace())
+		}
+
+		return scheme.Scheme.Convert(configMap, u, nil)
 	}
 }
 
@@ -121,7 +147,7 @@ func configureGatewayService(instance *v1beta1.KnativeServing) mf.Transformer {
 	}
 }
 
-// configureBootstrapConfigMap sets Kourier GW's bootstrap configmap name.
+// configureBootstrapConfigMap sets Kourier GW's bootstrap ConfigMap name.
 func configureBootstrapConfigMap(instance *v1beta1.KnativeServing) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		if u.GetKind() == "Deployment" && u.GetName() == kourierGatewayDeploymentNames {

--- a/pkg/reconciler/knativeserving/ingress/kourier_test.go
+++ b/pkg/reconciler/knativeserving/ingress/kourier_test.go
@@ -18,6 +18,7 @@ package ingress
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	mf "github.com/manifestival/manifestival"
@@ -180,6 +181,61 @@ func TestTransformKourierManifest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReplaceBootstrapNamespace(t *testing.T) {
+	const customNamespace = "custom-serving"
+
+	client := fake.New()
+	manifest, err := mf.NewManifest("testdata/kodata/ingress/1.9/kourier/kourier.yaml", mf.UseClient(client))
+	if err != nil {
+		t.Fatalf("Failed to read manifest: %v", err)
+	}
+
+	before := bootstrapConfigMap(t, manifest)
+	defaultControllerAddress := "net-kourier-controller." + kourierDefaultNamespace
+	if bootstrap := before.Data[kourierBootstrapDataKey]; !strings.Contains(bootstrap, defaultControllerAddress) {
+		t.Fatalf("Bootstrap config does not contain default controller address %q", defaultControllerAddress)
+	}
+
+	manifest, err = manifest.Transform(
+		mf.InjectNamespace(customNamespace),
+		replaceBootstrapNamespace(),
+	)
+	if err != nil {
+		t.Fatalf("Failed to transform manifest: %v", err)
+	}
+
+	after := bootstrapConfigMap(t, manifest)
+	if after.Namespace != customNamespace {
+		t.Fatalf("Bootstrap ConfigMap namespace = %q, want %q", after.Namespace, customNamespace)
+	}
+	bootstrap := after.Data[kourierBootstrapDataKey]
+	if strings.Contains(bootstrap, kourierDefaultNamespace) {
+		t.Fatalf("Bootstrap config still contains default namespace %q", kourierDefaultNamespace)
+	}
+	if want := "net-kourier-controller." + customNamespace; !strings.Contains(bootstrap, want) {
+		t.Fatalf("Bootstrap config does not contain controller address %q", want)
+	}
+}
+
+func bootstrapConfigMap(t *testing.T, manifest mf.Manifest) *v1.ConfigMap {
+	t.Helper()
+
+	for _, u := range manifest.Resources() {
+		if u.GetKind() != "ConfigMap" || u.GetName() != kourierDefaultVolumeName {
+			continue
+		}
+
+		configMap := &v1.ConfigMap{}
+		if err := scheme.Scheme.Convert(&u, configMap, nil); err != nil {
+			t.Fatalf("Failed to convert bootstrap ConfigMap: %v", err)
+		}
+		return configMap
+	}
+
+	t.Fatal("Bootstrap ConfigMap not found")
+	return nil
 }
 
 func verifyGatewayServiceTypeNodePortHTTP(t *testing.T, u *unstructured.Unstructured, expHTTPPort int32) {


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Use the Kourier bootstrap ConfigMap namespace to replace the default namespace embedded in its Envoy bootstrap configuration.
* Handle the raw ConfigMap data that the common namespace transformer cannot update, following the existing `replaceGatewayNamespace` pattern.
* Add regression coverage for installing Knative Serving outside the `knative-serving` namespace.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix Kourier connectivity when Knative Serving is installed in a non-default namespace.
```
