### PR TITLE
Guard Knative readiness predicates against failed reads

### DIFF
--- a/test/resources/knativeeventing.go
+++ b/test/resources/knativeeventing.go
@@ -71,5 +71,8 @@ func EnsureKnativeEventingExists(clients eventingv1beta1.KnativeEventingInterfac
 
 // IsKnativeEventingReady will check the status conditions of the KnativeEventing and return true if the KnativeEventing is ready.
 func IsKnativeEventingReady(s *v1beta1.KnativeEventing, err error) (bool, error) {
-	return s.Status.IsReady(), err
+	if err != nil {
+		return false, err
+	}
+	return s.Status.IsReady(), nil
 }

--- a/test/resources/knativeserving.go
+++ b/test/resources/knativeserving.go
@@ -91,7 +91,10 @@ func WaitForConfigMap(name string, client kubernetes.Interface, fn func(map[stri
 
 // IsKnativeServingReady will check the status conditions of the KnativeServing and return true if the KnativeServing is ready.
 func IsKnativeServingReady(s *v1beta1.KnativeServing, err error) (bool, error) {
-	return s.Status.IsReady(), err
+	if err != nil {
+		return false, err
+	}
+	return s.Status.IsReady(), nil
 }
 
 // IsDeploymentAvailable will check the status conditions of the deployment and return true if the deployment is available.


### PR DESCRIPTION
## Changes

- Return API read errors before accessing KnativeServing or KnativeEventing status.

**Release Note**

```release-note
NONE
```
