### PR TITLE
Unpin e2e test versions to resume 1.24 development

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -18,15 +18,15 @@
 source "$(dirname "${BASH_SOURCE[0]}")/../vendor/knative.dev/hack/e2e-tests.sh"
 
 # The previous serving release, installed by the operator. This value should be in the semantic format of major.minor.
-readonly PREVIOUS_SERVING_RELEASE_VERSION="1.22"
+readonly PREVIOUS_SERVING_RELEASE_VERSION="1.23"
 # The previous eventing release, installed by the operator. This value should be in the semantic format of major.minor.
-readonly PREVIOUS_EVENTING_RELEASE_VERSION="1.22"
+readonly PREVIOUS_EVENTING_RELEASE_VERSION="1.23"
 # The target serving/eventing release to upgrade, installed by the operator. It can be a release available under
 # kodata or an incoming new release. This value should be in the semantic format of major.minor.
-readonly TARGET_RELEASE_VERSION="1.23"
+readonly TARGET_RELEASE_VERSION="latest"
 # This is the branch name of knative repos, where we run the upgrade tests.
 # Default to empty for local runs (not in Prow).
-readonly KNATIVE_REPO_BRANCH="release-1.23"
+readonly KNATIVE_REPO_BRANCH="${PULL_BASE_REF}"
 # Namespaces used for tests
 # This environment variable TEST_NAMESPACE defines the namespace to install Knative Serving.
 export TEST_NAMESPACE="${TEST_NAMESPACE:-knative-operator-testing}"


### PR DESCRIPTION
<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

<!--
Request Prow to automatically lint any go code in this PR:

/lint
-->

Fixes #

## Proposed Changes

* Unpin e2e test version to resume 1.24 development

Per established resume development pattern.

/cc @houshengbo @kahirokunn 