### PR TITLE
Update Kafka 1.23 generated manifests

### DIFF
--- a/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-controller.yaml
+++ b/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-controller.yaml
@@ -17,7 +17,7 @@ metadata:
   name: kafka-broker-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 data:
   default.topic.partitions: "10"
   default.topic.replication.factor: "3"
@@ -43,7 +43,7 @@ metadata:
   name: kafka-channel-config
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 data:
   bootstrap.servers: "my-cluster-kafka-bootstrap.kafka:9092"
 
@@ -67,7 +67,7 @@ kind: CustomResourceDefinition
 metadata:
   name: kafkachannels.messaging.knative.dev
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
     duck.knative.dev/addressable: "true"
@@ -707,7 +707,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     knative.dev/crd-install: "true"
   name: consumers.internal.kafka.eventing.knative.dev
 spec:
@@ -763,7 +763,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     knative.dev/crd-install: "true"
   name: consumergroups.internal.kafka.eventing.knative.dev
 spec:
@@ -834,7 +834,7 @@ metadata:
   labels:
     duck.knative.dev/addressable: "true"
     knative.dev/crd-install: "true"
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 spec:
   group: eventing.knative.dev
   names:
@@ -1030,7 +1030,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
@@ -1930,7 +1930,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: eventing-kafka-source-observer
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
@@ -1963,7 +1963,7 @@ metadata:
   name: config-kafka-source-defaults
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
   annotations:
     knative.dev/example-checksum: "b6ed351d"
 data:
@@ -2023,7 +2023,7 @@ metadata:
   name: config-kafka-autoscaler
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 data:
   class: "keda.autoscaling.knative.dev"
   min-scale: "0"
@@ -2089,7 +2089,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
   name: config-kafka-leader-election
   namespace: knative-eventing
   annotations:
@@ -2155,7 +2155,7 @@ metadata:
   name: kafka-config-logging
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 data:
   config.xml: |
     <configuration>
@@ -2216,7 +2216,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-kafka-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:
@@ -2259,7 +2259,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-channelable-manipulator
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:
@@ -2296,7 +2296,7 @@ kind: ClusterRole
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 rules:
   - apiGroups:
       - ""
@@ -2586,7 +2586,7 @@ metadata:
   name: kafka-controller
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -2607,7 +2607,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -2622,7 +2622,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-controller-addressable-resolver
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: kafka-controller
@@ -2653,7 +2653,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     app.kubernetes.io/component: kafka-controller
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -2665,7 +2665,7 @@ spec:
       name: kafka-controller
       labels:
         app: kafka-controller
-        app.kubernetes.io/version: "1.23.0"
+        app.kubernetes.io/version: "1.23.1"
         app.kubernetes.io/component: kafka-controller
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -2691,7 +2691,7 @@ spec:
               weight: 100
       containers:
         - name: controller
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:c9d39c9896fb735f7e821ff1b4a2ce5219adaaac74f42d05c5dd89b524c8a26f
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/kafka-controller@sha256:82ee0826a2fe52e02cf277a7c2dc03c11087aa26f25dddfc39f2bdbfd84cb26a
           imagePullPolicy: IfNotPresent
           env:
             - name: BROKER_DATA_PLANE_CONFIG_MAP_NAMESPACE
@@ -2840,7 +2840,7 @@ kind: ClusterRole
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:
@@ -2946,7 +2946,7 @@ metadata:
   name: kafka-webhook-eventing
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -2967,7 +2967,7 @@ kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook-eventing
@@ -2997,7 +2997,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -3029,7 +3029,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: pods.defaulting.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 webhooks:
   # Dispatcher pods webhook config.
   - admissionReviewVersions: ["v1", "v1beta1"]
@@ -3083,7 +3083,7 @@ metadata:
   name: kafka-webhook-eventing-certs
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 # The data is populated at install time.
 
 ---
@@ -3106,7 +3106,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.eventing.knative.dev
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 webhooks:
   - admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
@@ -3140,7 +3140,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -3151,7 +3151,7 @@ spec:
     metadata:
       labels:
         app: kafka-webhook-eventing
-        app.kubernetes.io/version: "1.23.0"
+        app.kubernetes.io/version: "1.23.1"
         app.kubernetes.io/component: kafka-webhook-eventing
         app.kubernetes.io/name: knative-eventing
     spec:
@@ -3171,7 +3171,7 @@ spec:
       containers:
         - name: kafka-webhook-eventing
           terminationMessagePolicy: FallbackToLogsOnError
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:d7c421f9747c3f6d8aa9a66e18ad82562c206740d925daaf3ac416535b9e4328
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/webhook-kafka@sha256:2410fd9a0ac141054753bcd1b5823ec45b9aac060686aff97ea724b9b47610c3
           resources:
             requests:
               cpu: 20m
