### PR TITLE
Add extraObjects support to the knative-operator chart

### DIFF
--- a/config/charts/knative-operator/templates/extra-objects.yaml
+++ b/config/charts/knative-operator/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/config/charts/knative-operator/values.yaml
+++ b/config/charts/knative-operator/values.yaml
@@ -71,3 +71,13 @@ knative_operator:
         cpu: 500m
         memory: 500Mi
   kubernetes_min_version: v1.25.0
+
+# extraObjects renders arbitrary manifests alongside the operator, e.g. extra
+# RBAC or platform-specific resources such as OpenShift SCC bindings or
+# NetworkPolicies.
+extraObjects: []
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: example


### PR DESCRIPTION
## What

Adds an optional `extraObjects` list to the `knative-operator` Helm chart. Each entry renders as a manifest alongside the operator. Empty by default — no behavior change for existing installs.

## Why

Operators frequently need small platform-specific adjuncts that don't belong in the chart proper: OpenShift SCC bindings, extra RBAC, NetworkPolicies, PriorityClasses. The standard Helm `extraObjects` idiom (as in kube-prometheus-stack and bitnami charts) lets users keep those in the same release instead of parallel tooling.

Example:

```yaml
extraObjects:
  - apiVersion: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
    metadata:
      name: knative-serving-nonroot-v2-scc
    roleRef:
      apiGroup: rbac.authorization.k8s.io
      kind: ClusterRole
      name: system:openshift:scc:nonroot-v2
    subjects:
      - kind: ServiceAccount
        name: default
        namespace: knative-serving
```