@@ -3241,7 +3241,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-webhook-eventing
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     app.kubernetes.io/component: kafka-webhook-eventing
     app.kubernetes.io/name: knative-eventing
 spec:

--- a/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-post-install.yaml
+++ b/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-post-install.yaml
@@ -16,7 +16,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 rules: null
 
 ---
@@ -39,7 +39,7 @@ metadata:
   name: knative-kafka-controller-post-install
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 
 ---
 # Copyright 2020 The Knative Authors
@@ -61,7 +61,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 rules:
   # Storage version upgrader needs to be able to patch CRDs.
   - apiGroups:
@@ -144,14 +144,14 @@ metadata:
   name: knative-kafka-storage-version-migrator
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-storage-version-migrator
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-storage-version-migrator
@@ -180,7 +180,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-controller-post-install
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-controller-post-install
@@ -212,7 +212,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-controller-post-install
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -220,7 +220,7 @@ spec:
     metadata:
       labels:
         app: kafka-controller-post-install
-        app.kubernetes.io/version: "1.23.0"
+        app.kubernetes.io/version: "1.23.1"
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -229,7 +229,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: post-install
-          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:fef0b7adace9d36f75b165de0b5fe275b5c4ae84caa7c9f79cb6f719ab416c4b
+          image: gcr.io/knative-releases/knative.dev/eventing-kafka-broker/control-plane/cmd/post-install@sha256:6533567519138284fb8a0ab3695a15a743d2d3f2ab1f19a35226a3b3fc5c8f5c
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:
@@ -269,7 +269,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: "knative-kafka-storage-version-migrator"
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -277,7 +277,7 @@ spec:
     metadata:
       labels:
         app: "knative-kafka-storage-version-migrator"
-        app.kubernetes.io/version: "1.23.0"
+        app.kubernetes.io/version: "1.23.1"
         sidecar.istio.io/inject: "false"
       annotations:
         sidecar.istio.io/inject: "false"
@@ -286,7 +286,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:1c9e08c3a26dc7739f457768328b8e205842e7083275ad693e5282e4a8abd4fb
+          image: gcr.io/knative-releases/knative.dev/pkg/apiextensions/storageversion/cmd/migrate@sha256:6aa831521d266875d477633a272aa5e852ab72d810e6d50dfedeacf3e9a0091b
           env:
             - name: IGNORE_NOT_FOUND
               value: "true"

--- a/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-source.yaml
+++ b/cmd/operator/kodata/eventing-source/1.23/kafka/eventing-kafka-source.yaml
@@ -17,7 +17,7 @@ metadata:
   name: config-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
   annotations:
     knative.dev/example-checksum: "8157ecb1"
 data:
@@ -177,7 +177,7 @@ kind: ClusterRole
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 rules:
   - apiGroups:
       - ""
@@ -214,7 +214,7 @@ metadata:
   name: knative-kafka-source-data-plane
   namespace: knative-eventing
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 
 ---
 # Copyright 2021 The Knative Authors
@@ -235,7 +235,7 @@ kind: ClusterRoleBinding
 metadata:
   name: knative-kafka-source-data-plane
   labels:
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
 subjects:
   - kind: ServiceAccount
     name: knative-kafka-source-data-plane
@@ -266,7 +266,7 @@ metadata:
   namespace: knative-eventing
   labels:
     app: kafka-source-dispatcher
-    app.kubernetes.io/version: "1.23.0"
+    app.kubernetes.io/version: "1.23.1"
     app.kubernetes.io/component: kafka-source-dispatcher
     app.kubernetes.io/name: knative-eventing
 spec:
@@ -280,7 +280,7 @@ spec:
       name: kafka-source-dispatcher
       labels:
         app: kafka-source-dispatcher
-        app.kubernetes.io/version: "1.23.0"
+        app.kubernetes.io/version: "1.23.1"
         app.kubernetes.io/component: kafka-channel-dispatcher
         app.kubernetes.io/name: knative-eventing
         app.kubernetes.io/kind: kafka-dispatcher
@@ -307,7 +307,7 @@ spec:
         runAsUser: 1001
       containers:
         - name: kafka-source-dispatcher
-          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:e37a025c5467a94627abc34533278a26499778d60bce79c8469b7170e7dca33c
+          image: gcr.io/knative-releases/knative-kafka-broker-dispatcher-loom@sha256:f07cfb54066949a4ebe348c0d6b1d6a2a7860f6fbf58fb7c2d02c82fff87d4ff
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /etc/config


### PR DESCRIPTION
## Proposed Changes

- Update Kafka component version labels from 1.23.0 to 1.23.1.
- Update controller, webhook, post-install, migration, and source image digests to the 1.23.1 release artifacts.

**Release Note**

```release-note
NONE
```